### PR TITLE
fix: show title in search clearly in dark mode

### DIFF
--- a/frontend/src/pages/Search.vue
+++ b/frontend/src/pages/Search.vue
@@ -166,7 +166,7 @@
               </div>
               <div class="w-full">
                 <div class="flex items-center">
-                  <div v-if="item.title" class="text-base font-medium" v-html="item.title" />
+                  <div v-if="item.title" class="text-base font-medium text-ink-gray-9" v-html="item.title" />
                   <div class="text-base font-medium" v-else>
                     {{ $user(item.author).full_name }}
                   </div>


### PR DESCRIPTION
I've used `text-ink-gray-9` - on both light and dark mode - earlier it was white.

Before:

<img width="875" height="104" alt="image" src="https://github.com/user-attachments/assets/3bb4dc64-844a-443a-8661-cc74da4c7a93" />


After:

<img width="875" height="104" alt="image" src="https://github.com/user-attachments/assets/64d52a92-daad-4b44-9184-e005153df3ab" />
