### PR TITLE
fix: set theme color for PWA

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,6 +7,7 @@
       content="width=device-width, initial-scale=1.0, maximum-scale=1.0, viewport-fit=cover, user-scalable=no"
     />
     <title>Gameplan</title>
+    <meta name="theme-color" content="#FFFFFF">
     <link rel="manifest" href="/assets/gameplan/manifest/site.webmanifest" />
     <link
       rel="icon"


### PR DESCRIPTION
The PWA had a black bar on top:

<img width="1179" height="705" alt="image" src="https://github.com/user-attachments/assets/91a199b1-19b4-4eba-ad16-9832c0031b24" />

Will raise the PR once tested locally.