### PR TITLE
fix: sidebar coverage on tall screens

### DIFF
--- a/frontend/src/components/AppSidebar.vue
+++ b/frontend/src/components/AppSidebar.vue
@@ -17,7 +17,7 @@
     leave-to-class="-translate-x-full"
   >
     <div
-      class="flex w-72 flex-1 flex-col overflow-auto bg-gray-100 pb-40"
+      class="flex w-72 flex-1 flex-col overflow-auto bg-gray-100 pb-40 h-full"
       v-show="sidebarOpen"
     >
       <div class="flex w-full items-center justify-between px-2 py-4">


### PR DESCRIPTION
Sidebar doesn't extend to the bottom of the screen on a 27" QHD

![Screen Shot 2022-09-11 at 13 27 52](https://user-images.githubusercontent.com/29507195/189517793-84f3f9c3-a575-4b8d-a93b-cd23ea42ade7.png)
