### PR TITLE
Realtime inbox badge updates — decrement unread count when notifications are marked read

### DIFF
--- a/gameplan/gameplan/doctype/gp_notification/gp_notification.py
+++ b/gameplan/gameplan/doctype/gp_notification/gp_notification.py
@@ -11,6 +11,19 @@ class GPNotification(Document):
 	def after_insert(self):
 		gameplan.refetch_resource("Unread Notifications Count", user=self.to_user)
 
+	def on_update(self):
+		# When a notification's read status changes, inform clients to refetch
+		try:
+			# Prefer precise invalidation only when read flag toggles
+			if hasattr(self, "has_value_changed") and self.has_value_changed("read"):
+				gameplan.refetch_resource("Unread Notifications Count", user=self.to_user)
+			elif self.read:
+				# Fallback: if API version doesn't support has_value_changed, still refetch when read is set
+				gameplan.refetch_resource("Unread Notifications Count", user=self.to_user)
+		except Exception:
+			# Avoid breaking save flow due to realtime errors
+			frappe.log_error(title="GPNotification on_update refetch failed")
+
 	@staticmethod
 	def clear_notifications(discussion=None, comment=None, task=None, user=None):
 		if not user:


### PR DESCRIPTION
# Fix: Realtime inbox badge updates — decrement unread count when notifications are marked read

## Summary
Unread notification count in the sidebar did not decrement after opening/marking a notification as read until a full page reload. This adds a realtime refetch on notification updates so the count updates immediately.

## Changes
- Add `on_update` to `GPNotification` to publish `refetch_resource` for `Unread Notifications Count` when `read` changes (with a safe fallback when `read` is set).

## Rationale
- New notifications were already triggering realtime via `after_insert`, but marking as read had no corresponding event. Emitting a refetch on read state change keeps the badge accurate without reloads.

## Testing
- Create a notification for a user; verify sidebar shows count = 1.
- Open the notification or click “Mark as read”.
- Observe the sidebar “Inbox” badge decrements to 0 without reloading.
- Repeat across multiple browser tabs; all tabs should update in realtime.

## Notes
- Frontend already listens for `refetch_resource` and reloads `Unread Notifications Count`, so no UI changes were needed.
- Wrapped in try/except to avoid save failures if realtime publish fails.