### PR TITLE
fix: update import path for get_modules_from_all_apps_for_user

### DIFF
--- a/gameplan/api.py
+++ b/gameplan/api.py
@@ -437,7 +437,7 @@ def search(query, start=0):
 
 def can_access_gameplan():
 	"""Check if the app should be shown in /apps"""
-	from frappe.utils.modules import get_modules_from_all_apps_for_user
+	from frappe.config import get_modules_from_all_apps_for_user
 
 	if frappe.session.user == "Administrator":
 		return True


### PR DESCRIPTION
## Problem
For Frappe v15 this function `get_modules_from_all_apps_for_user` is in `frappe.config` but it is trying to import it from `frappe.utils.modules` in both main and develop branch(assuming main is compatible with v15 and develop is compatible with v16),
causing ModuleNotFoundError when gameplan checks app permissions

**Support Ticket**: [https://support.frappe.io/helpdesk/tickets/66763](https://support.frappe.io/helpdesk/tickets/66763)

<img width="1467" height="877" alt="image" src="https://github.com/user-attachments/assets/d47751b3-afae-4a8f-9a11-a608c35a5817" />
