### PR TITLE
fix: Preserve query parameters while adding slug

### DIFF
--- a/frontend/src/components/DiscussionView.vue
+++ b/frontend/src/components/DiscussionView.vue
@@ -436,6 +436,7 @@ export default {
             ...this.$route.params,
             slug: doc.slug,
           },
+          query: this.$route.query
         })
       }
     },


### PR DESCRIPTION
updateUrlSlug throws away query params (e.g. comment=xxx), which then moves the user to the last unseen comment instead of where they were supposed to go.

Found this with URLs in Notifications, these don't have slugs in them.