### PR TITLE
fix: Consistent scrollbars across browsers

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -5,3 +5,34 @@
   outline: none;
   caret-color: theme('colors.blue.600');
 }
+
+/* Works on Firefox */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: #c0c6cc #ebeef0;
+}
+
+html {
+  scrollbar-width: auto;
+}
+
+/* Works on Chrome, Edge, and Safari */
+*::-webkit-scrollbar-thumb {
+  background: #c0c6cc;
+  border-radius: 6px;
+}
+
+*::-webkit-scrollbar-track,
+*::-webkit-scrollbar-corner {
+  background: #ebeef0;
+}
+
+*::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+body::-webkit-scrollbar {
+  width: 12px;
+  height: 12px;
+}


### PR DESCRIPTION
> Firefox

Before: 

![scroll-old](https://user-images.githubusercontent.com/34810212/185420337-2cd3b1d8-7035-456d-8e70-0a48c81cecf8.gif)

After: 

![scroll-new](https://user-images.githubusercontent.com/34810212/185420360-24602371-a03a-40d5-9366-7a641249cfa3.gif)

