### PR TITLE
fix: include gameplan in apps page

### DIFF
--- a/gameplan/hooks.py
+++ b/gameplan/hooks.py
@@ -10,6 +10,16 @@ app_icon_url = "/assets/gameplan/manifest/favicon-180.png"
 app_icon_title = "Gameplan"
 app_icon_route = "/g"
 
+add_to_apps_screen = [
+	{
+		"name": "gameplan",
+		"logo": "/assets/gameplan/manifest/favicon-196.png",
+		"title": "Gameplan",
+		"route": "/g",
+		# "has_permission": "gameplan.api.permission.has_app_permission"
+	}
+]
+
 # Includes in <head>
 # ------------------
 


### PR DESCRIPTION

Dependent on https://github.com/frappe/frappe/pull/27292/

Updated hooks.py to include gameplan app in apps page

<img width="1430" alt="image" src="https://github.com/user-attachments/assets/1eec71fe-cc56-4ec9-8327-dbe209f951a6">