### PR TITLE
Fix: Change EoL CRLF to LF #224

### DIFF
--- a/docker/init.sh
+++ b/docker/init.sh
@@ -25,10 +25,10 @@ sed -i '/watch/d' ./Procfile
 bench get-app gameplan
 
 bench new-site gameplan.localhost \
---force \
---mariadb-root-password 123 \
---admin-password admin \
---no-mariadb-socket
+    --force \
+    --mariadb-root-password 123 \
+    --admin-password admin \
+    --no-mariadb-socket
 
 bench --site gameplan.localhost install-app gameplan
 bench --site gameplan.localhost set-config developer_mode 1


### PR DESCRIPTION
PR to fix #224 
Change the EoL from CRLF to LF + formatted.

Tested locally.

`docker compose up` now runs.
![image](https://github.com/frappe/gameplan/assets/26256974/4c34e809-b26c-470b-83c2-bfdc040e7dbc)
