### PR TITLE
fix: Fetch missing 'modified' field

### DIFF
--- a/frontend/src/data/projects.js
+++ b/frontend/src/data/projects.js
@@ -2,7 +2,15 @@ import { createListResource } from 'frappe-ui'
 
 export let projects = createListResource({
   doctype: 'Team Project',
-  fields: ['name', 'title', 'icon', 'team', 'archived_at', 'is_private'],
+  fields: [
+    'name',
+    'title',
+    'icon',
+    'team',
+    'archived_at',
+    'is_private',
+    'modified',
+  ],
   order_by: 'title asc',
   limit: 999,
   cache: 'Projects',


### PR DESCRIPTION
This always read **Updated a few seconds ago**:

<img width="907" alt="image" src="https://user-images.githubusercontent.com/34810212/195061760-f761b099-9ad1-4879-8a08-8f628fb6dce7.png">

Problem: The 'modified' field of Team Project was not fetched in the list resource.