### PR TITLE
Fix Redis connection URIs in Docker initialization script

### DIFF
--- a/docker/init.sh
+++ b/docker/init.sh
@@ -14,9 +14,9 @@ cd frappe-bench
 
 # Use containers instead of localhost
 bench set-mariadb-host mariadb
-bench set-redis-cache-host redis:6379
-bench set-redis-queue-host redis:6379
-bench set-redis-socketio-host redis:6379
+bench set-redis-cache-host redis://redis:6379
+bench set-redis-queue-host redis://redis:6379
+bench set-redis-socketio-host redis://redis:6379
 
 # Remove redis, watch from Procfile
 sed -i '/redis/d' ./Procfile


### PR DESCRIPTION
## Summary
Updated Redis connection configuration in the Docker initialization script to use proper Redis URI scheme format.

## Key Changes
- Modified Redis host configuration to use `redis://` URI scheme instead of plain `host:port` format
  - `redis-cache-host`: `redis:6379` → `redis://redis:6379`
  - `redis-queue-host`: `redis:6379` → `redis://redis:6379`
  - `redis-socketio-host`: `redis:6379` → `redis://redis:6379`

## Details
The Redis client libraries expect connection strings to follow the standard Redis URI format (`redis://host:port`). The previous configuration using only `host:port` may have caused connection issues or been interpreted incorrectly by the Frappe bench commands. This change ensures proper URI formatting for all three Redis service connections in the Docker environment.

https://claude.ai/code/session_01CaPcfqQzGgDLkGtQxRQk8g