### PR TITLE
fix: improve pnpm installation script

### DIFF
--- a/scripts/install-pnpm.sh
+++ b/scripts/install-pnpm.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
+set -euo pipefail
 
-if ! command -v pnpm &> /dev/null
-then
+if ! command -v pnpm &> /dev/null; then
     echo "pnpm could not be found, installing..."
     npm install -g pnpm@latest-10
-else
-    echo "pnpm is already installed."
+fi
+
+if ! command -v pnpm &> /dev/null; then
+    echo "ERROR: pnpm installation failed, binary still not found in PATH" >&2
+    exit 1
 fi
 
 echo "pnpm version: $(pnpm --version)"
-
-exit 0


### PR DESCRIPTION
## Problem

When building a custom image via `frappe_docker` with the `gameplan` app included in
`apps.json`, `bench init` fails during asset building with a confusing
exit code 127 from Yarn.

The root cause: `install-pnpm.sh` unconditionally exits 0 even when
`npm install -g pnpm@latest-10` silently fails (e.g. in minimal Docker
images where global installs can behave unexpectedly). The build then
continues into `pnpm install && pnpm build` with no pnpm binary
available, which blows up deep in the Yarn/bench build chain.

The log looks like this:

pnpm could not be found, installing...
pnpm version:
...
status: 127
error Command failed with exit code 1.

## Fix

- Add `set -euo pipefail` so failures aren't silently swallowed.
- After the install attempt, verify pnpm is actually on PATH before
  continuing. If it's not, exit 1 with a clear message instead of
  letting the build proceed and fail later with a misleading error.
- Remove the unconditional `exit 0` at the end.