### PR TITLE
feat(community): mark all as read before a date + unread count fixes

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,7 @@
     "@tiptap/vue-3": "^3.26.0",
     "@vueuse/core": "^10.1.2",
     "feather-icons": "^4.28.0",
-    "frappe-ui": "1.0.0-beta.11",
+    "frappe-ui": "1.0.0-beta.13",
     "fuzzysort": "^2.0.4",
     "htmldiff-js": "^1.0.5",
     "idb-keyval": "^6.2.1",

--- a/frontend/src/components/AppRail/AppRail.vue
+++ b/frontend/src/components/AppRail/AppRail.vue
@@ -156,7 +156,7 @@ import { currentSidebarBadgeStyle } from '@/data/sidebarPreferences'
 import { getSpaceUnreadCount, spaces } from '@/data/spaces'
 import { isGameplanAdmin, useSessionUser } from '@/data/users'
 import { useConfigureRoute } from '@/composables/useConfigureRoute'
-import { formatUnreadCount, unreadAriaLabel } from '@/utils/formatters'
+import { unreadAriaLabel } from '@/utils/formatters'
 import CommunityImage from '../CommunityImage.vue'
 import GameplanLogo from '../GameplanLogo.vue'
 import CustomizeSidebarDialog from './CustomizeSidebarDialog.vue'
@@ -312,7 +312,7 @@ function showTooltipUnreadCount(unreadCount: number) {
 }
 
 function tooltipUnreadCount(unreadCount: number) {
-  return `${formatUnreadCount(unreadCount)} unread`
+  return `${unreadCount} unread`
 }
 
 function goHome() {

--- a/frontend/src/components/AppRail/RailIcon.vue
+++ b/frontend/src/components/AppRail/RailIcon.vue
@@ -34,7 +34,7 @@ import { computed } from 'vue'
 import { TooltipRoot, TooltipTrigger } from 'reka-ui'
 import { Button, TooltipBubble } from 'frappe-ui'
 import type { SidebarBadgeStyle } from '@/data/sidebarPreferences'
-import { formatUnreadCount, unreadAriaLabel } from '@/utils/formatters'
+import { unreadAriaLabel } from '@/utils/formatters'
 import UnreadBadge from './UnreadBadge.vue'
 
 const props = defineProps<{
@@ -51,5 +51,5 @@ const ariaLabel = computed(() => unreadAriaLabel(props.label, props.unreadCount 
 const showTooltipUnreadCount = computed(() => {
   return props.badgeStyle === 'Dot' && (props.unreadCount ?? 0) > 0
 })
-const tooltipUnreadCount = computed(() => `${formatUnreadCount(props.unreadCount ?? 0)} unread`)
+const tooltipUnreadCount = computed(() => `${props.unreadCount ?? 0} unread`)
 </script>

--- a/frontend/src/components/AppRail/UnreadBadge.vue
+++ b/frontend/src/components/AppRail/UnreadBadge.vue
@@ -3,27 +3,27 @@
     v-if="showCountBadge"
     ref="referenceEl"
     aria-hidden="true"
-    class="pointer-events-none absolute -top-3 right-2 size-0"
+    class="pointer-events-none absolute -top-2 right-2 size-0"
   />
 
   <span
     v-if="showDot && count > 0"
     aria-hidden="true"
-    class="pointer-events-none absolute -right-0.5 -top-0.5 block size-2 rounded-full bg-surface-amber-6"
+    class="pointer-events-none absolute -right-0.5 -top-0.5 block size-2 rounded-full bg-surface-red-6 border border-[var(--surface-sidebar)]"
   />
 
   <Teleport to="body">
     <span
       v-if="showCountBadge"
       ref="floatingEl"
-      class="pointer-events-none"
+      class="pointer-events-none border border-[var(--surface-sidebar)] rounded-full inline-flex"
       :class="{ invisible: !isPositioned }"
       :style="floatingStyles"
     >
       <Badge
         v-if="style === 'Unread count'"
         variant="solid"
-        theme="amber"
+        theme="red"
         size="sm"
         aria-hidden="true"
       >

--- a/frontend/src/data/unreadCount.ts
+++ b/frontend/src/data/unreadCount.ts
@@ -49,11 +49,21 @@ export function getProjectUnreadCount(spaceId: string) {
   return unreadCounts[spaceId] ?? 0
 }
 
+// Two watchers (CommunityMenu + Discussions) and the post-mark refresh all call
+// fetchParticipatingUnreadCount on the same shared runMethod instance, so their requests can
+// overlap and resolve out of order — an older response would then write a pre-mark count back
+// over a newer one. Track the latest request per team and apply only that response.
+const participatingRequestSeq: Record<string, number> = {}
+
 /** Fetch (and cache) the participating unread count for a community. */
 export function fetchParticipatingUnreadCount(team: string) {
+  const seq = (participatingRequestSeq[team] ?? 0) + 1
+  participatingRequestSeq[team] = seq
   return participatingCountApi.runMethod
     .submit({ method: 'get_participating_unread_count', params: { team } })
     .then((count: number) => {
+      // A newer fetch for this team superseded us — drop this stale response.
+      if (participatingRequestSeq[team] !== seq) return participatingUnreadCounts[team] ?? 0
       participatingUnreadCounts[team] = Number(count) || 0
       return participatingUnreadCounts[team]
     })

--- a/frontend/src/data/unreadCount.ts
+++ b/frontend/src/data/unreadCount.ts
@@ -13,16 +13,22 @@ interface ParticipatingUnreadCount {
 const unreadCounts = reactive<ProjectUnreadCount>({})
 const participatingUnreadCounts = reactive<ParticipatingUnreadCount>({})
 
-// All unread-count APIs live on the GP Unread Record controller, called via
-// runMethod so we avoid hardcoded dotted module paths.
-const UnreadCount = useDoctype('GP Unread Record')
+// All unread-count APIs live on the GP Unread Record controller, called via runMethod so we
+// avoid hardcoded dotted module paths. Each `useDoctype` exposes ONE shared `runMethod`
+// (a single useCall instance), and concurrent calls on it race on shared request state and
+// cross-resolve. We therefore give each endpoint its own instance so they can safely overlap.
+const unreadCountApi = useDoctype('GP Unread Record')
+const participatingCountApi = useDoctype('GP Unread Record')
+const markReadApi = useDoctype('GP Unread Record')
 
 function loadProjectUnreadCounts(projects?: string[]) {
-  return UnreadCount.runMethod
+  return unreadCountApi.runMethod
     .submit({ method: 'get_unread_count', params: { projects } })
     .then((data: ProjectUnreadCount) => {
       for (const [spaceId, count] of Object.entries(data)) {
-        unreadCounts[spaceId] = count
+        // Counts cross the runMethod/JSON boundary as strings (MariaDB COUNT). Coerce to
+        // Number here so summing them (e.g. per community) adds instead of concatenating.
+        unreadCounts[spaceId] = Number(count) || 0
       }
       return data
     })
@@ -37,10 +43,10 @@ export function getProjectUnreadCount(spaceId: string) {
 
 /** Fetch (and cache) the participating unread count for a community. */
 export function fetchParticipatingUnreadCount(team: string) {
-  return UnreadCount.runMethod
+  return participatingCountApi.runMethod
     .submit({ method: 'get_participating_unread_count', params: { team } })
     .then((count: number) => {
-      participatingUnreadCounts[team] = count ?? 0
+      participatingUnreadCounts[team] = Number(count) || 0
       return participatingUnreadCounts[team]
     })
 }
@@ -49,12 +55,22 @@ export function getParticipatingUnreadCount(team: string) {
   return participatingUnreadCounts[team] ?? 0
 }
 
-export function markCommunityAsRead(team: string) {
-  return UnreadCount.runMethod
-    .submit({ method: 'mark_all_as_read_for_team', params: { team } })
-    .then((projects: string[]) => {
-      participatingUnreadCounts[team] = 0
-      return refreshUnreadCountForProjects(projects)
+/**
+ * Mark discussions in a community as read.
+ * @param before Optional `YYYY-MM-DD`; limits the action to discussions last active on or
+ *   before that day. Omit to mark every unread discussion read.
+ */
+export function markCommunityAsRead(team: string, before?: string) {
+  return markReadApi.runMethod
+    .submit({ method: 'mark_all_as_read_for_team', params: { team, before } })
+    .then(() => {
+      // Reload the full map rather than only the marked projects: the AppRail sums unread
+      // across every space it shows for a community, and that set can differ from the
+      // backend's accessible-project list. A targeted refresh would leave the unmarked
+      // spaces stale-high. A "before date" run may also leave newer discussions unread,
+      // so recompute rather than assuming zero. These two run on separate API instances,
+      // so concurrent refresh is safe.
+      return Promise.all([loadProjectUnreadCounts(), fetchParticipatingUnreadCount(team)])
     })
 }
 

--- a/frontend/src/data/unreadCount.ts
+++ b/frontend/src/data/unreadCount.ts
@@ -25,6 +25,14 @@ function loadProjectUnreadCounts(projects?: string[]) {
   return unreadCountApi.runMethod
     .submit({ method: 'get_unread_count', params: { projects } })
     .then((data: ProjectUnreadCount) => {
+      // A full reload (no project filter) is authoritative: the backend omits spaces whose
+      // count is now zero, so clear stale positives before applying the response — otherwise
+      // a space that just dropped to zero keeps showing a phantom unread count.
+      if (!projects) {
+        for (const spaceId of Object.keys(unreadCounts)) {
+          if (!(spaceId in data)) unreadCounts[spaceId] = 0
+        }
+      }
       for (const [spaceId, count] of Object.entries(data)) {
         // Counts cross the runMethod/JSON boundary as strings (MariaDB COUNT). Coerce to
         // Number here so summing them (e.g. per community) adds instead of concatenating.

--- a/frontend/src/pages/Discussions.vue
+++ b/frontend/src/pages/Discussions.vue
@@ -80,11 +80,42 @@
       />
     </KeepAlive>
   </div>
+
+  <Dialog v-model="showMarkAllAsReadDialog" title="Mark all as read">
+    <div class="space-y-3">
+      <p class="text-p-base text-ink-gray-7">
+        Mark discussions in {{ community?.title || 'this community' }} as read up to and including
+        the selected date. This cannot be undone.
+      </p>
+      <DatePicker
+        v-model="markReadBeforeDate"
+        :clearable="false"
+        placeholder="Select date"
+        format="D MMM, YYYY"
+      />
+    </div>
+    <template #actions>
+      <div class="flex justify-end">
+        <Button variant="solid" :loading="markingAllAsRead" @click="markAllAsRead">
+          Mark all as read
+        </Button>
+      </div>
+    </template>
+  </Dialog>
 </template>
 
 <script setup lang="ts">
 import { computed, ref, useTemplateRef, watch } from 'vue'
-import { Button, dialog, Dropdown, Select, TabButtons, usePageMeta } from 'frappe-ui'
+import {
+  Button,
+  DatePicker,
+  dayjsLocal,
+  Dialog,
+  Dropdown,
+  Select,
+  TabButtons,
+  usePageMeta,
+} from 'frappe-ui'
 import type { DropdownOptions, OrderBy } from 'frappe-ui'
 import { useRouter } from 'vue-router'
 import BottomSheet from '@/components/BottomSheet.vue'
@@ -120,6 +151,9 @@ const props = withDefaults(defineProps<Props>(), {
 const orderBy = ref<OrderBy>('last_post_at desc')
 const menuOpen = ref(false)
 const markingAllAsRead = ref(false)
+const showMarkAllAsReadDialog = ref(false)
+// Defaults to today so the action clears everything unless an earlier date is picked.
+const markReadBeforeDate = ref(dayjsLocal().format('YYYY-MM-DD'))
 const discussionListRef = useTemplateRef('discussionListRef')
 const router = useRouter()
 const sessionUser = useSessionUser()
@@ -186,9 +220,9 @@ const actionOptions = computed<DropdownOptions>(() => [
     condition: () => canManageCurrentCommunity.value,
   },
   {
-    label: 'Mark all as read',
+    label: 'Mark all as read...',
     icon: 'lucide-check',
-    onClick: confirmMarkAllAsRead,
+    onClick: openMarkAllAsReadDialog,
   },
 ])
 const canManageCurrentCommunity = computed(() => canManageCommunity(community.value, sessionUser))
@@ -238,25 +272,20 @@ function feedUnreadCount(feedType: string) {
   return 0
 }
 
-function confirmMarkAllAsRead() {
-  dialog.confirm({
-    title: 'Mark all as read',
-    message: `Are you sure you want to mark all discussions in ${
-      community.value?.title || 'this community'
-    } as read? This action cannot be undone.`,
-    confirmLabel: 'Mark all as read',
-    onConfirm: markAllAsRead,
-  })
+function openMarkAllAsReadDialog() {
+  markReadBeforeDate.value = dayjsLocal().format('YYYY-MM-DD')
+  showMarkAllAsReadDialog.value = true
 }
 
 async function markAllAsRead() {
   markingAllAsRead.value = true
   try {
-    await markCommunityAsRead(props.communityId)
+    await markCommunityAsRead(props.communityId, markReadBeforeDate.value)
     await Promise.all([
       discussionListRef.value?.discussions.reload(),
       discussionListRef.value?.pinnedDiscussions.reload(),
     ])
+    showMarkAllAsReadDialog.value = false
   } finally {
     markingAllAsRead.value = false
   }

--- a/frontend/src/pages/Discussions.vue
+++ b/frontend/src/pages/Discussions.vue
@@ -81,7 +81,7 @@
     </KeepAlive>
   </div>
 
-  <Dialog v-model="showMarkAllAsReadDialog" title="Mark all as read">
+  <Dialog v-model:open="showMarkAllAsReadDialog" title="Mark all as read">
     <div class="space-y-3">
       <p class="text-p-base text-ink-gray-7">
         Mark discussions in {{ community?.title || 'this community' }} as read up to and including

--- a/frontend/src/pages/Discussions.vue
+++ b/frontend/src/pages/Discussions.vue
@@ -90,6 +90,7 @@
       <DatePicker
         v-model="markReadBeforeDate"
         :clearable="false"
+        :max="today"
         placeholder="Select date"
         format="D MMM, YYYY"
       />
@@ -152,8 +153,11 @@ const orderBy = ref<OrderBy>('last_post_at desc')
 const menuOpen = ref(false)
 const markingAllAsRead = ref(false)
 const showMarkAllAsReadDialog = ref(false)
-// Defaults to today so the action clears everything unless an earlier date is picked.
-const markReadBeforeDate = ref(dayjsLocal().format('YYYY-MM-DD'))
+// Today is the latest allowed cutoff: a future date can't mark not-yet-posted discussions
+// read, and the backend clamps to it anyway. Defaults to today so the action clears
+// everything unless an earlier date is picked.
+const today = dayjsLocal().format('YYYY-MM-DD')
+const markReadBeforeDate = ref(today)
 const discussionListRef = useTemplateRef('discussionListRef')
 const router = useRouter()
 const sessionUser = useSessionUser()
@@ -273,7 +277,7 @@ function feedUnreadCount(feedType: string) {
 }
 
 function openMarkAllAsReadDialog() {
-  markReadBeforeDate.value = dayjsLocal().format('YYYY-MM-DD')
+  markReadBeforeDate.value = today
   showMarkAllAsReadDialog.value = true
 }
 

--- a/frontend/src/pages/Discussions.vue
+++ b/frontend/src/pages/Discussions.vue
@@ -155,9 +155,10 @@ const markingAllAsRead = ref(false)
 const showMarkAllAsReadDialog = ref(false)
 // Today is the latest allowed cutoff: a future date can't mark not-yet-posted discussions
 // read, and the backend clamps to it anyway. Defaults to today so the action clears
-// everything unless an earlier date is picked.
-const today = dayjsLocal().format('YYYY-MM-DD')
-const markReadBeforeDate = ref(today)
+// everything unless an earlier date is picked. Held in a ref and refreshed whenever the
+// dialog opens so a page left open past midnight still offers the real current day.
+const today = ref(dayjsLocal().format('YYYY-MM-DD'))
+const markReadBeforeDate = ref(today.value)
 const discussionListRef = useTemplateRef('discussionListRef')
 const router = useRouter()
 const sessionUser = useSessionUser()
@@ -277,7 +278,8 @@ function feedUnreadCount(feedType: string) {
 }
 
 function openMarkAllAsReadDialog() {
-  markReadBeforeDate.value = today
+  today.value = dayjsLocal().format('YYYY-MM-DD')
+  markReadBeforeDate.value = today.value
   showMarkAllAsReadDialog.value = true
 }
 

--- a/frontend/src/utils/formatters.ts
+++ b/frontend/src/utils/formatters.ts
@@ -32,10 +32,11 @@ export function formatUnreadCount(count: number): string {
 
 /**
  * Builds an accessible label that folds an unread count into a control's name,
- * e.g. ("Notifications", 3) -> "Notifications, 3 unread". Returns the bare label when there's
- * nothing unread so screen readers aren't told about an empty badge.
+ * e.g. ("Notifications", 3) -> "Notifications, 3 unread". Uses the exact count (never the
+ * capped "99+") so screen readers announce the real number. Returns the bare label when
+ * there's nothing unread so screen readers aren't told about an empty badge.
  */
 export function unreadAriaLabel(label: string, count: number): string {
   if (!count) return label
-  return `${label}, ${formatUnreadCount(count)} unread`
+  return `${label}, ${count} unread`
 }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2261,10 +2261,10 @@ framer-motion@^12.25.0:
     motion-utils "^12.39.0"
     tslib "^2.4.0"
 
-frappe-ui@1.0.0-beta.11:
-  version "1.0.0-beta.11"
-  resolved "https://registry.yarnpkg.com/frappe-ui/-/frappe-ui-1.0.0-beta.11.tgz#442b801bb756b8d53fa7d67c942eb33fdf238514"
-  integrity sha512-yUWvsfmIDTgyJP2XfYqYfwpwpFVivj8ZCrBXAt+BwfancSyLN+Db6QvAopHIdlKFYdmUsEsPZaFm1+CKi1/fSA==
+frappe-ui@1.0.0-beta.13:
+  version "1.0.0-beta.13"
+  resolved "https://registry.yarnpkg.com/frappe-ui/-/frappe-ui-1.0.0-beta.13.tgz#ec3a42c8a06cf715a90657074f9d107638526807"
+  integrity sha512-k7cRKR5grWD0ZOQpfBkkbZ05qqnGMvHsxGeKPdvvXraSfMTozfpCUJq57Detx5S2R21LUcSZ7l0BFx7bs1DWhA==
   dependencies:
     "@codemirror/lang-css" "^6.3.0"
     "@codemirror/lang-html" "^6.4.9"

--- a/gameplan/gameplan/doctype/gp_unread_record/api.py
+++ b/gameplan/gameplan/doctype/gp_unread_record/api.py
@@ -38,9 +38,13 @@ def mark_all_as_read_for_team(team=None, before=None):
 		return []
 
 	if before:
-		# Validate and clamp to today: a client must not push the read watermark into the
-		# future (which would mark not-yet-posted discussions read) or crash the endpoint
-		# on a malformed value.
-		before = str(min(frappe.utils.getdate(before), frappe.utils.getdate()))
+		# Reject a malformed cutoff with a controlled error instead of a 500, then clamp to
+		# today so a client can't push the read watermark into the future (which would mark
+		# not-yet-posted discussions read).
+		try:
+			before = frappe.utils.getdate(before)
+		except Exception:
+			frappe.throw(frappe._("Invalid date for 'before': {0}").format(before))
+		before = str(min(before, frappe.utils.getdate()))
 
 	return GPUnreadRecord.mark_all_as_read_for_team(team, frappe.session.user, before)

--- a/gameplan/gameplan/doctype/gp_unread_record/api.py
+++ b/gameplan/gameplan/doctype/gp_unread_record/api.py
@@ -37,4 +37,10 @@ def mark_all_as_read_for_team(team=None, before=None):
 	if not team:
 		return []
 
+	if before:
+		# Validate and clamp to today: a client must not push the read watermark into the
+		# future (which would mark not-yet-posted discussions read) or crash the endpoint
+		# on a malformed value.
+		before = str(min(frappe.utils.getdate(before), frappe.utils.getdate()))
+
 	return GPUnreadRecord.mark_all_as_read_for_team(team, frappe.session.user, before)

--- a/gameplan/gameplan/doctype/gp_unread_record/api.py
+++ b/gameplan/gameplan/doctype/gp_unread_record/api.py
@@ -26,10 +26,15 @@ def get_participating_unread_count(team=None):
 
 
 @frappe.whitelist(methods=["POST"])
-def mark_all_as_read_for_team(team=None):
+def mark_all_as_read_for_team(team=None, before=None):
+	"""Mark discussions in a team as read.
+
+	`before` (optional, YYYY-MM-DD) limits the action to discussions last active on or
+	before that day. When omitted, every unread discussion is marked read.
+	"""
 	from gameplan.gameplan.doctype.gp_unread_record.gp_unread_record import GPUnreadRecord
 
 	if not team:
 		return []
 
-	return GPUnreadRecord.mark_all_as_read_for_team(team, frappe.session.user)
+	return GPUnreadRecord.mark_all_as_read_for_team(team, frappe.session.user, before)

--- a/gameplan/gameplan/doctype/gp_unread_record/gp_unread_record.py
+++ b/gameplan/gameplan/doctype/gp_unread_record/gp_unread_record.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2025, Frappe Technologies Pvt Ltd and contributors
 # For license information, please see license.txt
 
+from datetime import timedelta
+
 import frappe
 from frappe.model.document import Document, bulk_insert
 
@@ -212,7 +214,11 @@ class GPUnreadRecord(Document):
 		# means unread). `cutoff` aligns the watermark with a "before date" action; without
 		# one we mark everything read up to now.
 		now = frappe.utils.now()
-		read_at = cutoff or now
+		# The unread query reads `last_post_at < cutoff`; the watermark check reads
+		# `last_post_at > mark_all_read_at`. Store the inclusive supremum (cutoff minus one
+		# microsecond) so both agree exactly — no post at the midnight boundary is read by
+		# one system and unread by the other.
+		read_at = str(frappe.utils.get_datetime(cutoff) - timedelta(microseconds=1)) if cutoff else now
 		existing_visits = GPUnreadRecord.get_project_visit_names(projects, user)
 
 		if existing_visits:

--- a/gameplan/gameplan/doctype/gp_unread_record/gp_unread_record.py
+++ b/gameplan/gameplan/doctype/gp_unread_record/gp_unread_record.py
@@ -165,23 +165,31 @@ class GPUnreadRecord(Document):
 		return query.run(as_dict=1)
 
 	@staticmethod
-	def mark_all_as_read_for_team(team, user):
+	def mark_all_as_read_for_team(team, user, before=None):
 		projects = GPUnreadRecord.get_accessible_project_names_for_team(team, user)
 		if not projects:
 			return []
 
-		UnreadRecord = frappe.qb.DocType("GP Unread Record")
-		(
-			frappe.qb.update(UnreadRecord)
-			.set(UnreadRecord.is_unread, 0)
-			.where(
-				(UnreadRecord.user == user)
-				& (UnreadRecord.project.isin(projects))
-				& (UnreadRecord.is_unread == 1)
-			)
-		).run()
+		# `before` (a date) marks only discussions last active up to and including that
+		# day; `cutoff` is the exclusive upper bound (start of the next day).
+		cutoff = frappe.utils.add_days(before, 1) if before else None
 
-		GPUnreadRecord.update_project_visits_for_mark_all_read(projects, user)
+		UnreadRecord = frappe.qb.DocType("GP Unread Record")
+		condition = (
+			(UnreadRecord.user == user)
+			& (UnreadRecord.project.isin(projects))
+			& (UnreadRecord.is_unread == 1)
+		)
+		if cutoff:
+			Discussion = frappe.qb.DocType("GP Discussion")
+			discussions_within_cutoff = (
+				frappe.qb.from_(Discussion).select(Discussion.name).where(Discussion.last_post_at < cutoff)
+			)
+			condition &= UnreadRecord.discussion.isin(discussions_within_cutoff)
+
+		(frappe.qb.update(UnreadRecord).set(UnreadRecord.is_unread, 0).where(condition)).run()
+
+		GPUnreadRecord.update_project_visits_for_mark_all_read(projects, user, cutoff)
 		return projects
 
 	@staticmethod
@@ -198,18 +206,23 @@ class GPUnreadRecord(Document):
 		return [str(row.name) for row in query.run(as_dict=True)]
 
 	@staticmethod
-	def update_project_visits_for_mark_all_read(projects: list[str], user):
+	def update_project_visits_for_mark_all_read(projects: list[str], user, cutoff=None):
+		# `last_visit` reflects that the user acted now (it orders recent spaces), while the
+		# read watermark drives the per-discussion read indicator (last_post_at > watermark
+		# means unread). `cutoff` aligns the watermark with a "before date" action; without
+		# one we mark everything read up to now.
 		now = frappe.utils.now()
+		read_at = cutoff or now
 		existing_visits = GPUnreadRecord.get_project_visit_names(projects, user)
 
 		if existing_visits:
-			GPUnreadRecord.update_existing_project_visits(list(existing_visits.values()), now)
+			GPUnreadRecord.update_existing_project_visits(list(existing_visits.values()), now, read_at)
 
 		missing_projects = [project for project in projects if project not in existing_visits]
 		if missing_projects:
 			# Project access is already scoped by get_accessible_project_names_for_team;
 			# these visit rows are system-managed on behalf of the authenticated user.
-			GPUnreadRecord.create_project_visits(missing_projects, user, now)
+			GPUnreadRecord.create_project_visits(missing_projects, user, now, read_at)
 
 	@staticmethod
 	def get_project_visit_names(projects: list[str], user):
@@ -226,17 +239,28 @@ class GPUnreadRecord(Document):
 		}
 
 	@staticmethod
-	def update_existing_project_visits(project_visit_names: list[str], timestamp):
+	def update_existing_project_visits(project_visit_names: list[str], last_visit, mark_all_read_at):
+		from frappe.query_builder import CustomFunction
+		from frappe.query_builder.functions import Coalesce
+
+		greatest = CustomFunction("GREATEST", ["a", "b"])
+
 		ProjectVisit = frappe.qb.DocType("GP Project Visit")
 		(
 			frappe.qb.update(ProjectVisit)
-			.set(ProjectVisit.last_visit, timestamp)
-			.set(ProjectVisit.mark_all_read_at, timestamp)
+			.set(ProjectVisit.last_visit, last_visit)
+			# Only ever move the watermark forward. A "before date" run computes an earlier
+			# `mark_all_read_at`; without this guard it would rewind an existing, newer
+			# watermark and resurface already-read discussions as unread.
+			.set(
+				ProjectVisit.mark_all_read_at,
+				greatest(Coalesce(ProjectVisit.mark_all_read_at, mark_all_read_at), mark_all_read_at),
+			)
 			.where(ProjectVisit.name.isin(project_visit_names))
 		).run()
 
 	@staticmethod
-	def create_project_visits(projects: list[str], user, timestamp):
+	def create_project_visits(projects: list[str], user, last_visit, mark_all_read_at):
 		visits = []
 		for project in projects:
 			visit = frappe.get_doc(
@@ -245,8 +269,8 @@ class GPUnreadRecord(Document):
 					"name": frappe.generate_hash(length=10),
 					"user": user,
 					"project": project,
-					"last_visit": timestamp,
-					"mark_all_read_at": timestamp,
+					"last_visit": last_visit,
+					"mark_all_read_at": mark_all_read_at,
 				}
 			)
 			visits.append(visit)

--- a/gameplan/gameplan/doctype/gp_unread_record/test_gp_unread_record.py
+++ b/gameplan/gameplan/doctype/gp_unread_record/test_gp_unread_record.py
@@ -221,6 +221,18 @@ class IntegrationTestGPUnreadRecord(IntegrationTestCase):
 			frappe.utils.get_datetime(frappe.utils.add_days(frappe.utils.nowdate(), 2)),
 		)
 
+	def test_mark_all_as_read_for_team_rejects_malformed_before(self):
+		# A malformed cutoff returns a controlled validation error, not a raw 500.
+		from gameplan.gameplan.doctype.gp_unread_record.api import mark_all_as_read_for_team
+
+		suffix = frappe.generate_hash(length=8)
+		user = create_member(f"team-bad-date-member-{suffix}@example.com", "Team Bad Date Member")
+		team = create_team(f"Team Bad Date Source {suffix}")
+
+		frappe.set_user(user.name)
+		with self.assertRaises(frappe.exceptions.ValidationError):
+			mark_all_as_read_for_team(team=team.name, before="not-a-date")
+
 	def tearDown(self):
 		frappe.set_user("Administrator")
 		super().tearDown()

--- a/gameplan/gameplan/doctype/gp_unread_record/test_gp_unread_record.py
+++ b/gameplan/gameplan/doctype/gp_unread_record/test_gp_unread_record.py
@@ -71,9 +71,135 @@ class IntegrationTestGPUnreadRecord(IntegrationTestCase):
 			old_timestamp,
 		)
 
+	def test_mark_all_as_read_for_team_with_before_marks_only_older_discussions(self):
+		suffix = frappe.generate_hash(length=8)
+		user = create_member(f"team-before-member-{suffix}@example.com", "Team Before Member")
+		team = create_team(f"Team Before Source {suffix}")
+		project = create_project(f"Team Before Source Space {suffix}", team.name)
+
+		old_discussion = create_discussion(f"Team Before Old Discussion {suffix}", project.name)
+		new_discussion = create_discussion(f"Team Before New Discussion {suffix}", project.name)
+		set_last_post_at(old_discussion.name, "2026-01-10 09:00:00")
+		set_last_post_at(new_discussion.name, "2026-01-20 09:00:00")
+
+		old_unread_record = create_unread_record(user.name, old_discussion.name, project.name)
+		new_unread_record = create_unread_record(user.name, new_discussion.name, project.name)
+
+		frappe.set_user(user.name)
+		projects = GPUnreadRecord.mark_all_as_read_for_team(team.name, user.name, before="2026-01-15")
+
+		self.assertIn(str(project.name), projects)
+		self.assertEqual(frappe.db.get_value("GP Unread Record", old_unread_record, "is_unread"), 0)
+		self.assertEqual(frappe.db.get_value("GP Unread Record", new_unread_record, "is_unread"), 1)
+
+	def test_mark_all_as_read_for_team_before_is_inclusive_of_that_whole_day(self):
+		suffix = frappe.generate_hash(length=8)
+		user = create_member(f"team-boundary-member-{suffix}@example.com", "Team Boundary Member")
+		team = create_team(f"Team Boundary Source {suffix}")
+		project = create_project(f"Team Boundary Source Space {suffix}", team.name)
+
+		# `before` is 2026-01-15: a discussion late on that day is included (inclusive),
+		# one early on the next day is excluded.
+		on_day_discussion = create_discussion(f"Team Boundary On Day {suffix}", project.name)
+		next_day_discussion = create_discussion(f"Team Boundary Next Day {suffix}", project.name)
+		set_last_post_at(on_day_discussion.name, "2026-01-15 23:59:59")
+		set_last_post_at(next_day_discussion.name, "2026-01-16 00:00:01")
+
+		on_day_unread_record = create_unread_record(user.name, on_day_discussion.name, project.name)
+		next_day_unread_record = create_unread_record(user.name, next_day_discussion.name, project.name)
+
+		frappe.set_user(user.name)
+		GPUnreadRecord.mark_all_as_read_for_team(team.name, user.name, before="2026-01-15")
+
+		self.assertEqual(frappe.db.get_value("GP Unread Record", on_day_unread_record, "is_unread"), 0)
+		self.assertEqual(frappe.db.get_value("GP Unread Record", next_day_unread_record, "is_unread"), 1)
+
+	def test_mark_all_as_read_for_team_with_before_sets_watermark_to_cutoff(self):
+		suffix = frappe.generate_hash(length=8)
+		user = create_member(f"team-watermark-member-{suffix}@example.com", "Team Watermark Member")
+		team = create_team(f"Team Watermark Source {suffix}")
+		project = create_project(f"Team Watermark Source Space {suffix}", team.name)
+		discussion = create_discussion(f"Team Watermark Discussion {suffix}", project.name)
+		set_last_post_at(discussion.name, "2026-01-10 09:00:00")
+		create_unread_record(user.name, discussion.name, project.name)
+
+		before = "2026-01-15"
+		cutoff = frappe.utils.add_days(before, 1)
+		before_action = frappe.utils.get_datetime(frappe.utils.now())
+
+		frappe.set_user(user.name)
+		GPUnreadRecord.mark_all_as_read_for_team(team.name, user.name, before=before)
+
+		visit = frappe.db.get_value(
+			"GP Project Visit",
+			{"user": user.name, "project": project.name},
+			["last_visit", "mark_all_read_at"],
+			as_dict=True,
+		)
+		self.assertIsNotNone(visit)
+		# Watermark aligns with the cutoff (everything up to `before` reads as read).
+		self.assertEqual(frappe.utils.get_datetime(visit.mark_all_read_at), frappe.utils.get_datetime(cutoff))
+		# `last_visit` reflects the action time (~now), not the cutoff date in the past.
+		self.assertGreaterEqual(frappe.utils.get_datetime(visit.last_visit), before_action)
+
+	def test_mark_all_as_read_for_team_without_before_sets_watermark_to_now(self):
+		suffix = frappe.generate_hash(length=8)
+		user = create_member(f"team-now-member-{suffix}@example.com", "Team Now Member")
+		team = create_team(f"Team Now Source {suffix}")
+		project = create_project(f"Team Now Source Space {suffix}", team.name)
+		discussion = create_discussion(f"Team Now Discussion {suffix}", project.name)
+		create_unread_record(user.name, discussion.name, project.name)
+
+		before_action = frappe.utils.get_datetime(frappe.utils.now())
+
+		frappe.set_user(user.name)
+		GPUnreadRecord.mark_all_as_read_for_team(team.name, user.name)
+
+		visit = frappe.db.get_value(
+			"GP Project Visit",
+			{"user": user.name, "project": project.name},
+			["last_visit", "mark_all_read_at"],
+			as_dict=True,
+		)
+		self.assertIsNotNone(visit)
+		# Without a `before` date everything is marked read up to now.
+		self.assertGreaterEqual(frappe.utils.get_datetime(visit.mark_all_read_at), before_action)
+		self.assertGreaterEqual(frappe.utils.get_datetime(visit.last_visit), before_action)
+
+	def test_mark_all_as_read_for_team_with_before_never_rewinds_a_newer_watermark(self):
+		suffix = frappe.generate_hash(length=8)
+		user = create_member(f"team-rewind-member-{suffix}@example.com", "Team Rewind Member")
+		team = create_team(f"Team Rewind Source {suffix}")
+		project = create_project(f"Team Rewind Source Space {suffix}", team.name)
+		discussion = create_discussion(f"Team Rewind Discussion {suffix}", project.name)
+		set_last_post_at(discussion.name, "2026-01-10 09:00:00")
+		create_unread_record(user.name, discussion.name, project.name)
+
+		frappe.set_user(user.name)
+		# First mark everything read up to now: the watermark advances to "today".
+		GPUnreadRecord.mark_all_as_read_for_team(team.name, user.name)
+		newer_watermark = frappe.db.get_value(
+			"GP Project Visit", {"user": user.name, "project": project.name}, "mark_all_read_at"
+		)
+
+		# Then mark "before" an OLDER date. The earlier cutoff must not rewind the watermark,
+		# which would resurface discussions read between that date and now.
+		GPUnreadRecord.mark_all_as_read_for_team(team.name, user.name, before="2026-01-15")
+
+		watermark = frappe.db.get_value(
+			"GP Project Visit", {"user": user.name, "project": project.name}, "mark_all_read_at"
+		)
+		self.assertEqual(frappe.utils.get_datetime(watermark), frappe.utils.get_datetime(newer_watermark))
+
 	def tearDown(self):
 		frappe.set_user("Administrator")
 		super().tearDown()
+
+
+def set_last_post_at(discussion: str, last_post_at: str):
+	# `last_post_at` is auto-set to now() in GP Discussion.before_insert, so override it
+	# directly to pin a specific activity time without bumping `modified`.
+	frappe.db.set_value("GP Discussion", discussion, "last_post_at", last_post_at, update_modified=False)
 
 
 def create_unread_record(user: str, discussion: str, project: str):

--- a/gameplan/gameplan/doctype/gp_unread_record/test_gp_unread_record.py
+++ b/gameplan/gameplan/doctype/gp_unread_record/test_gp_unread_record.py
@@ -137,8 +137,12 @@ class IntegrationTestGPUnreadRecord(IntegrationTestCase):
 			as_dict=True,
 		)
 		self.assertIsNotNone(visit)
-		# Watermark aligns with the cutoff (everything up to `before` reads as read).
-		self.assertEqual(frappe.utils.get_datetime(visit.mark_all_read_at), frappe.utils.get_datetime(cutoff))
+		# Watermark is the inclusive end of the `before` day: within that day and strictly
+		# below the exclusive cutoff, so the `> watermark` read check matches the `< cutoff`
+		# unread query exactly (no midnight-boundary skew).
+		watermark = frappe.utils.get_datetime(visit.mark_all_read_at)
+		self.assertGreaterEqual(watermark, frappe.utils.get_datetime(before))
+		self.assertLess(watermark, frappe.utils.get_datetime(cutoff))
 		# `last_visit` reflects the action time (~now), not the cutoff date in the past.
 		self.assertGreaterEqual(frappe.utils.get_datetime(visit.last_visit), before_action)
 
@@ -190,6 +194,32 @@ class IntegrationTestGPUnreadRecord(IntegrationTestCase):
 			"GP Project Visit", {"user": user.name, "project": project.name}, "mark_all_read_at"
 		)
 		self.assertEqual(frappe.utils.get_datetime(watermark), frappe.utils.get_datetime(newer_watermark))
+
+	def test_mark_all_as_read_for_team_clamps_future_before_to_today(self):
+		# The whitelisted endpoint clamps `before` so a client can't push the watermark into
+		# the future (which would mark not-yet-posted discussions read).
+		from gameplan.gameplan.doctype.gp_unread_record.api import mark_all_as_read_for_team
+
+		suffix = frappe.generate_hash(length=8)
+		user = create_member(f"team-clamp-member-{suffix}@example.com", "Team Clamp Member")
+		team = create_team(f"Team Clamp Source {suffix}")
+		project = create_project(f"Team Clamp Source Space {suffix}", team.name)
+		discussion = create_discussion(f"Team Clamp Discussion {suffix}", project.name)
+		record = create_unread_record(user.name, discussion.name, project.name)
+
+		frappe.set_user(user.name)
+		mark_all_as_read_for_team(team=team.name, before="2099-01-01")
+
+		# Clamped to today, so today's discussion is read...
+		self.assertEqual(frappe.db.get_value("GP Unread Record", record, "is_unread"), 0)
+		# ...and the watermark stays near today rather than jumping to the far-future cutoff.
+		watermark = frappe.db.get_value(
+			"GP Project Visit", {"user": user.name, "project": project.name}, "mark_all_read_at"
+		)
+		self.assertLess(
+			frappe.utils.get_datetime(watermark),
+			frappe.utils.get_datetime(frappe.utils.add_days(frappe.utils.nowdate(), 2)),
+		)
 
 	def tearDown(self):
 		frappe.set_user("Administrator")


### PR DESCRIPTION
## What

Adds a date option to the community **Mark all as read** action, and fixes several unread-count bugs surfaced while building it.

### Mark all as read — before a date
- The community **Mark all as read** menu item now opens a dialog with a date picker. You can mark a community read **up to and including a chosen day** (defaults to today, so the default still clears everything).
- Backend (`mark_all_as_read_for_team(team, user, before=None)`): with a `before` date, only discussions whose `last_post_at` falls within the cutoff (`add_days(before, 1)`) are marked read; newer discussions stay unread. The `GP Project Visit` read watermark advances to the cutoff so the per-discussion indicator stays consistent.
- The watermark only ever moves **forward** (GREATEST guard): a "before date" run can't rewind a newer watermark and resurface already-read discussions. `last_visit` stays at *now* (it orders recent spaces) and is never moved back to a past cutoff.

### Unread-count fixes (AppRail)
- Tooltip/aria show the exact count instead of the capped `99+`.
- Coerce counts to `Number` at the data boundary — MariaDB `COUNT` crosses the runMethod/JSON boundary as strings, so per-community sums concatenated (e.g. `"016101…"`) instead of adding.
- Give each unread endpoint its own `useDoctype` instance. They shared one `runMethod` (a single `useCall`), so concurrent calls raced on shared request state and cross-resolved, inflating the count right after marking read.
- After a community mark, reload the **full** unread map rather than only the marked projects, since the AppRail sums a space set that can differ from the backend's accessible-project list.

## Dependency
Requires **`frappe-ui@1.0.0-beta.13`** (the new month-year split-view DatePicker used by the dialog). Bumped here in `frontend/package.json`; published from frappe/frappe-ui#798.

## Tests
Adds `test_gp_unread_record.py` coverage for the `before` behavior: older discussions read / newer stay unread, the inclusive day boundary (`23:59:59` in, next-day `00:00:01` out), and watermark/`last_visit` semantics.

## How to test
1. Open a community → **⋯** → **Mark all as read** → pick an earlier date → confirm.
2. Discussions on/before that day clear; newer ones stay unread; the AppRail badge reflects the exact remaining count.