### PR TITLE
chore: chore: loosely pin rembg

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.10"
 readme = "README.md"
 dynamic = ["version"]
 dependencies = [
-    "rembg==2.0.49",
+    "rembg>=2.0.49,<2.1",
 ]
 
 [build-system]


### PR DESCRIPTION
Framework officially supports 3.12. GP can as well.
https://github.com/frappe/gameplan/issues/312
https://discuss.frappe.io/t/gameplan-installation-error/131923
