### PR TITLE
perf: add db indexes to speed up list view queries

### DIFF
--- a/gameplan/gameplan/doctype/team_discussion/team_discussion.json
+++ b/gameplan/gameplan/doctype/team_discussion/team_discussion.json
@@ -23,7 +23,8 @@
    "in_list_view": 1,
    "label": "Project",
    "options": "Team Project",
-   "reqd": 1
+   "reqd": 1,
+   "search_index": 1
   },
   {
    "fieldname": "content",
@@ -54,12 +55,14 @@
    "fieldname": "team",
    "fieldtype": "Link",
    "label": "Team",
-   "options": "Team"
+   "options": "Team",
+   "search_index": 1
   },
   {
    "fieldname": "last_post_at",
    "fieldtype": "Datetime",
-   "label": "Last Post At"
+   "label": "Last Post At",
+   "search_index": 1
   },
   {
    "fieldname": "comments_count",
@@ -75,7 +78,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2022-09-09 22:01:18.371578",
+ "modified": "2022-09-26 12:42:08.358227",
  "modified_by": "Administrator",
  "module": "Gameplan",
  "name": "Team Discussion",

--- a/gameplan/gameplan/doctype/team_discussion_visit/team_discussion_visit.json
+++ b/gameplan/gameplan/doctype/team_discussion_visit/team_discussion_visit.json
@@ -17,7 +17,8 @@
    "in_list_view": 1,
    "label": "User",
    "options": "User",
-   "reqd": 1
+   "reqd": 1,
+   "search_index": 1
   },
   {
    "fieldname": "discussion",
@@ -35,7 +36,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2022-08-31 20:13:13.347428",
+ "modified": "2022-09-26 12:41:34.555761",
  "modified_by": "Administrator",
  "module": "Gameplan",
  "name": "Team Discussion Visit",


### PR DESCRIPTION
closes https://github.com/frappe/gameplan/issues/98 

Gameplan has no loading indicators except first visit. This PR will make it go away too 🚀 

Result for `/api/method/gameplan.gameplan.doctype.team_discussion.api.get_discussions` on site with ~90K visits. 

Before: 
**442 milliseconds**

<img width="1219" alt="image" src="https://user-images.githubusercontent.com/9079960/192212940-f20a7209-adb9-43b4-b505-27e89ae041f5.png">



After:
**32 milliseconds** - 92% faster
<img width="1202" alt="image" src="https://user-images.githubusercontent.com/9079960/192214806-88da7d01-915e-407d-90c8-731e1e50d7df.png">


<img width="754" alt="image" src="https://user-images.githubusercontent.com/9079960/192245475-9a6bed2b-a6ce-420d-b915-5cde8e04029c.png">




Since Gameplan is **VERY** read-heavy, we can ignore the negligible cost during insert.