### PR TITLE
fix: typeerror on bench update

### DIFF
--- a/gameplan/patches/rename_doctypes_with_gp_prefix.py
+++ b/gameplan/patches/rename_doctypes_with_gp_prefix.py
@@ -45,9 +45,10 @@ def create_sequences():
 		sequence_name = frappe.scrub(doctype + '_id_seq')
 		frappe.db.sql_ddl('drop sequence if exists {0}'.format(sequence_name))
 		last_name = frappe.db.get_all(doctype, fields=['max(name) as last'])[0].last
-		start_value = last_name + 1
-		print('Creating sequence for {0} starting at {1}'.format(doctype, start_value))
-		frappe.db.create_sequence(doctype, start_value=start_value, check_not_exists=True, cache=frappe.db.SEQUENCE_CACHE)
+		if last_name:
+			start_value = last_name + 1
+			print('Creating sequence for {0} starting at {1}'.format(doctype, start_value))
+			frappe.db.create_sequence(doctype, start_value=start_value, check_not_exists=True, cache=frappe.db.SEQUENCE_CACHE)
 
 def rename_doctype_links():
 	doctypes_with_links = {


### PR DESCRIPTION
If any of the doctype is empty, typeerror is thrown on bench update
<img width="1037" alt="Screenshot 2023-01-21 at 9 14 50 PM" src="https://user-images.githubusercontent.com/3272205/213875391-50870f2c-90c2-40e0-b629-764ddb2fa834.png">
