### PR TITLE
[codex] Support community merge URL healing

### DIFF
--- a/frontend/cypress/e2e/community-merge-url-healing.cy.ts
+++ b/frontend/cypress/e2e/community-merge-url-healing.cy.ts
@@ -1,0 +1,117 @@
+type InsertedDoc = {
+  name: string
+  slug?: string
+}
+
+describe('Community merge URL healing', () => {
+  const sourceCommunity = 'source-community'
+  const middleCommunity = 'middle-community'
+  const finalCommunity = 'final-community'
+  let sourceSpaceId: string
+  let discussionId: string
+  let discussionSlug: string
+  let pageId: string
+  let pageSlug: string
+  let taskId: string
+
+  beforeEach(() => {
+    cy.login()
+    cy.request({
+      method: 'POST',
+      url: '/api/method/gameplan.test_api.clear_data',
+    })
+
+    cy.request('POST', '/api/method/frappe.client.insert_many', {
+      docs: [
+        { doctype: 'GP Team', title: 'Source Community' },
+        { doctype: 'GP Team', title: 'Middle Community' },
+        { doctype: 'GP Team', title: 'Final Community' },
+        { doctype: 'GP Project', title: 'Source Space', team: sourceCommunity },
+      ],
+    })
+      .its('body.message')
+      .then((names) => {
+        sourceSpaceId = String(names[3])
+
+        return cy.request('POST', '/api/v2/method/GP Team/update_joined_teams', {
+          teams: [sourceCommunity, middleCommunity, finalCommunity],
+        })
+      })
+      .then(() => {
+        return insertDoc<InsertedDoc>({
+          doctype: 'GP Discussion',
+          title: 'Merge Route Discussion',
+          content: 'Discussion body',
+          project: sourceSpaceId,
+        })
+      })
+      .then((discussion) => {
+        discussionId = discussion.name
+        discussionSlug = discussion.slug ?? 'merge-route-discussion'
+
+        return insertDoc<InsertedDoc>({
+          doctype: 'GP Page',
+          title: 'Merge Route Page',
+          content: 'Page body',
+          project: sourceSpaceId,
+        })
+      })
+      .then((page) => {
+        pageId = page.name
+        pageSlug = page.slug ?? 'merge-route-page'
+
+        return insertDoc<InsertedDoc>({
+          doctype: 'GP Task',
+          title: 'Merge Route Task',
+          description: 'Task body',
+          project: sourceSpaceId,
+        })
+      })
+      .then((task) => {
+        taskId = task.name
+
+        return mergeCommunity(sourceCommunity, middleCommunity)
+      })
+      .then(() => {
+        return mergeCommunity(middleCommunity, finalCommunity)
+      })
+  })
+
+  it('heals stale discussion, page, and task URLs from the content record', () => {
+    assertHealsToCanonicalRoute(
+      `/g/community/${sourceCommunity}/space/${sourceSpaceId}/discussion/${discussionId}/${discussionSlug}`,
+      `/g/community/${finalCommunity}/space/${sourceSpaceId}/discussion/${discussionId}/${discussionSlug}`,
+    )
+    cy.contains('h1:visible', 'Merge Route Discussion').should('exist')
+
+    assertHealsToCanonicalRoute(
+      `/g/community/${middleCommunity}/space/${sourceSpaceId}/pages/${pageId}/${pageSlug}`,
+      `/g/community/${finalCommunity}/space/${sourceSpaceId}/pages/${pageId}/${pageSlug}`,
+    )
+    cy.get('input[placeholder="Title"]:visible').should('have.value', 'Merge Route Page')
+
+    assertHealsToCanonicalRoute(
+      `/g/community/${sourceCommunity}/space/${sourceSpaceId}/tasks/${taskId}`,
+      `/g/community/${finalCommunity}/space/${sourceSpaceId}/tasks/${taskId}`,
+    )
+    cy.get('input[placeholder="Title"]:visible').should('have.value', 'Merge Route Task')
+  })
+})
+
+function insertDoc<T>(doc: Record<string, unknown>) {
+  return cy
+    .request('POST', '/api/method/frappe.client.insert', { doc })
+    .its('body.message')
+    .then((inserted) => inserted as T)
+}
+
+function mergeCommunity(source: string, target: string) {
+  return cy.request('POST', `/api/v2/document/GP%20Team/${source}/method/merge_into_team`, {
+    team: target,
+  })
+}
+
+function assertHealsToCanonicalRoute(stalePath: string, canonicalPath: string) {
+  cy.visit(stalePath)
+  cy.location('pathname').should('eq', canonicalPath)
+}

--- a/frontend/src/pages/Configure/CommunityOptions.vue
+++ b/frontend/src/pages/Configure/CommunityOptions.vue
@@ -5,20 +5,31 @@
     :label="`${community.title} Community Options`"
     :options="options"
   />
+
+  <MergeCommunityDialog
+    v-model="showMergeDialog"
+    :community="community"
+    @merged="redirectAfterMerge"
+  />
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import { dialog, Dropdown, useDoctype } from 'frappe-ui'
 import { communities } from '@/data/communities'
 import type { Community } from '@/data/communities'
 import type { GPTeam } from '@/types/doctypes'
+import MergeCommunityDialog from './MergeCommunityDialog.vue'
 
 const props = defineProps<{
   community: Community
 }>()
 
 const teams = useDoctype<GPTeam>('GP Team')
+const route = useRoute()
+const router = useRouter()
+const showMergeDialog = ref(false)
 
 const options = computed(() => [
   {
@@ -30,6 +41,12 @@ const options = computed(() => [
     label: 'View members',
     icon: 'lucide-users-2',
     route: { name: 'CommunityMembers', params: { communityId: props.community.name } },
+  },
+  {
+    label: 'Merge into...',
+    icon: 'lucide-merge',
+    onClick: () => (showMergeDialog.value = true),
+    condition: () => !props.community.archived_at,
   },
   {
     label: 'Unarchive',
@@ -61,5 +78,18 @@ async function updateArchiveState(method: 'archive' | 'unarchive') {
     method,
   })
   await communities.reload()
+}
+
+function redirectAfterMerge(communityId: string) {
+  if (route.params.communityId !== props.community.name) return
+
+  router.replace({
+    name: route.name ?? 'CommunitySpaces',
+    params: {
+      ...route.params,
+      communityId,
+    },
+    query: route.query,
+  })
 }
 </script>

--- a/frontend/src/pages/Configure/MergeCommunityDialog.vue
+++ b/frontend/src/pages/Configure/MergeCommunityDialog.vue
@@ -1,0 +1,90 @@
+<template>
+  <Dialog title="Merge community" @after-leave="selectedCommunity = null" v-model:open="show">
+    <p class="mb-4 text-p-base text-ink-gray-7">
+      This will move all spaces and members from
+      <span class="whitespace-nowrap font-semibold">{{ community.title }}</span>
+      into the selected community. The old community will be archived and content links will use
+      each item's current space.
+    </p>
+    <Combobox
+      :options="communityOptions"
+      v-model="selectedCommunity"
+      placeholder="Select a community"
+      class="w-full"
+      open-on-click
+      autofocus
+    />
+    <ErrorMessage class="mt-2" :message="teams.runDocMethod.error" />
+    <template #actions>
+      <Button
+        class="w-full"
+        variant="solid"
+        :loading="teams.runDocMethod.isLoading(community.name, 'merge_into_team')"
+        @click="submit"
+      >
+        {{ selectedCommunity ? `Merge into ${selectedCommunityLabel}` : 'Merge' }}
+      </Button>
+    </template>
+  </Dialog>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { Combobox, useDoctype } from 'frappe-ui'
+import { communities, type Community } from '@/data/communities'
+import { spaces } from '@/data/spaces'
+import { useSessionUser } from '@/data/users'
+import type { GPTeam } from '@/types/doctypes'
+import { getManageableCommunities } from '@/utils/permissions'
+
+const props = defineProps<{
+  community: Community
+}>()
+const emit = defineEmits<{
+  (event: 'merged', communityId: string): void
+}>()
+
+const show = defineModel<boolean>()
+const teams = useDoctype<GPTeam>('GP Team')
+const sessionUser = useSessionUser()
+const selectedCommunity = ref<string | null>(null)
+
+const communityOptions = computed(() => {
+  return getManageableCommunities(communities.data || [], sessionUser)
+    .filter((community) => !community.archived_at && community.name !== props.community.name)
+    .map((community) => ({
+      label: community.title,
+      value: community.name,
+    }))
+})
+const selectedCommunityLabel = computed(() => {
+  return (
+    communityOptions.value.find((community) => community.value === selectedCommunity.value)
+      ?.label ?? ''
+  )
+})
+
+function submit() {
+  teams.runDocMethod
+    .submit({
+      method: 'merge_into_team',
+      name: props.community.name,
+      params: {
+        team: selectedCommunity.value,
+      },
+      validate() {
+        if (!selectedCommunity.value) {
+          return 'Select a community to merge into'
+        }
+      },
+    })
+    .then(async () => {
+      const targetCommunity = selectedCommunity.value
+      await Promise.all([communities.reload(), spaces.reload()])
+      show.value = false
+      if (targetCommunity) {
+        emit('merged', targetCommunity)
+      }
+    })
+}
+</script>

--- a/frontend/src/router.ts
+++ b/frontend/src/router.ts
@@ -36,6 +36,7 @@ type ProjectContentDoc = {
 }
 
 const discussionFeeds = ['recent', 'unread', 'participating']
+const projectContentDocRequests = new Map<string, Promise<ProjectContentDoc | null>>()
 
 // Redirect-style guards still need a component record so Vue Router matches them consistently.
 const RouteGuard = { render: () => null }
@@ -480,11 +481,6 @@ const routes: RouteRecordRaw[] = [
     path: '/space/:spaceId/pages/:pageId/:slug?',
     component: RouteGuard,
     async beforeEnter(to) {
-      const canonicalRoute = await getCanonicalContentRoute(to)
-      if (canonicalRoute) {
-        return canonicalRoute
-      }
-
       const space = await findSpace(routeParam(to.params.spaceId))
 
       if (!space?.team) {
@@ -527,11 +523,6 @@ const routes: RouteRecordRaw[] = [
     path: '/space/:spaceId/tasks/:taskId',
     component: RouteGuard,
     async beforeEnter(to) {
-      const canonicalRoute = await getCanonicalContentRoute(to)
-      if (canonicalRoute) {
-        return canonicalRoute
-      }
-
       const space = await findSpace(routeParam(to.params.spaceId))
 
       if (!space?.team) {
@@ -553,11 +544,6 @@ const routes: RouteRecordRaw[] = [
     path: '/space/:spaceId/discussion/:postId/:slug?',
     component: RouteGuard,
     async beforeEnter(to) {
-      const canonicalRoute = await getCanonicalContentRoute(to)
-      if (canonicalRoute) {
-        return canonicalRoute
-      }
-
       const space = await findSpace(routeParam(to.params.spaceId))
 
       if (!space?.team) {
@@ -788,16 +774,16 @@ router.beforeEach(async (to, from) => {
     return getHomeRoute()
   }
 
+  const canonicalContentRoute = await getCanonicalContentRoute(to)
+  if (canonicalContentRoute) {
+    return canonicalContentRoute
+  }
+
   if (!isCommunityScopedRoute) {
     return
   }
 
   let communityId = routeParam(to.params.communityId)
-
-  const canonicalContentRoute = await getCanonicalContentRoute(to)
-  if (canonicalContentRoute) {
-    return canonicalContentRoute
-  }
 
   let space = to.params.spaceId ? getSpace(routeParam(to.params.spaceId)) : null
 
@@ -957,6 +943,19 @@ function getContentRouteDescriptor(to: RouteLocationNormalized): ContentRouteDes
 }
 
 async function getProjectContentDoc(doctype: ContentRouteDescriptor['doctype'], name: string) {
+  const cacheKey = `${doctype}:${name}`
+  const cachedRequest = projectContentDocRequests.get(cacheKey)
+  if (cachedRequest) return cachedRequest
+
+  const request = fetchProjectContentDoc(doctype, name)
+  projectContentDocRequests.set(cacheKey, request)
+  request.finally(() => {
+    window.setTimeout(() => projectContentDocRequests.delete(cacheKey), 1000)
+  })
+  return request
+}
+
+async function fetchProjectContentDoc(doctype: ContentRouteDescriptor['doctype'], name: string) {
   try {
     return await call<ProjectContentDoc>('frappe.client.get', { doctype, name })
   } catch {

--- a/frontend/src/router.ts
+++ b/frontend/src/router.ts
@@ -6,6 +6,7 @@ import {
   type RouteRecordRaw,
 } from 'vue-router'
 import { until } from '@vueuse/core'
+import { call } from 'frappe-ui'
 import { session } from './data/session'
 import { isGameplanAdmin, users, useSessionUser } from './data/users'
 import { communities, getActiveCommunity, getCommunity } from './data/communities'
@@ -22,6 +23,17 @@ type ResourceLike = {
 }
 
 type RouteParamValue = string | string[]
+type ContentRouteDescriptor = {
+  doctype: 'GP Discussion' | 'GP Page' | 'GP Task'
+  documentParam: 'postId' | 'pageId' | 'taskId'
+  routeName: 'Discussion' | 'SpacePage' | 'SpaceTask'
+  slugParam?: 'slug'
+}
+type ProjectContentDoc = {
+  name: string
+  project?: string
+  slug?: string
+}
 
 const discussionFeeds = ['recent', 'unread', 'participating']
 
@@ -468,6 +480,11 @@ const routes: RouteRecordRaw[] = [
     path: '/space/:spaceId/pages/:pageId/:slug?',
     component: RouteGuard,
     async beforeEnter(to) {
+      const canonicalRoute = await getCanonicalContentRoute(to)
+      if (canonicalRoute) {
+        return canonicalRoute
+      }
+
       const space = await findSpace(routeParam(to.params.spaceId))
 
       if (!space?.team) {
@@ -510,6 +527,11 @@ const routes: RouteRecordRaw[] = [
     path: '/space/:spaceId/tasks/:taskId',
     component: RouteGuard,
     async beforeEnter(to) {
+      const canonicalRoute = await getCanonicalContentRoute(to)
+      if (canonicalRoute) {
+        return canonicalRoute
+      }
+
       const space = await findSpace(routeParam(to.params.spaceId))
 
       if (!space?.team) {
@@ -531,6 +553,11 @@ const routes: RouteRecordRaw[] = [
     path: '/space/:spaceId/discussion/:postId/:slug?',
     component: RouteGuard,
     async beforeEnter(to) {
+      const canonicalRoute = await getCanonicalContentRoute(to)
+      if (canonicalRoute) {
+        return canonicalRoute
+      }
+
       const space = await findSpace(routeParam(to.params.spaceId))
 
       if (!space?.team) {
@@ -767,12 +794,31 @@ router.beforeEach(async (to, from) => {
 
   let communityId = routeParam(to.params.communityId)
 
+  const canonicalContentRoute = await getCanonicalContentRoute(to)
+  if (canonicalContentRoute) {
+    return canonicalContentRoute
+  }
+
+  let space = to.params.spaceId ? getSpace(routeParam(to.params.spaceId)) : null
+
+  if (to.params.spaceId && !space) {
+    return { name: 'NotFound' }
+  }
+
+  if (space?.team && space.team !== communityId) {
+    return redirectCurrentRouteToCommunity(to, space.team)
+  }
+
   let community = getCommunity(communityId)
 
   // Invalid community URLs should fail loudly instead of silently switching shell state.
   // Public communities are visible even when the user has not joined them, so route validity
   // cannot be tied to the active sidebar community list.
-  if (!community || community.archived_at) {
+  if (!community) {
+    return { name: 'NotFound' }
+  }
+
+  if (community.archived_at) {
     return { name: 'NotFound' }
   }
 
@@ -780,30 +826,6 @@ router.beforeEach(async (to, from) => {
 
   if (getActiveCommunity(communityId) && communityState.joinedId !== communityId) {
     communityState.change(communityId)
-  }
-
-  if (!to.params.spaceId) {
-    return
-  }
-
-  let space = getSpace(routeParam(to.params.spaceId))
-
-  // A scoped space URL is only valid inside the community that owns that space.
-  if (!space) {
-    return { name: 'NotFound' }
-  }
-
-  if (space.team !== communityId) {
-    return {
-      name: to.name ?? 'Space',
-      params: {
-        ...to.params,
-        communityId: space.team,
-      },
-      query: to.query,
-      hash: to.hash,
-      replace: true,
-    }
   }
 })
 
@@ -857,6 +879,105 @@ function isMobileViewport() {
 
 function hasAnyData(): boolean {
   return (communities.data?.length ?? 0) > 0 || (spaces.data?.length ?? 0) > 0
+}
+
+function redirectCurrentRouteToCommunity(to: RouteLocationNormalized, communityId: string) {
+  return {
+    name: to.name ?? 'Space',
+    params: {
+      ...to.params,
+      communityId,
+    },
+    query: to.query,
+    hash: to.hash,
+    replace: true,
+  }
+}
+
+async function getCanonicalContentRoute(
+  to: RouteLocationNormalized,
+): Promise<RouteLocationRaw | undefined> {
+  const descriptor = getContentRouteDescriptor(to)
+  if (!descriptor) return
+
+  const documentName = routeParam(to.params[descriptor.documentParam])
+  if (!documentName) return
+
+  const doc = await getProjectContentDoc(descriptor.doctype, documentName)
+  if (!doc?.project) return { name: 'NotFound' }
+
+  const space = await findSpace(String(doc.project))
+  if (!space?.team) return { name: 'NotFound' }
+
+  const params: Record<string, RouteParamValue | undefined> = {
+    ...to.params,
+    communityId: space.team,
+    spaceId: space.name,
+  }
+  if (descriptor.slugParam && doc.slug) {
+    params[descriptor.slugParam] = doc.slug
+  }
+
+  if (isCurrentContentRoute(to, descriptor, params)) return
+
+  return {
+    name: descriptor.routeName,
+    params,
+    query: to.query,
+    hash: to.hash,
+    replace: true,
+  }
+}
+
+function getContentRouteDescriptor(to: RouteLocationNormalized): ContentRouteDescriptor | null {
+  if (to.params.postId) {
+    return {
+      doctype: 'GP Discussion',
+      documentParam: 'postId',
+      routeName: 'Discussion',
+      slugParam: 'slug',
+    }
+  }
+  if (to.params.pageId) {
+    return {
+      doctype: 'GP Page',
+      documentParam: 'pageId',
+      routeName: 'SpacePage',
+      slugParam: 'slug',
+    }
+  }
+  if (to.params.taskId) {
+    return {
+      doctype: 'GP Task',
+      documentParam: 'taskId',
+      routeName: 'SpaceTask',
+    }
+  }
+  return null
+}
+
+async function getProjectContentDoc(doctype: ContentRouteDescriptor['doctype'], name: string) {
+  try {
+    return await call<ProjectContentDoc>('frappe.client.get', { doctype, name })
+  } catch {
+    return null
+  }
+}
+
+function isCurrentContentRoute(
+  to: RouteLocationNormalized,
+  descriptor: ContentRouteDescriptor,
+  params: Record<string, RouteParamValue | undefined>,
+) {
+  if (to.name !== descriptor.routeName) return false
+  if (routeParam(to.params.communityId) !== params.communityId) return false
+  if (routeParam(to.params.spaceId) !== params.spaceId) return false
+
+  if (descriptor.slugParam && params.slug) {
+    return optionalRouteParam(to.params.slug) === params.slug
+  }
+
+  return true
 }
 
 async function findSpace(spaceId: string): Promise<Space | null> {

--- a/gameplan/gameplan/doctype/gp_project/gp_project.py
+++ b/gameplan/gameplan/doctype/gp_project/gp_project.py
@@ -21,6 +21,17 @@ from gameplan.permissions import (
 )
 
 DEFAULT_SPACE_ICON = "lucide-hash"
+PROJECT_TEAM_DOCTYPES = [
+	"GP Discussion",
+	"GP Draft",
+	"GP Followed Project",
+	"GP Guest Access",
+	"GP Notification",
+	"GP Page",
+	"GP Pinned Project",
+	"GP Project Visit",
+	"GP Task",
+]
 
 
 class GPProject(ManageMembersMixin, Archivable, Document):
@@ -66,16 +77,11 @@ class GPProject(ManageMembersMixin, Archivable, Document):
 			return
 		self.team = team
 		self.save()
-		# Repoint child discussions/tasks in one statement each. Loading + saving every
-		# doc would needlessly re-run their full on_update (notify_mentions, etc.); only
-		# the denormalized `team` column changes here.
-		for doctype in ["GP Task", "GP Discussion"]:
-			DocType = frappe.qb.DocType(doctype)
-			(
-				frappe.qb.update(DocType)
-				.set(DocType.team, self.team)
-				.where(DocType.project == str(self.name))
-			).run()
+		self.update_project_team_references()
+
+	def update_project_team_references(self):
+		for doctype in PROJECT_TEAM_DOCTYPES:
+			update_project_team_reference(doctype, self.name, self.team)
 
 	@frappe.whitelist()
 	def merge_with_project(self, project=None):
@@ -269,6 +275,11 @@ def get_activity():
 				activity_by_project[project_name] = last_activity_at
 
 	return activity_by_project
+
+
+def update_project_team_reference(doctype: str, project: str, team: str | None):
+	DocType = frappe.qb.DocType(doctype)
+	(frappe.qb.update(DocType).set(DocType.team, team).where(DocType.project == str(project))).run()
 
 
 @frappe.whitelist()

--- a/gameplan/gameplan/doctype/gp_team/gp_team.py
+++ b/gameplan/gameplan/doctype/gp_team/gp_team.py
@@ -2,6 +2,7 @@
 # For license information, please see license.txt
 
 import frappe
+from frappe import _
 from frappe.model.document import Document
 from frappe.model.naming import append_number_if_name_exists
 from frappe.utils import cint
@@ -116,10 +117,10 @@ class GPTeam(Archivable, Document):
 	@frappe.whitelist()
 	def merge_into_team(self, team: str):
 		if self.archived_at:
-			frappe.throw("Cannot merge an archived community")
+			frappe.throw(_("Cannot merge an archived community"))
 
-		target = self.get_merge_target(team)
 		require_can_manage_community(self)
+		target = self.get_merge_target(team)
 		require_can_manage_community(target)
 
 		self.move_spaces_to(target.name)
@@ -187,13 +188,13 @@ class GPTeam(Archivable, Document):
 
 	def get_merge_target(self, team: str):
 		if not team or team == self.name:
-			frappe.throw("Select a different community to merge into")
+			frappe.throw(_("Select a different community to merge into"))
 		if not frappe.db.exists("GP Team", team):
-			frappe.throw(f'Invalid community "{team}"')
+			frappe.throw(_('Invalid community "{0}"').format(team))
 
 		target = frappe.get_doc("GP Team", team)
 		if target.archived_at:
-			frappe.throw("Cannot merge into an archived community")
+			frappe.throw(_("Cannot merge into an archived community"))
 		return target
 
 	def move_spaces_to(self, team: str):
@@ -205,6 +206,7 @@ class GPTeam(Archivable, Document):
 		for member in self.members:
 			if member.user:
 				target.add_member(member.user, is_admin=member.is_admin)
+		# The merge caller has already asserted manage-community permission on target.
 		target.save(ignore_permissions=True)
 
 

--- a/gameplan/gameplan/doctype/gp_team/gp_team.py
+++ b/gameplan/gameplan/doctype/gp_team/gp_team.py
@@ -56,11 +56,15 @@ class GPTeam(Archivable, Document):
 		)
 
 	def add_member(self, email, is_admin=0):
-		if email not in [member.user for member in self.members]:
-			self.append(
-				"members",
-				{"email": email, "user": email, "status": "Accepted", "is_admin": is_admin},
-			)
+		member = self.get_member(email)
+		if member:
+			member.is_admin = cint(member.is_admin) or cint(is_admin)
+			return
+
+		self.append(
+			"members",
+			{"email": email, "user": email, "status": "Accepted", "is_admin": is_admin},
+		)
 
 	@frappe.whitelist()
 	def add_members(self, users):
@@ -108,6 +112,19 @@ class GPTeam(Archivable, Document):
 			return
 
 		frappe.delete_doc("GP Invitation", invitation.name, ignore_permissions=True)
+
+	@frappe.whitelist()
+	def merge_into_team(self, team: str):
+		if self.archived_at:
+			frappe.throw("Cannot merge an archived community")
+
+		target = self.get_merge_target(team)
+		require_can_manage_community(self)
+		require_can_manage_community(target)
+
+		self.move_spaces_to(target.name)
+		self.copy_members_to(target)
+		self.archive()
 
 	@frappe.whitelist()
 	def set_member_admin(self, user, is_admin):
@@ -167,6 +184,28 @@ class GPTeam(Archivable, Document):
 			filters["is_private"] = is_private
 
 		return frappe.qb.get_query("GP Project", filters=filters, fields=["name"]).run(pluck=True)
+
+	def get_merge_target(self, team: str):
+		if not team or team == self.name:
+			frappe.throw("Select a different community to merge into")
+		if not frappe.db.exists("GP Team", team):
+			frappe.throw(f'Invalid community "{team}"')
+
+		target = frappe.get_doc("GP Team", team)
+		if target.archived_at:
+			frappe.throw("Cannot merge into an archived community")
+		return target
+
+	def move_spaces_to(self, team: str):
+		for project_name in self.get_project_names():
+			project = frappe.get_doc("GP Project", project_name)
+			project.move_to_team(team)
+
+	def copy_members_to(self, target):
+		for member in self.members:
+			if member.user:
+				target.add_member(member.user, is_admin=member.is_admin)
+		target.save(ignore_permissions=True)
 
 
 @frappe.whitelist(methods=["POST"])

--- a/gameplan/gameplan/doctype/gp_team/test_gp_team.py
+++ b/gameplan/gameplan/doctype/gp_team/test_gp_team.py
@@ -6,7 +6,7 @@ from frappe.tests.utils import FrappeTestCase
 
 from gameplan.gameplan.doctype.gp_team.gp_team import update_joined_teams
 from gameplan.gameplan.doctype.gp_user_profile.gp_user_profile import get_session_user_profile
-from gameplan.tests.utils import create_member
+from gameplan.tests.utils import create_discussion, create_member, create_project
 
 
 class TestGPTeam(FrappeTestCase):
@@ -73,3 +73,29 @@ class TestGPTeam(FrappeTestCase):
 		frappe.set_user(user.name)
 
 		self.assertRaises(frappe.ValidationError, update_joined_teams, [team.name], "Banner")
+
+	def test_merge_into_team_moves_spaces_members_and_archives_source(self):
+		source_member = create_member("merge-source-member@example.com", "Merge Source Member")
+		source = frappe.get_doc(doctype="GP Team", title="Merge Source Team").insert(ignore_permissions=True)
+		target = frappe.get_doc(doctype="GP Team", title="Merge Target Team").insert(ignore_permissions=True)
+		source.add_member(source_member.name, is_admin=1)
+		source.save(ignore_permissions=True)
+		project = create_project("Merge Source Space", source.name)
+		discussion = create_discussion("Merge Source Discussion", project.name)
+		task = frappe.get_doc(doctype="GP Task", title="Merge Source Task", project=project.name).insert(
+			ignore_permissions=True
+		)
+		page = frappe.get_doc(doctype="GP Page", title="Merge Source Page", project=project.name).insert(
+			ignore_permissions=True
+		)
+
+		source.merge_into_team(target.name)
+
+		source.reload()
+		target.reload()
+		self.assertTrue(source.archived_at)
+		self.assertTrue(target.get_member(source_member.name).is_admin)
+		self.assertEqual(frappe.db.get_value("GP Project", project.name, "team"), target.name)
+		self.assertEqual(frappe.db.get_value("GP Discussion", discussion.name, "team"), target.name)
+		self.assertEqual(frappe.db.get_value("GP Task", task.name, "team"), target.name)
+		self.assertEqual(frappe.db.get_value("GP Page", page.name, "team"), target.name)


### PR DESCRIPTION
## Summary

Adds first-class community merging so spaces, members, and project-scoped content move to a target community while old discussion, page, and task URLs heal from the content record.

## Details

- Add `GP Team.merge_into_team` to move spaces, copy members, and archive the source community.
- Sync denormalized `team` fields across project content when a space moves communities.
- Canonicalize discussion, page, and task routes from the current content document instead of relying on explicit community redirects.
- Add a Configure UI dialog for merging communities.
- Add backend and Cypress coverage for repeated merges and stale URL healing.

## Validation

- `pre-commit run --files gameplan/gameplan/doctype/gp_project/gp_project.py gameplan/gameplan/doctype/gp_team/gp_team.py gameplan/gameplan/doctype/gp_team/test_gp_team.py frontend/src/router.ts frontend/src/pages/Configure/CommunityOptions.vue frontend/src/pages/Configure/MergeCommunityDialog.vue frontend/cypress/e2e/community-merge-url-healing.cy.ts`
- `bench --site gameplan-demo.test run-tests --module gameplan.gameplan.doctype.gp_team.test_gp_team`
- `yarn build`
- `cd frontend && yarn cypress run --spec cypress/e2e/community-merge-url-healing.cy.ts`
