### PR TITLE
chore(ci): bump node and python version for Frappe v16

### DIFF
--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.14"
 
       - name: Check for valid Python & Merge Conflicts
         run: |
@@ -47,7 +47,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 24
           check-latest: true
 
       - uses: pnpm/action-setup@v2


### PR DESCRIPTION
Not sure if MariaDB version needs to be updated.