### PR TITLE
fix(notifications): refresh sidebar badge when marking as read

### DIFF
--- a/frontend/src/pages/Notifications.vue
+++ b/frontend/src/pages/Notifications.vue
@@ -71,6 +71,7 @@
 import { TabButtons, Tooltip, Breadcrumbs, dayjsLocal } from 'frappe-ui'
 import PageHeader from '@/components/PageHeader.vue'
 import Link from '@/components/Link.vue'
+import { unreadNotifications } from '@/data/notifications'
 
 export default {
   name: 'Notifications',
@@ -143,7 +144,7 @@ export default {
       return {
         url: 'gameplan.api.mark_all_notifications_as_read',
         onSuccess() {
-          this.$getResource('Unread Notifications Count')?.reload()
+          unreadNotifications.reload()
           this.$resources.unreadNotifications.reload()
         },
       }
@@ -165,14 +166,14 @@ export default {
         },
         {
           onSuccess: () => {
-            this.$getResource('Unread Notifications Count')?.reload()
+            unreadNotifications.reload()
           },
         },
       )
     },
   },
   mounted() {
-    this.$getResource('Unread Notifications Count')?.reload()
+    unreadNotifications.reload()
   },
 }
 </script>


### PR DESCRIPTION
## Summary
- The sidebar inbox badge stayed stuck on the unread count after a user opened/cleared a notification — only a full page reload made it disappear.
- Root cause: `Notifications.vue` reloaded via `this.\$getResource('Unread Notifications Count')`, which only looks up the legacy `createResource` cache. The actual sidebar badge reads from the `useCall`-based `unreadNotifications` resource in `frontend/src/data/notifications.ts`, which lives in a separate registry and was never being refreshed.
- Fix: import `unreadNotifications` directly and call `.reload()` on it from `markAsRead`, `markAllAsRead`, and `mounted()`.

Fixes #365

## Test plan
- [ ] With one unread notification, sidebar badge shows `1`.
- [ ] Open the Inbox page and click "View Discussion" on the notification — sidebar badge updates to `0` without a page reload.
- [ ] Click "Mark all as read" with multiple unread — badge clears immediately.
- [ ] When a new notification arrives via realtime, the badge increments (existing behavior, unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)