### PR TITLE
Docker Compose for easy local testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@
 
 <details>
   <summary>Show more screenshots</summary>
-  
+
   <img width="1402" alt="Screenshot 2022-09-18 at 9 18 17 PM" src="https://user-images.githubusercontent.com/9355208/190922154-e5bdb690-57d3-4024-9143-9d009894b035.png">
 
   <img width="1402" alt="Screenshot 2022-09-18 at 9 18 47 PM" src="https://user-images.githubusercontent.com/9355208/190922161-61eb1cd7-a56a-4460-bc7f-d6c24d1c2df7.png">
-  
+
   <img width="1402" alt="Screenshot 2022-09-18 at 11 47 06 PM" src="https://user-images.githubusercontent.com/9355208/190922333-fdad6271-2a77-4c7d-8d74-7c518d3052d6.png">
 
 
@@ -59,7 +59,19 @@ These are some of the tools used on frontend:
 - [HeadlessUI](https://headlessui.com)
 
 ## Local Setup
+### Docker Compose
+ Clone the repo
+```
+git clone https://github.com/frappe/gameplan
+cd gameplan/docker
+docker-compose up
+```
 
+Wait for sometime until the setup script creates a site. After that you can
+access `http://localhost:8000` in your browser and Gameplan's login screen
+should show up.
+
+### Frappe Bench
 1. Setup frappe-bench by following [this guide](https://frappeframework.com/docs/v14/user/en/installation)
 1. In the frappe-bench directory, run `bench start` and keep it running. Open a new terminal session and cd into `frappe-bench` directory.
 1. Run the following commands:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,32 @@
+version: "3.7"
+name: gameplan
+services:
+  mariadb:
+    image: mariadb:10.6
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+      - --skip-character-set-client-handshake
+      - --skip-innodb-read-only-compressed # Temporary fix for MariaDB 10.6
+    environment:
+      MYSQL_ROOT_PASSWORD: 123
+    volumes:
+      - mariadb-data:/var/lib/mysql
+
+  redis:
+    image: redis:alpine
+
+  frappe:
+    image: frappe/bench:latest
+    command: bash /workspace/init.sh
+    environment:
+      - SHELL=/bin/bash
+    working_dir: /home/frappe
+    volumes:
+      - .:/workspace
+    ports:
+      - 8000:8000
+      - 9000:9000
+
+volumes:
+  mariadb-data:

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -1,0 +1,39 @@
+#!bin/bash
+
+if [ -d "/home/frappe/frappe-bench/apps/frappe" ]; then
+    echo "Bench already exists, skipping init"
+    cd frappe-bench
+    bench start
+else
+    echo "Creating new bench..."
+fi
+
+bench init --skip-redis-config-generation frappe-bench
+
+cd frappe-bench
+
+# Use containers instead of localhost
+bench set-mariadb-host mariadb
+bench set-redis-cache-host redis:6379
+bench set-redis-queue-host redis:6379
+bench set-redis-socketio-host redis:6379
+
+# Remove redis, watch from Procfile
+sed -i '/redis/d' ./Procfile
+sed -i '/watch/d' ./Procfile
+
+bench get-app gameplan
+
+bench new-site gameplan.localhost \
+--force \
+--mariadb-root-password 123 \
+--admin-password admin \
+--no-mariadb-socket
+
+bench --site gameplan.localhost install-app gameplan
+bench --site gameplan.localhost set-config developer_mode 1
+bench --site gameplan.localhost clear-cache
+bench --site gameplan.localhost set-config mute_emails 1
+bench use gameplan.localhost
+
+bench start


### PR DESCRIPTION
Docker world has so many concepts to learn. There is great documentation at https://github.com/frappe/frappe_docker.

Initially thought of containerizing gameplan separately. But I need more time to understand how it works.

Starting off with a docker-compose file which will setup a local site with gameplan installed and ready to be accessed at `localhost:8000`. This compose file is a modified version of development setup at frappe/frappe_docker.

Frappe Bench setup should not be a blocker for people to try Gameplan out.