### PR TITLE
Auto-reload discussions feed when tab becomes visible

### DIFF
--- a/frontend/src/data/discussions.ts
+++ b/frontend/src/data/discussions.ts
@@ -22,6 +22,9 @@ export type UseDiscussionOptions = Pick<
 >
 
 export function useDiscussions(options: UseDiscussionOptions) {
+  // Track when the list was last fetched so we only reload a stale feed.
+  let lastLoadedAt = Date.now()
+
   const discussions = useList<Discussion>({
     url: '/api/v2/method/gameplan.gameplan.doctype.gp_discussion.api.get_discussions',
     doctype: 'GP Discussion',
@@ -30,16 +33,10 @@ export function useDiscussions(options: UseDiscussionOptions) {
     limit: options.limit || 50,
     orderBy: options.orderBy,
     immediate: options.immediate ?? true,
-  })
-
-  // Track when the list was last fetched so we only reload a stale feed.
-  let lastLoadedAt = Date.now()
-  watch(
-    () => discussions.loading,
-    (loading) => {
-      if (!loading) lastLoadedAt = Date.now()
+    onSuccess() {
+      lastLoadedAt = Date.now()
     },
-  )
+  })
 
   const visibility = useDocumentVisibility()
   watch(visibility, (state) => {

--- a/frontend/src/data/discussions.ts
+++ b/frontend/src/data/discussions.ts
@@ -1,7 +1,12 @@
-import { MaybeRefOrGetter, toValue } from 'vue'
+import { MaybeRefOrGetter, toValue, watch } from 'vue'
 import { useDoc, useList } from 'frappe-ui'
 import { UseListOptions } from 'frappe-ui'
+import { useDocumentVisibility } from '@vueuse/core'
 import { GPDiscussion } from '@/types/doctypes'
+
+// Reload the feed when the tab is re-activated after sitting in the background
+// for at least this long, so new posts show up without a manual refresh.
+const STALE_RELOAD_THRESHOLD = 2 * 60 * 1000
 
 export interface Discussion extends GPDiscussion {
   project_title: string
@@ -26,6 +31,25 @@ export function useDiscussions(options: UseDiscussionOptions) {
     orderBy: options.orderBy,
     immediate: options.immediate ?? true,
   })
+
+  // Track when the list was last fetched so we only reload a stale feed.
+  let lastLoadedAt = Date.now()
+  watch(
+    () => discussions.loading,
+    (loading) => {
+      if (!loading) lastLoadedAt = Date.now()
+    },
+  )
+
+  const visibility = useDocumentVisibility()
+  watch(visibility, (state) => {
+    if (state !== 'visible') return
+    // Skip if it never loaded, is mid-fetch, or was refreshed recently.
+    if (discussions.loading || !discussions.data) return
+    if (Date.now() - lastLoadedAt < STALE_RELOAD_THRESHOLD) return
+    discussions.reload()
+  })
+
   return discussions
 }
 


### PR DESCRIPTION
## Summary
Added automatic reloading of the discussions feed when the browser tab is re-activated after being in the background for a sufficient duration, ensuring users see new posts without manual refresh.

## Key Changes
- Import `watch` from Vue and `useDocumentVisibility` from VueUse to monitor tab visibility state
- Add `STALE_RELOAD_THRESHOLD` constant (2 minutes) to define when a feed is considered stale
- Track the last time the discussions list was successfully loaded using `lastLoadedAt`
- Watch the document visibility state and automatically reload the feed when:
  - The tab becomes visible again
  - The feed hasn't been reloaded within the stale threshold
  - The list is not currently loading and has data

## Implementation Details
- The reload is skipped if the list is mid-fetch, has never loaded, or was recently refreshed to avoid unnecessary network requests
- Uses Vue's `watch` to monitor both the loading state (to update `lastLoadedAt`) and visibility state (to trigger reload)
- The 2-minute threshold balances keeping content fresh while avoiding excessive API calls for users who frequently switch tabs

https://claude.ai/code/session_01HYywtxcwACx6gUXpQidYof

closes #474 