### PR TITLE
fix(tasks): persist status & priority from the desktop sidebar

### DIFF
--- a/frontend/src/components/TaskDetail.vue
+++ b/frontend/src/components/TaskDetail.vue
@@ -131,7 +131,12 @@
         </div>
         <div>Status</div>
         <div>
-          <Select v-model="task.doc.status" :options="statusOptions" placeholder="Set status">
+          <Select
+            :modelValue="task.doc.status"
+            :options="statusOptions"
+            placeholder="Set status"
+            @update:modelValue="(status) => task.setValue.submit({ status })"
+          >
             <template #item-prefix="{ item }">
               <TaskStatusIcon :status="item.value" />
             </template>
@@ -139,7 +144,12 @@
         </div>
         <div>Priority</div>
         <div>
-          <Select v-model="task.doc.priority" :options="priorityOptions" placeholder="Set priority">
+          <Select
+            :modelValue="task.doc.priority"
+            :options="priorityOptions"
+            placeholder="Set priority"
+            @update:modelValue="(priority) => task.setValue.submit({ priority })"
+          >
             <template #item-prefix="{ item }">
               <TaskPriorityIcon :priority="item.value" />
             </template>


### PR DESCRIPTION
### Problem
On a task detail page (desktop, `sm:block` sidebar), selecting a **Status** or **Priority** appears to change but never persists — no autosave, reverts on reload. Comments and the other sidebar fields (Assignee/Space/Due Date) save fine. The mobile layout (`<Dropdown>`) is unaffected.

### Cause
`TaskDetail.vue` desktop sidebar uses:
```vue
<Select v-model="task.doc.status" :options="statusOptions" …>
```
where `statusOptions` entries carry `onClick: () => task.setValue.submit({ status })`. A native `<Select>` renders `<option>` elements and never invokes per-option `onClick` (that's a `<Dropdown>` pattern); with only `v-model` the change mutates the local doc and never calls `setValue`. Priority has the same issue.

### Fix
Switch both to `:modelValue` + `@update:modelValue → task.setValue.submit()`, mirroring the working Assignee/Space/Due Date controls in the same component.