### PR TITLE
fix(docker): Add redis:// scheme to init script

### DIFF
--- a/docker/init.sh
+++ b/docker/init.sh
@@ -14,9 +14,9 @@ cd frappe-bench
 
 # Use containers instead of localhost
 bench set-mariadb-host mariadb
-bench set-redis-cache-host redis:6379
-bench set-redis-queue-host redis:6379
-bench set-redis-socketio-host redis:6379
+bench set-redis-cache-host redis://redis:6379
+bench set-redis-queue-host redis://redis:6379
+bench set-redis-socketio-host redis://redis:6379
 
 # Remove redis, watch from Procfile
 sed -i '/redis/d' ./Procfile


### PR DESCRIPTION
### Description
This pull request resolves a `ValueError` during the local Docker setup caused by an invalid Redis URL format. This prevents new users from successfully running `docker-compose up`.

### The Problem
The `init.sh` script sets Redis connection strings (e.g., `redis:6379`) without a URL scheme. The underlying Python Redis library now strictly requires a full URL, which causes the build process to fail with the error: `ValueError: Redis URL must specify one of the following schemes (redis://, rediss://, unix://)`.

### The Solution
This PR updates the `docker/init.sh` script to prepend `redis://` to the `redis_cache`, `redis_queue`, and `redis_socketio` configurations. This aligns with modern library requirements and allows the installation to complete successfully.

### How This Was Tested
I confirmed this fix by:
1.  Running `docker-compose down -v` to ensure a clean state.
2.  Applying this change to the `init.sh` script.
3.  Running `docker-compose up`.
4.  The build completed successfully and the Gameplan site became accessible.