### PR TITLE
fix: Update IndexDefintion import

### DIFF
--- a/gameplan/utils/search.py
+++ b/gameplan/utils/search.py
@@ -7,7 +7,7 @@ import json
 import frappe
 from frappe.utils import cstr
 from redis.commands.search.field import TagField, TextField
-from redis.commands.search.indexDefinition import IndexDefinition
+from redis.commands.search.index_definition import IndexDefinition
 from redis.commands.search.query import Query
 from redis.exceptions import ResponseError
 


### PR DESCRIPTION
Gameplan install (install-app) fails with 

```python
builtins.ImportError: Module import failed for GP Task, the DocType you're trying to open might be deleted.
Error: No module named 'redis.commands.search.indexDefinition'
```

References: 
- https://github.com/redis/redis-py/pull/3469/files#diff-a42ffe4f92b282f8ad7a475814e75e61db5926118adb76e894775a37b73fb4d2
- https://cloud.frappe.io/app/agent-job/eilf9tfavn