### PR TITLE
Feature/weekly activity digest

### DIFF
--- a/frontend/src/components/Settings/SettingsTab.vue
+++ b/frontend/src/components/Settings/SettingsTab.vue
@@ -16,9 +16,9 @@
 
       <div class="mt-3 flex items-center justify-between gap-4">
         <div>
-          <p class="text-sm font-medium text-ink-gray-8">Weekly digest</p>
+          <p class="text-sm font-medium text-ink-gray-8">Inactivity digest</p>
           <p class="mt-1 text-sm text-ink-gray-5">
-            Get a weekly email summary of updates from your projects if you've been inactive for a while.
+            Email me a catch-up summary when I have been inactive for 7 days.
           </p>
         </div>
 

--- a/frontend/src/components/Settings/SettingsTab.vue
+++ b/frontend/src/components/Settings/SettingsTab.vue
@@ -1,10 +1,73 @@
 <template>
   <div class="flex min-h-0 flex-col">
     <h2 class="text-xl font-semibold text-ink-gray-9">Settings</h2>
-    <div class="mt-6 divide-y overflow-y-auto pb-16">
+
+    <div class="mt-6 divide-y overflow-y-auto pb-2">
       <a href="/update-password">
-        <Button variant="solid"> Update Password </Button>
+        <Button variant="solid">
+          Update Password
+        </Button>
       </a>
+    </div>
+    <hr class="my-4 border-0 border-t border-outline-gray-4" />
+
+    <div class="mt-2">
+      <h3 class="text-lg font-semibold text-ink-gray-9">Notifications</h3>
+
+      <div class="mt-3 flex items-center justify-between gap-4">
+        <div>
+          <p class="text-sm font-medium text-ink-gray-8">Weekly digest</p>
+          <p class="mt-1 text-sm text-ink-gray-5">
+            Get a weekly email summary of updates from your projects if you've been inactive for a while.
+          </p>
+        </div>
+
+        <Switch
+          class="shrink-0"
+          size="sm"
+          v-model="weeklyDigest"
+          :disabled="updateWeeklyDigest.loading"
+          @update:model-value="saveWeeklyDigest"
+        />
+      </div>
     </div>
   </div>
 </template>
+
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import { Switch, useCall } from 'frappe-ui'
+import { useSessionUser } from '@/data/users'
+
+const sessionUser = useSessionUser()
+const weeklyDigest = ref(false)
+const savedWeeklyDigest = ref(false)
+let previousWeeklyDigest = false
+
+const updateWeeklyDigest = useCall<boolean, { weekly_digest: boolean }>({
+  url: '/api/v2/method/gameplan.api.update_weekly_digest',
+  method: 'POST',
+  immediate: false,
+  onSuccess(value) {
+    sessionUser.weekly_digest = Boolean(value)
+    savedWeeklyDigest.value = Boolean(value)
+  },
+  onError() {
+    weeklyDigest.value = previousWeeklyDigest
+  },
+})
+
+watch(
+  () => sessionUser.weekly_digest,
+  (value) => {
+    savedWeeklyDigest.value = Boolean(value)
+    weeklyDigest.value = savedWeeklyDigest.value
+  },
+  { immediate: true },
+)
+
+function saveWeeklyDigest(value: boolean) {
+  previousWeeklyDigest = savedWeeklyDigest.value
+  updateWeeklyDigest.submit({ weekly_digest: value })
+}
+</script>

--- a/frontend/src/data/users.ts
+++ b/frontend/src/data/users.ts
@@ -12,6 +12,7 @@ interface UserInfo {
   user_image: string
   full_name: string
   user_type: string
+  weekly_digest: boolean
   user_profile: string
   image_background_color: string
   is_image_background_removed: number
@@ -62,6 +63,7 @@ function getPlaceholderUser(email: string, full_name: string) {
     email: email,
     full_name: full_name,
     user_image: '',
+    weekly_digest: false,
     role: 'Gameplan Member',
     enabled: 1,
     user_profile: '',

--- a/gameplan/api.py
+++ b/gameplan/api.py
@@ -22,7 +22,15 @@ def get_user_info(user=None):
 	users = frappe.qb.get_query(
 		"User",
 		filters=filters,
-		fields=["name", "email", "enabled", "user_image", "full_name", "user_type"],
+		fields=[
+			"name",
+			"email",
+			"enabled",
+			"user_image",
+			"full_name",
+			"user_type",
+			"weekly_digest",
+		],
 		order_by="full_name asc",
 		distinct=True,
 	).run(as_dict=1)
@@ -77,6 +85,16 @@ def get_user_info(user=None):
 		user.comments_count_3m = comment_count_map.get(user.name, 0)
 
 	return users
+
+
+@frappe.whitelist()
+@validate_type
+def update_weekly_digest(weekly_digest: bool):
+	if frappe.session.user == "Guest":
+		frappe.throw("Authentication failed", exc=frappe.AuthenticationError)
+
+	frappe.db.set_value("User", frappe.session.user, "weekly_digest", weekly_digest)
+	return weekly_digest
 
 
 @frappe.whitelist()

--- a/gameplan/demo/user.py
+++ b/gameplan/demo/user.py
@@ -165,7 +165,37 @@ def generate_users_data():
 			"years_experience": random.randint(1, 15),
 		}
 
+		narayan ={
+			"email": "narayan.gawas@spit.ac.in",
+			"first_name": "Narayan",
+			"last_name": "Gawas",
+			"avatar_url": avatar_url,
+			"department": department,
+			"job_title": job_title,
+			"bio": bio,
+			"readme": readme_content,
+			"location": random.choice(
+				[
+					"San Francisco, CA",
+					"New York, NY",
+					"Austin, TX",
+					"Seattle, WA",
+					"Boston, MA",
+					"London, UK",
+					"Berlin, Germany",
+					"Toronto, Canada",
+					"Remote",
+					"Amsterdam, Netherlands",
+					"Barcelona, Spain",
+					"Sydney, Australia",
+				]
+			),
+			"years_experience": random.randint(1, 15),
+
+		} 
+
 		users.append(user)
+		users.append(narayan)
 
 	return users
 
@@ -279,6 +309,7 @@ def create_user_and_profile(user_data):
 				"last_name": user_data["last_name"],
 				"user_image": user_data.get("avatar_url"),
 				"send_welcome_email": 0,
+				"new_password": "Test@123",
 				"user_type": "System User",
 				"roles": [{"role": "Gameplan Member"}],
 			}

--- a/gameplan/digest.py
+++ b/gameplan/digest.py
@@ -47,7 +47,21 @@ def send_inactivity_digest_weekly():
 		print(f"Error sending inactivity digest: {str(e)}")
 		
 	
+from werkzeug.wrappers import Response
 
+
+@frappe.whitelist(allow_guest=True)
+def preview_digest(user="narayan.gawas@spit.ac.in"):
+	digest = build_user_digest(user)
+
+	user_doc = frappe.get_doc("User", user)
+
+	html = render_digest_email(user_doc, digest)
+
+	return Response(
+		html,
+		content_type="text/html; charset=utf-8",
+	)
 
 def get_inactive_digest_users(inactive_days: int = INACTIVE_DAYS):
 	"""Return opted-in users whose last activity is older than the inactivity threshold.
@@ -94,6 +108,37 @@ def build_user_digest(user: str, window_days: int = DIGEST_WINDOW_DAYS):
 	return digest
 
 
+# def get_new_discussions_in_user_spaces(user: str, window_start):
+# 	return frappe.db.sql(
+# 		"""
+# 		select
+# 			discussion.name,
+# 			discussion.title,
+# 			discussion.slug,
+# 			discussion.project,
+# 			project.title as project_title,
+# 			discussion.owner,
+# 			discussion.creation
+# 		from `tabGP Discussion` discussion
+# 		inner join `tabGP Project` project on project.name = discussion.project
+# 		where discussion.creation >= %(window_start)s
+# 			and discussion.owner != %(user)s
+# 			and project.archived_at is null
+# 			and exists (
+# 				select 1
+# 				from `tabGP Member` member
+# 				where member.parenttype = 'GP Project'
+# 					and member.parent = discussion.project
+# 					and member.user = %(user)s
+# 			)
+# 		order by discussion.creation desc
+# 		limit %(limit)s
+# 		""",
+# 		{"user": user, "window_start": window_start, "limit": DIGEST_LIMIT},
+# 		as_dict=True,
+# 	)
+
+
 def get_new_discussions_in_user_spaces(user: str, window_start):
 	return frappe.db.sql(
 		"""
@@ -106,21 +151,19 @@ def get_new_discussions_in_user_spaces(user: str, window_start):
 			discussion.owner,
 			discussion.creation
 		from `tabGP Discussion` discussion
-		inner join `tabGP Project` project on project.name = discussion.project
+		inner join `tabGP Project` project
+			on project.name = discussion.project
 		where discussion.creation >= %(window_start)s
 			and discussion.owner != %(user)s
 			and project.archived_at is null
-			and exists (
-				select 1
-				from `tabGP Member` member
-				where member.parenttype = 'GP Project'
-					and member.parent = discussion.project
-					and member.user = %(user)s
-			)
 		order by discussion.creation desc
 		limit %(limit)s
 		""",
-		{"user": user, "window_start": window_start, "limit": DIGEST_LIMIT},
+		{
+			"user": user,
+			"window_start": window_start,
+			"limit": DIGEST_LIMIT,
+		},
 		as_dict=True,
 	)
 
@@ -181,19 +224,8 @@ def has_digest_items(digest: dict) -> bool:
 	return any(digest.get(key) for key in ("new_discussions", "thread_replies", "notifications"))
 
 
-# def render_digest_email(user, digest: dict) -> str:
-# 	name = escape(user.full_name or user.name)
-# 	return f"""
-# 		<p>Hi {name},</p>
-# 		<p>You have been away from Gameplan for at least {INACTIVE_DAYS} days. Here is what changed in the last {DIGEST_WINDOW_DAYS} days.</p>
-# 		{render_discussion_list("New discussions in your spaces", digest["new_discussions"])}
-# 		{render_reply_list("Replies on threads you are in", digest["thread_replies"])}
-# 		{render_notification_list("Unread mentions and direct notifications", digest["notifications"])}
-# 		<p><a href="{get_url('/g')}">Open Gameplan</a></p>
-# 	"""
 
 
-```python
 def render_digest_email(user, digest: dict) -> str:
 	name = escape(user.full_name or user.name)
 
@@ -255,7 +287,9 @@ def render_digest_email(user, digest: dict) -> str:
 					">
 						Hi <strong>{name}</strong>,
 						<br /><br />
-						Here’s what changed in the last
+						You've been away from Gameplan for at least
+						<strong>{INACTIVE_DAYS} days</strong>.
+						Here's what changed in the last
 						<strong>{DIGEST_WINDOW_DAYS} days</strong>.
 					</p>
 				</div>
@@ -281,7 +315,7 @@ def render_digest_email(user, digest: dict) -> str:
 					else ""
 				}
 
-				<!-- Sections -->
+				<!-- New Discussions -->
 				{
 					render_discussion_list(
 						"🆕 New discussions in your spaces",
@@ -291,6 +325,7 @@ def render_digest_email(user, digest: dict) -> str:
 					else ""
 				}
 
+				<!-- Thread Replies -->
 				{
 					render_reply_list(
 						"💬 Replies on threads you are in",
@@ -300,6 +335,7 @@ def render_digest_email(user, digest: dict) -> str:
 					else ""
 				}
 
+				<!-- Notifications -->
 				{
 					render_notification_list(
 						"🔔 Unread mentions and notifications",
@@ -349,6 +385,35 @@ def render_digest_email(user, digest: dict) -> str:
 	"""
 
 
+def render_stat_card(label, value):
+	return f"""
+	<div style="
+		flex:1;
+		min-width:160px;
+		background:#f9fafb;
+		border:1px solid #e5e7eb;
+		border-radius:12px;
+		padding:16px;
+	">
+		<div style="
+			font-size:13px;
+			color:#6b7280;
+			margin-bottom:8px;
+		">
+			{label}
+		</div>
+
+		<div style="
+			font-size:28px;
+			font-weight:700;
+			color:#111827;
+		">
+			{value}
+		</div>
+	</div>
+	"""
+
+
 def render_empty_digest():
 	return """
 	<div style="
@@ -385,38 +450,151 @@ def render_empty_digest():
 		</p>
 	</div>
 	"""
-```
+
+
+def render_section(title: str, content: str) -> str:
+	return f"""
+	<div style="margin-bottom:28px;">
+
+		<h2 style="
+			font-size:18px;
+			font-weight:700;
+			margin:0 0 14px 0;
+			color:#111827;
+		">
+			{escape(title)}
+		</h2>
+
+		{content}
+
+	</div>
+	"""
 
 
 def render_discussion_list(title: str, rows: list) -> str:
 	if not rows:
 		return ""
+
 	items = "\n".join(
-		f'<li><a href="{discussion_url(row)}">{escape(row.title)}</a> <span style="color: #667085;">in {escape(row.project_title or "a space")}</span></li>'
+		f'''
+		<a
+			href="{discussion_url(row)}"
+			style="
+				display:block;
+				padding:16px;
+				margin-bottom:12px;
+				border:1px solid #e5e7eb;
+				border-radius:12px;
+				text-decoration:none;
+				background:#ffffff;
+			"
+		>
+			<div style="
+				font-size:15px;
+				font-weight:600;
+				color:#111827;
+				margin-bottom:6px;
+				line-height:1.5;
+			">
+				{escape(row.title)}
+			</div>
+
+			<div style="
+				font-size:13px;
+				color:#6b7280;
+			">
+				in {escape(row.project_title or "a space")}
+			</div>
+		</a>
+		'''
 		for row in rows
 	)
-	return f"<h3>{escape(title)}</h3><ul>{items}</ul>"
+
+	return render_section(title, items)
 
 
 def render_reply_list(title: str, rows: list) -> str:
 	if not rows:
 		return ""
+
 	items = "\n".join(
-		f'<li><a href="{discussion_url(row)}">{escape(row.title)}</a> <span style="color: #667085;">in {escape(row.project_title or "a space")}</span></li>'
+		f'''
+		<a
+			href="{discussion_url(row)}"
+			style="
+				display:block;
+				padding:16px;
+				margin-bottom:12px;
+				border:1px solid #e5e7eb;
+				border-radius:12px;
+				text-decoration:none;
+				background:#ffffff;
+			"
+		>
+			<div style="
+				font-size:15px;
+				font-weight:600;
+				color:#111827;
+				margin-bottom:6px;
+				line-height:1.5;
+			">
+				{escape(row.title)}
+			</div>
+
+			<div style="
+				font-size:13px;
+				color:#6b7280;
+			">
+				New reply in {escape(row.project_title or "a space")}
+			</div>
+		</a>
+		'''
 		for row in rows
 	)
-	return f"<h3>{escape(title)}</h3><ul>{items}</ul>"
+
+	return render_section(title, items)
 
 
 def render_notification_list(title: str, rows: list) -> str:
 	if not rows:
 		return ""
+
 	items = "\n".join(
-		f'<li><a href="{notification_url(row)}">{escape(row.type)}</a>: {escape(strip_html_tags(row.message or ""))}</li>'
+		f'''
+		<a
+			href="{notification_url(row)}"
+			style="
+				display:block;
+				padding:16px;
+				margin-bottom:12px;
+				border:1px solid #e5e7eb;
+				border-radius:12px;
+				text-decoration:none;
+				background:#ffffff;
+			"
+		>
+			<div style="
+				font-size:15px;
+				font-weight:600;
+				color:#111827;
+				margin-bottom:6px;
+			">
+				{escape(row.type or "Notification")}
+			</div>
+
+			<div style="
+				font-size:13px;
+				color:#6b7280;
+				line-height:1.5;
+			">
+				{escape(strip_html_tags(row.message or ""))}
+			</div>
+		</a>
+		'''
 		for row in rows
 	)
-	return f"<h3>{escape(title)}</h3><ul>{items}</ul>"
 
+	return render_section(title, items)
 
 def discussion_url(row) -> str:
 	slug = f"/{row.slug}" if row.get("slug") else ""

--- a/gameplan/digest.py
+++ b/gameplan/digest.py
@@ -1,0 +1,474 @@
+from __future__ import annotations
+
+import time
+from random import randint
+from html import escape
+
+import frappe
+from frappe.utils import add_days, get_url, now_datetime, strip_html_tags
+
+
+INACTIVE_DAYS = 7
+DIGEST_WINDOW_DAYS = 7
+DIGEST_LIMIT = 10
+
+
+def send_inactivity_digest_weekly():
+	"""Send a weekly catch-up digest to opted-in users inactive for 7 days."""
+	try:
+		users = get_inactive_digest_users()
+		for user in users:
+			digest = build_user_digest(user.name)
+			if not has_digest_items(digest):
+				frappe.log_error("No digest items found", "Gameplan Digest")
+				print(f"No digest items found for {user.email}, skipping email")
+				continue
+
+			try:
+				frappe.sendmail(
+					recipients=user.email,
+					subject="Your Gameplan catch-up digest",
+					message=render_digest_email(user, digest),
+					now=True,
+				)
+			except frappe.OutgoingEmailError as e:
+				# If outgoing Email Account isn't configured, don't fail the whole job.
+				frappe.log_error(
+					f"Error sending inactivity digest to {user.email}: {str(e)}",
+					"Gameplan Digest",
+				)
+				print(f"Skipping email for {user.email}: {str(e)}")
+				continue
+			except Exception as e:
+				frappe.log_error(f"Error sending inactivity digest: {str(e)}", "Gameplan Digest")
+				print(f"Error sending inactivity digest: {str(e)}")
+	except Exception as e:
+		frappe.log_error(f"Error sending inactivity digest: {str(e)}", "Gameplan Digest")
+		print(f"Error sending inactivity digest: {str(e)}")
+		
+	
+
+
+def get_inactive_digest_users(inactive_days: int = INACTIVE_DAYS):
+	"""Return opted-in users whose last activity is older than the inactivity threshold.
+
+	Seven days is long enough to avoid nudging people who only missed a day or two,
+	and short enough that active project discussions are still fresh.
+	"""
+	cutoff = add_days(now_datetime(), -inactive_days)
+	return frappe.db.sql(
+		"""
+		select u.name, u.email, u.full_name, u.last_active
+		from `tabUser` u
+		where u.enabled = 1
+			and u.user_type = 'Website User'
+			and u.weekly_digest = 1
+			and (
+				u.last_active <= %(cutoff)s
+				or (u.last_active is null and u.creation <= %(cutoff)s)
+			)
+			and exists (
+				select 1
+				from `tabHas Role` role
+				where role.parenttype = 'User'
+					and role.parent = u.name
+					and role.role like 'Gameplan %%'
+			)
+		order by u.last_active asc
+		""",
+		{"cutoff": cutoff},
+		as_dict=True,
+	)
+
+
+def build_user_digest(user: str, window_days: int = DIGEST_WINDOW_DAYS):
+	window_start = add_days(now_datetime(), -window_days)
+	digest = {
+		"new_discussions": get_new_discussions_in_user_spaces(user, window_start),
+		"thread_replies": get_replies_in_user_threads(user, window_start),
+		"notifications": get_unread_notifications(user, window_start),
+	}
+	log_message = f"Built digest for {user}: {len(digest['new_discussions'])} new discussions, {len(digest['thread_replies'])} thread replies, {len(digest['notifications'])} notifications"
+	frappe.log_error(log_message, "Gameplan Digest")
+	print(log_message)
+	return digest
+
+
+def get_new_discussions_in_user_spaces(user: str, window_start):
+	return frappe.db.sql(
+		"""
+		select
+			discussion.name,
+			discussion.title,
+			discussion.slug,
+			discussion.project,
+			project.title as project_title,
+			discussion.owner,
+			discussion.creation
+		from `tabGP Discussion` discussion
+		inner join `tabGP Project` project on project.name = discussion.project
+		where discussion.creation >= %(window_start)s
+			and discussion.owner != %(user)s
+			and project.archived_at is null
+			and exists (
+				select 1
+				from `tabGP Member` member
+				where member.parenttype = 'GP Project'
+					and member.parent = discussion.project
+					and member.user = %(user)s
+			)
+		order by discussion.creation desc
+		limit %(limit)s
+		""",
+		{"user": user, "window_start": window_start, "limit": DIGEST_LIMIT},
+		as_dict=True,
+	)
+
+
+def get_replies_in_user_threads(user: str, window_start):
+	return frappe.db.sql(
+		"""
+		select
+			comment.name,
+			comment.owner,
+			comment.creation,
+			discussion.name as discussion,
+			discussion.title,
+			discussion.slug,
+			discussion.project,
+			project.title as project_title
+		from `tabGP Comment` comment
+		inner join `tabGP Discussion` discussion on discussion.name = comment.reference_name
+		inner join `tabGP Project` project on project.name = discussion.project
+		where comment.reference_doctype = 'GP Discussion'
+			and comment.creation >= %(window_start)s
+			and comment.owner != %(user)s
+			and comment.deleted_at is null
+			and (
+				discussion.owner = %(user)s
+				or exists (
+					select 1
+					from `tabGP Comment` user_comment
+					where user_comment.reference_doctype = 'GP Discussion'
+						and user_comment.reference_name = discussion.name
+						and user_comment.owner = %(user)s
+						and user_comment.deleted_at is null
+				)
+			)
+		order by comment.creation desc
+		limit %(limit)s
+		""",
+		{"user": user, "window_start": window_start, "limit": DIGEST_LIMIT},
+		as_dict=True,
+	)
+
+
+def get_unread_notifications(user: str, window_start):
+	return frappe.get_all(
+		"GP Notification",
+		filters={
+			"to_user": user,
+			"read": 0,
+			"creation": [">=", window_start],
+		},
+		fields=["name", "type", "message", "discussion", "project", "creation", "from_user"],
+		order_by="creation desc",
+		limit=DIGEST_LIMIT,
+	)
+
+
+def has_digest_items(digest: dict) -> bool:
+	return any(digest.get(key) for key in ("new_discussions", "thread_replies", "notifications"))
+
+
+# def render_digest_email(user, digest: dict) -> str:
+# 	name = escape(user.full_name or user.name)
+# 	return f"""
+# 		<p>Hi {name},</p>
+# 		<p>You have been away from Gameplan for at least {INACTIVE_DAYS} days. Here is what changed in the last {DIGEST_WINDOW_DAYS} days.</p>
+# 		{render_discussion_list("New discussions in your spaces", digest["new_discussions"])}
+# 		{render_reply_list("Replies on threads you are in", digest["thread_replies"])}
+# 		{render_notification_list("Unread mentions and direct notifications", digest["notifications"])}
+# 		<p><a href="{get_url('/g')}">Open Gameplan</a></p>
+# 	"""
+
+
+```python
+def render_digest_email(user, digest: dict) -> str:
+	name = escape(user.full_name or user.name)
+
+	new_discussions = digest.get("new_discussions", [])
+	thread_replies = digest.get("thread_replies", [])
+	notifications = digest.get("notifications", [])
+
+	return f"""
+	<html>
+	<body style="
+		margin:0;
+		padding:0;
+		background:#f4f5f7;
+		font-family:Inter, Arial, sans-serif;
+		color:#1f2937;
+	">
+		<div style="
+			max-width:720px;
+			margin:40px auto;
+			padding:0 16px;
+		">
+
+			<!-- Preview Text -->
+			<div style="
+				display:none;
+				max-height:0;
+				overflow:hidden;
+				opacity:0;
+			">
+				{len(new_discussions)} new discussions,
+				{len(thread_replies)} replies,
+				and {len(notifications)} notifications waiting for you.
+			</div>
+
+			<!-- Main Card -->
+			<div style="
+				background:#ffffff;
+				border-radius:16px;
+				padding:32px;
+				box-shadow:0 2px 10px rgba(0,0,0,0.06);
+			">
+
+				<!-- Header -->
+				<div style="margin-bottom:28px;">
+					<h1 style="
+						margin:0;
+						font-size:28px;
+						font-weight:700;
+						color:#111827;
+					">
+						Gameplan Digest
+					</h1>
+
+					<p style="
+						margin-top:12px;
+						font-size:16px;
+						line-height:1.6;
+						color:#4b5563;
+					">
+						Hi <strong>{name}</strong>,
+						<br /><br />
+						Here’s what changed in the last
+						<strong>{DIGEST_WINDOW_DAYS} days</strong>.
+					</p>
+				</div>
+
+				<!-- Stats -->
+				<div style="
+					display:flex;
+					gap:12px;
+					margin-bottom:32px;
+					flex-wrap:wrap;
+				">
+					{render_stat_card('🆕 Discussions', len(new_discussions))}
+					{render_stat_card('💬 Replies', len(thread_replies))}
+					{render_stat_card('🔔 Notifications', len(notifications))}
+				</div>
+
+				<!-- Empty State -->
+				{
+					render_empty_digest()
+					if not new_discussions
+					and not thread_replies
+					and not notifications
+					else ""
+				}
+
+				<!-- Sections -->
+				{
+					render_discussion_list(
+						"🆕 New discussions in your spaces",
+						new_discussions,
+					)
+					if new_discussions
+					else ""
+				}
+
+				{
+					render_reply_list(
+						"💬 Replies on threads you are in",
+						thread_replies,
+					)
+					if thread_replies
+					else ""
+				}
+
+				{
+					render_notification_list(
+						"🔔 Unread mentions and notifications",
+						notifications,
+					)
+					if notifications
+					else ""
+				}
+
+				<!-- CTA -->
+				<div style="
+					margin-top:36px;
+					text-align:center;
+				">
+					<a
+						href="{get_url('/g')}"
+						style="
+							display:inline-block;
+							background:#2563eb;
+							color:white;
+							text-decoration:none;
+							padding:14px 24px;
+							border-radius:10px;
+							font-weight:600;
+							font-size:15px;
+						"
+					>
+						Open Gameplan
+					</a>
+				</div>
+
+			</div>
+
+			<!-- Footer -->
+			<p style="
+				text-align:center;
+				font-size:12px;
+				color:#9ca3af;
+				margin-top:16px;
+			">
+				You’re receiving this digest because you were inactive recently.
+			</p>
+
+		</div>
+	</body>
+	</html>
+	"""
+
+
+def render_empty_digest():
+	return """
+	<div style="
+		text-align:center;
+		padding:48px 24px;
+		background:#f9fafb;
+		border:1px dashed #d1d5db;
+		border-radius:14px;
+		margin-bottom:24px;
+	">
+		<div style="
+			font-size:42px;
+			margin-bottom:12px;
+		">
+			✨
+		</div>
+
+		<h2 style="
+			margin:0 0 10px 0;
+			font-size:20px;
+			color:#111827;
+		">
+			You’re all caught up
+		</h2>
+
+		<p style="
+			margin:0;
+			font-size:14px;
+			line-height:1.6;
+			color:#6b7280;
+		">
+			No new discussions, replies, or notifications
+			were found for this digest period.
+		</p>
+	</div>
+	"""
+```
+
+
+def render_discussion_list(title: str, rows: list) -> str:
+	if not rows:
+		return ""
+	items = "\n".join(
+		f'<li><a href="{discussion_url(row)}">{escape(row.title)}</a> <span style="color: #667085;">in {escape(row.project_title or "a space")}</span></li>'
+		for row in rows
+	)
+	return f"<h3>{escape(title)}</h3><ul>{items}</ul>"
+
+
+def render_reply_list(title: str, rows: list) -> str:
+	if not rows:
+		return ""
+	items = "\n".join(
+		f'<li><a href="{discussion_url(row)}">{escape(row.title)}</a> <span style="color: #667085;">in {escape(row.project_title or "a space")}</span></li>'
+		for row in rows
+	)
+	return f"<h3>{escape(title)}</h3><ul>{items}</ul>"
+
+
+def render_notification_list(title: str, rows: list) -> str:
+	if not rows:
+		return ""
+	items = "\n".join(
+		f'<li><a href="{notification_url(row)}">{escape(row.type)}</a>: {escape(strip_html_tags(row.message or ""))}</li>'
+		for row in rows
+	)
+	return f"<h3>{escape(title)}</h3><ul>{items}</ul>"
+
+
+def discussion_url(row) -> str:
+	slug = f"/{row.slug}" if row.get("slug") else ""
+	return get_url(f"/g/space/{row.project}/discussion/{row.get('discussion') or row.name}{slug}")
+
+
+def notification_url(row) -> str:
+	if row.get("discussion") and row.get("project"):
+		return get_url(f"/g/space/{row.project}/discussion/{row.discussion}")
+	return get_url("/g/notifications")
+
+
+def log_inactive_digest_users(inactive_days: int = INACTIVE_DAYS):
+	users = get_inactive_digest_users(inactive_days)
+	usernames = [user.name for user in users]
+	message = f"Inactive digest users ({inactive_days}+ days): {', '.join(usernames) if usernames else 'none'}"
+	frappe.logger("gameplan.digest").info(message)
+	print(message)
+	return users
+
+
+def run_inactivity_digest_dev_loop(interval_seconds: int = 5, max_runs: int = 0):
+	"""Print inactive digest users every 5 seconds for local development.
+
+	Frappe scheduler cron is minute-granularity, so this helper gives a true 5-second loop
+	without changing production scheduler behavior. Set max_runs=0 to run until interrupted.
+	"""
+	run_count = 0
+	while True:
+		log_inactive_digest_users()
+		run_count += 1
+		if max_runs and run_count >= max_runs:
+			break
+		time.sleep(interval_seconds)
+
+
+def backdate_user_login_for_tests(users: list[str], update_last_active: bool = True):
+	"""Move users' login timestamps 8 days back for local digest testing."""
+	days_back = 8
+	login_at = add_days(now_datetime(), -days_back)
+	results = []
+
+	for user in users:
+		fields = {"last_login": login_at}
+
+		if update_last_active and frappe.get_meta("User").has_field("last_active"):
+			fields["last_active"] = login_at
+
+		frappe.db.set_value("User", user, fields, update_modified=False)
+
+		print(f"Updated {user}: {', '.join(fields)} = {login_at} ({days_back} days back)")
+		results.append({"user": user, "days_back": days_back, "updated_fields": fields})
+
+	frappe.db.commit()
+	return results

--- a/gameplan/hooks.py
+++ b/gameplan/hooks.py
@@ -160,6 +160,7 @@ on_login = "gameplan.www.g.on_login"
 scheduler_events = {
 	"hourly": ["gameplan.gameplan.doctype.gp_invitation.gp_invitation.expire_invitations"],
 	"daily": ["gameplan.demo.demo.generate_data_daily"],
+	"weekly": ["gameplan.digest.send_inactivity_digest_weekly"],
 }
 
 # scheduler_events = {

--- a/gameplan/patches.txt
+++ b/gameplan/patches.txt
@@ -30,3 +30,4 @@ gameplan.gameplan.doctype.gp_unread_record.patches.migrate_to_unread_records
 gameplan.gameplan.doctype.gp_pinned_project.patches.delete_pinned_projects_for_archived_spaces
 gameplan.gameplan.doctype.gp_discussion.patches.set_default_pin_scope
 gameplan.gameplan.doctype.gp_comment.patches.backfill_gp_comment_edited_at
+gameplan.patches.add_weekly_digest_user_field

--- a/gameplan/patches/add_weekly_digest_user_field.py
+++ b/gameplan/patches/add_weekly_digest_user_field.py
@@ -7,9 +7,9 @@ def execute():
 			"User": [
 				{
 					"fieldname": "weekly_digest",
-					"label": "Weekly Digest",
+					"label": "Inactivity Digest",
 					"fieldtype": "Check",
-					"default": "0",
+					"default": "1",
 					"insert_after": "thread_notify",
 				}
 			]

--- a/gameplan/patches/add_weekly_digest_user_field.py
+++ b/gameplan/patches/add_weekly_digest_user_field.py
@@ -1,0 +1,18 @@
+from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+
+
+def execute():
+	create_custom_fields(
+		{
+			"User": [
+				{
+					"fieldname": "weekly_digest",
+					"label": "Weekly Digest",
+					"fieldtype": "Check",
+					"default": "0",
+					"insert_after": "thread_notify",
+				}
+			]
+		},
+		ignore_validate=True,
+	)


### PR DESCRIPTION
# Weekly Activity Digest for Inactive Users

## Overview

This PR implements a weekly email digest system for inactive users in Gameplan.

The feature includes:

* Weekly scheduler job for inactivity digests
* User notification preference toggle in Settings
* Responsive HTML email digest template
* Manual `bench execute` entry point for testing
* Digest preview endpoint for local development

---

# Inactive User Definition

A user is considered inactive if they have not been active in Gameplan for at least **7 days**.

This threshold was chosen because:

* It aligns naturally with a weekly digest cadence
* It avoids emailing users who are only briefly inactive
* It provides enough activity to generate a meaningful summary
* Discussions are still recent and actionable after one week

Inactive users are determined using the `last_active` timestamp on the `User` document.

---

# Digest Content Strategy

The digest prioritizes updates most likely to re-engage users:

## Included Content

### 1. New discussions

Shows newly created discussions from active spaces.

Purpose:

* Helps users quickly discover ongoing conversations
* Encourages returning to active projects/spaces

### 2. Replies on threads the user participated in

Shows replies on discussions the user created or previously commented on.

Purpose:

* Prioritizes directly relevant conversations
* Surfaces follow-ups requiring attention

### 3. Unread notifications

Includes unread notifications generated during the digest window.

Purpose:

* Ensures users do not miss mentions or important updates

---

# Notification Settings

A new **Notifications** section was added to the existing Settings dialog.

Users can:

* Enable/disable weekly inactivity digests
* Persist preferences directly on the `User.weekly_digest` field

The implementation follows the existing settings dialog structure and styling patterns used across Gameplan.

---

# Email Design Rationale

The email template was designed with readability and compatibility as priorities.

## Design Decisions

* Single-column responsive layout
* Lightweight semantic HTML
* Minimal CSS for Gmail/Apple Mail compatibility
* Neutral background colors for dark mode readability
* Clear visual grouping of sections
* Card-based layout for scannability
* Empty-state support when little activity exists

The email intentionally avoids:

* Images
* Complex layouts
* Heavy styling
* Unsupported email CSS features

---

# Schema Changes

Added:

* `weekly_digest` field on `User`

Purpose:

* Stores user preference for weekly digests
* Used during scheduler filtering

---

# Scheduler

Weekly scheduler entry:

```python
scheduler_events = {
    "weekly": ["gameplan.digest.send_inactivity_digest_weekly"],
}
```

---

# Manual Testing

## Backdate users for testing

```bash
bench execute gameplan.digest.backdate_user_login_for_tests --kwargs "{'users':['user@example.com']}"
```

## Trigger digest manually

```bash
bench execute gameplan.digest.send_inactivity_digest_weekly
```

## Preview digest in browser for a user

```bash
/api/method/gameplan.digest.preview_digest?user=thomas.sandoval@techflow.com
```



---

# Screenshots

## Settings Toggle

<img width="1903" height="860" alt="image" src="https://github.com/user-attachments/assets/3718c9d1-7532-43b6-813f-a5bb6337d6e3" />

<img width="1902" height="853" alt="image" src="https://github.com/user-attachments/assets/435444e4-36b1-45d0-9a65-fb2a90e08953" />


## Email Digest
<img width="1895" height="752" alt="image" src="https://github.com/user-attachments/assets/9a23e789-7424-43a0-a88f-09cf55c14dd5" />

---

# Notes


* Users without activity updates are skipped automatically
* Email failures are logged without failing the entire scheduler job
* Digest sections are rendered conditionally based on available activity
