### PR TITLE
fix: prevent browser shortcuts on cmd+k

### DIFF
--- a/frontend/src/components/CommandPalette.vue
+++ b/frontend/src/components/CommandPalette.vue
@@ -95,6 +95,7 @@ export default {
       window.addEventListener('keydown', (e) => {
         if (e.key === 'k' && (e.ctrlKey || e.metaKey)) {
           this.show = !this.show
+		  e.preventDefault();
         }
       })
     },


### PR DESCRIPTION
Firefox on linux opens search for ctrl+k.

NOTE: Untested on MacOS but no reason to not work.


closes https://github.com/frappe/gameplan/issues/147 