### PR TITLE
fix: Add page meta for notifications page

### DIFF
--- a/frontend/src/pages/Notifications.vue
+++ b/frontend/src/pages/Notifications.vue
@@ -85,6 +85,12 @@ export default {
       activeTab: 'Unread',
     }
   },
+  pageMeta() {
+    return {
+      title: 'Notifications',
+      emoji: '🔔',
+    }
+  },
   components: { Avatar, TabButtons, Tooltip, Link },
   resources: {
     unreadNotifications() {


### PR DESCRIPTION
<img width="266" alt="Screenshot 2022-08-18 at 6 40 01 PM" src="https://user-images.githubusercontent.com/34810212/185402981-15e161da-b0f2-4ad8-b1de-28e396b4f2bf.png">
