### PR TITLE
fix: strip titles always

### DIFF
--- a/gameplan/gameplan/doctype/team_discussion/team_discussion.py
+++ b/gameplan/gameplan/doctype/team_discussion/team_discussion.py
@@ -56,7 +56,8 @@ class TeamDiscussion(HasActivity, HasMentions, HasReactions, Document):
 		# remove special characters from title and set as slug
 		if not self.title:
 			return
-		slug = re.sub('[^A-Za-z0-9\s-]+', '', self.title.lower())
+		slug = re.sub(r'[^A-Za-z0-9\s-]+', '', self.title.lower())
+		slug = slug.replace('\n', ' ')
 		slug = slug.split(' ')
 		slug = [part for part in slug if part]
 		slug = '-'.join(slug)


### PR DESCRIPTION
For some weird reason titles can contain new lines (I am guessing something to do with double-enter=save?)

Just strip all titles for trailing/leading whitespaces, I dont think they matter ever.

You'll notice this when some url slugs contain `%0A` which is urlencoded linefeed.
