### PR TITLE
Full Text Search with Frappe Search

### DIFF
--- a/frontend/src/components/NewTaskDialog.vue
+++ b/frontend/src/components/NewTaskDialog.vue
@@ -98,7 +98,7 @@ function statusOptions({ onClick }) {
         label: status,
         onClick: () => onClick(status),
       }
-    },
+    }
   )
 }
 
@@ -118,7 +118,7 @@ function show({ defaults, onSuccess } = {}) {
   _onSuccess = onSuccess
 }
 
-function onCreateClick({ close }) {
+function onCreateClick(close) {
   createTask
     .submit(newTask.value, {
       validate() {

--- a/frontend/src/pages/Search.vue
+++ b/frontend/src/pages/Search.vue
@@ -25,9 +25,9 @@
       v-if="$resources.search.params && $resources.search.data"
       class="mt-4 text-base font-semibold text-gray-800"
     >
-      About {{ $resources.search.data.total }} results for "{{
+      {{ $resources.search.data.total }} results for "{{
         $resources.search.params?.query
-      }}" ({{ $resources.search.data.duration.toFixed(2) }}
+      }}" (in about {{ $resources.search.data.duration.toFixed(2) }}
       ms)
     </div>
     <div
@@ -87,10 +87,10 @@ export default {
       transform(data) {
         let out = {
           groups: [],
-          total: 100,
-          duration: 2,
+          total: data.total,
+          duration: data.duration,
         }
-        for (let group in data) {
+        for (let group in data.results) {
           let title
           if (group === 'GP Discussion') {
             title = 'Discussions'
@@ -101,10 +101,9 @@ export default {
           }
           out.groups.push({
             title,
-            items: data[group],
+            items: data.results[group],
           })
         }
-        console.log(out)
         return out
       }
     },

--- a/frontend/src/pages/Search.vue
+++ b/frontend/src/pages/Search.vue
@@ -80,7 +80,7 @@ export default {
   resources: {
     search: {
       cache: 'Search',
-      url: 'frappe_search.frappe_search.doctype.search.search.tantivy_search',
+      url: 'frappe_search.core.search',
       makeParams(query) {
         return { query, start: this.start }
       },

--- a/gameplan/gameplan/doctype/gp_discussion/gp_discussion.json
+++ b/gameplan/gameplan/doctype/gp_discussion/gp_discussion.json
@@ -119,7 +119,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-02-20 18:29:13.384580",
+ "modified": "2024-02-06 12:11:11.919002",
  "modified_by": "Administrator",
  "module": "Gameplan",
  "name": "GP Discussion",
@@ -163,13 +163,15 @@
    "write": 1
   },
   {
+   "create": 1,
    "email": 1,
    "export": 1,
    "print": 1,
    "read": 1,
    "report": 1,
    "role": "Gameplan Guest",
-   "share": 1
+   "share": 1,
+   "write": 1
   }
  ],
  "show_title_field_in_link": 1,

--- a/gameplan/gameplan/doctype/gp_page/gp_page.json
+++ b/gameplan/gameplan/doctype/gp_page/gp_page.json
@@ -54,7 +54,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-09-18 21:30:16.417667",
+ "modified": "2024-02-06 12:18:02.871772",
  "modified_by": "Administrator",
  "module": "Gameplan",
  "name": "GP Page",
@@ -98,6 +98,7 @@
    "write": 1
   },
   {
+   "create": 1,
    "email": 1,
    "export": 1,
    "print": 1,

--- a/gameplan/gameplan/doctype/gp_project/gp_project.json
+++ b/gameplan/gameplan/doctype/gp_project/gp_project.json
@@ -133,7 +133,7 @@
    "link_fieldname": "project"
   }
  ],
- "modified": "2023-05-29 17:46:40.841850",
+ "modified": "2024-02-06 12:12:18.808576",
  "modified_by": "Administrator",
  "module": "Gameplan",
  "name": "GP Project",
@@ -183,7 +183,8 @@
    "read": 1,
    "report": 1,
    "role": "Gameplan Guest",
-   "share": 1
+   "share": 1,
+   "write": 1
   }
  ],
  "show_title_field_in_link": 1,

--- a/gameplan/hooks.py
+++ b/gameplan/hooks.py
@@ -124,7 +124,6 @@ after_migrate = ["gameplan.search.build_index_in_background"]
 doc_events = {
     "*": {
         "on_trash": "gameplan.mixins.on_delete.on_trash",
-        "on_update": "frappe_search.frappe_search.doctype.search.search.update_index",
     },
     "User": {
         "after_insert": "gameplan.gameplan.doctype.gp_user_profile.gp_user_profile.create_user_profile",
@@ -226,3 +225,24 @@ scheduler_events = {
 # Recommended only for DocTypes which have limited documents with untranslated names
 # For example: Role, Gender, etc.
 # translated_search_doctypes = []
+
+frappe_search_doctypes = {
+    "GP Discussion": {
+        "title": "title",
+        "content": ["content"],
+        "extras": ["team", "project"],
+    },
+    "GP Task": {
+        "title": "title",
+        "content": ["description"],
+        "extras": ["team", "project"],
+    },
+    "GP Page": {
+        "title": "title",
+        "content": ["content"],
+        "extras": ["team", "project"],
+    },
+    "GP Comment": {
+        "content": ["content"],
+    },
+}

--- a/gameplan/hooks.py
+++ b/gameplan/hooks.py
@@ -40,7 +40,7 @@ app_icon_route = "/g"
 # Fixtures
 
 fixtures = [
-	{"dt": "Role", "filters": [["role_name", "like", "Gameplan %"]]},
+    {"dt": "Role", "filters": [["role_name", "like", "Gameplan %"]]},
 ]
 
 # Home Pages
@@ -51,15 +51,15 @@ fixtures = [
 
 # website user home page (by Role)
 # role_home_page = {
-#	"Role": "home_page"
+# 	"Role": "home_page"
 # }
 
 website_route_rules = [
-	{"from_route": "/g/<path:app_path>", "to_route": "g"},
+    {"from_route": "/g/<path:app_path>", "to_route": "g"},
 ]
 
 website_redirects = [
-	{"source": r"/teams(/.*)?", "target": r"/g\1"},
+    {"source": r"/teams(/.*)?", "target": r"/g\1"},
 ]
 
 # Generators
@@ -122,31 +122,28 @@ after_migrate = ["gameplan.search.build_index_in_background"]
 # Hook on document methods and events
 
 doc_events = {
-	"*": {
-		"on_trash": "gameplan.mixins.on_delete.on_trash",
-	},
-	"User": {
-		"after_insert": "gameplan.gameplan.doctype.gp_user_profile.gp_user_profile.create_user_profile",
-		"on_trash": [
-			"gameplan.gameplan.doctype.gp_user_profile.gp_user_profile.delete_user_profile",
-			"gameplan.gameplan.doctype.gp_guest_access.gp_guest_access.on_user_delete",
-		],
-		"on_update": "gameplan.gameplan.doctype.gp_user_profile.gp_user_profile.on_user_update"
-	}
+    "*": {
+        "on_trash": "gameplan.mixins.on_delete.on_trash",
+        "on_update": "frappe_search.frappe_search.doctype.search.search.update_index",
+    },
+    "User": {
+        "after_insert": "gameplan.gameplan.doctype.gp_user_profile.gp_user_profile.create_user_profile",
+        "on_trash": [
+            "gameplan.gameplan.doctype.gp_user_profile.gp_user_profile.delete_user_profile",
+            "gameplan.gameplan.doctype.gp_guest_access.gp_guest_access.on_user_delete",
+        ],
+        "on_update": "gameplan.gameplan.doctype.gp_user_profile.gp_user_profile.on_user_update",
+    },
 }
 
-on_login = 'gameplan.www.g.on_login'
+on_login = "gameplan.www.g.on_login"
 
 # Scheduled Tasks
 # ---------------
 
 scheduler_events = {
-	"all": [
-		"gameplan.search.build_index_if_not_exists"
-	],
-	"hourly": [
-		"gameplan.gameplan.doctype.gp_invitation.gp_invitation.expire_invitations"
-	],
+    "all": ["gameplan.search.build_index_if_not_exists"],
+    "hourly": ["gameplan.gameplan.doctype.gp_invitation.gp_invitation.expire_invitations"],
 }
 
 # scheduler_events = {


### PR DESCRIPTION
These are changes made so that Gameplan can use [Frappe Search](https://github.com/safwansamsudeen/frappe_search) for its full text search.

I don't know Vue, and might have messed something up - so please double check.

We need to make many other changes before merging - most importantly, we have to have a way to change the doctypes and fields to index. Right now, I've [hard coded it](https://github.com/safwansamsudeen/frappe_search/blob/develop/frappe_search/frappe_search/doctype/search/search.py).

We might also want to remove old search code and enhance performance before merging.

## To Test
To test this PR, install Frappe Search to your site and go over to the Search doctype, and click "Index". 

After indexing, Gameplan will use Frappe Search correctly.