### PR TITLE
fix: remove space from full_name

### DIFF
--- a/frontend/src/components/TextEditor.vue
+++ b/frontend/src/components/TextEditor.vue
@@ -26,7 +26,7 @@ export default {
       return this.$users.data
         .filter((user) => user.enabled)
         .map((user) => ({
-          label: user.full_name,
+          label: user.full_name.trimEnd(),
           value: user.name,
         }))
     },


### PR DESCRIPTION
closes task 2 of https://github.com/frappe/gameplan/issues/233


This happens if the full_name has an extra space at the end.  