### PR TITLE
fix: added app permission check for apps page

### DIFF
--- a/gameplan/api.py
+++ b/gameplan/api.py
@@ -391,3 +391,14 @@ def search(query, start=0):
 		"total": result.total,
 		"duration": result.duration,
 	}
+
+
+def check_app_permission():
+	if frappe.session.user == "Administrator":
+		return True
+
+	roles = frappe.get_roles()
+	if any(role in ["System Manager", "Gameplan Admin", "Gameplan Member", "Gameplan Guest"] for role in roles):
+		return True
+
+	return False

--- a/gameplan/hooks.py
+++ b/gameplan/hooks.py
@@ -16,7 +16,7 @@ add_to_apps_screen = [
 		"logo": "/assets/gameplan/manifest/favicon-196.png",
 		"title": "Gameplan",
 		"route": "/g",
-		# "has_permission": "gameplan.api.permission.has_app_permission"
+		"has_permission": "gameplan.api.check_app_permission"
 	}
 ]
 


### PR DESCRIPTION
Added `has_permission` to check if user has access to portal page

```Python
add_to_apps_screen = [
	{
		"name": "gameplan",
		"logo": "/assets/gameplan/manifest/favicon-196.png",
		"title": "Gameplan",
		"route": "/g",
		"has_permission": "gameplan.api.check_app_permission"
	}
]
```

```Python
def check_app_permission():
	if frappe.session.user == "Administrator":
		return True

	roles = frappe.get_roles()
	if any(role in ["System Manager", "Gameplan Admin", "Gameplan Member", "Gameplan Guest"] for role in roles):
		return True

	return False
```