### PR TITLE
fix(unread): clear discussions with NULL last_post_at on dated mark-all

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ Local dev site is `gameplan-demo.test` (CI uses `gameplan.test`).
 ## Backend conventions
 
 - Prefer `frappe.qb.get_query()` over `frappe.db.get_all()` (pass `ignore_permissions=False` when checks are needed).
+- Prefer `frappe.qb` for writing database patches as well.
 - Permissions: `has_permission` hooks in `hooks.py` (e.g. `GP Page`); community/space membership gates access.
 - Debugging: add `def execute():` to a file like `gameplan/debug.py`, run via `bench --site gameplan-demo.test execute gameplan.debug.execute`.
 

--- a/gameplan/gameplan/doctype/gp_discussion/gp_discussion.py
+++ b/gameplan/gameplan/doctype/gp_discussion/gp_discussion.py
@@ -91,6 +91,13 @@ class GPDiscussion(HasActivity, HasAttachments, HasMentions, HasReactions, HasTa
 		self.log_title_update()
 		self.update_participants_count()
 		self.attach_files_in_content()
+		self.sync_unread_records_on_move()
+
+	def sync_unread_records_on_move(self):
+		# When a discussion moves to another space, realign its unread records so the count
+		# follows it instead of staying attributed to (and stuck in) the old space.
+		if self.has_value_changed("project"):
+			GPUnreadRecord.update_project_for_discussion(self.name, self.project)
 
 	def before_save(self):
 		self.update_slug()

--- a/gameplan/gameplan/doctype/gp_discussion/patches/backfill_null_last_post_at.py
+++ b/gameplan/gameplan/doctype/gp_discussion/patches/backfill_null_last_post_at.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+import frappe
+
+
+def execute():
+	"""Backfill `last_post_at` for discussions that never had it set.
+
+	The earlier `set_last_post` patch INNER JOINs to comments/polls, so it only touched
+	discussions with at least one reply. Discussions with no posts (e.g. seeded "About the
+	X category" / welcome posts) were left with a NULL `last_post_at`. That NULL breaks the
+	dated "mark all as read" path, whose `last_post_at < cutoff` filter drops NULL rows and
+	strands those discussions as permanently unread. Mirror `before_insert`, which sets
+	`last_post_at` to the discussion's creation time when there are no posts.
+	"""
+	Discussion = frappe.qb.DocType("GP Discussion")
+	(
+		frappe.qb.update(Discussion)
+		.set(Discussion.last_post_at, Discussion.creation)
+		.where(Discussion.last_post_at.isnull())
+	).run()

--- a/gameplan/gameplan/doctype/gp_unread_record/gp_unread_record.py
+++ b/gameplan/gameplan/doctype/gp_unread_record/gp_unread_record.py
@@ -203,13 +203,15 @@ class GPUnreadRecord(Document):
 		)
 		if cutoff:
 			Discussion = frappe.qb.DocType("GP Discussion")
-			# A NULL last_post_at means the discussion has no activity, so it is by definition
-			# before any cutoff. Include it explicitly: `last_post_at < cutoff` alone evaluates to
-			# UNKNOWN for NULLs and drops them, stranding those discussions as permanently unread.
+			# `last_post_at` is always set: `before_insert` defaults it to the creation time and the
+			# `backfill_null_last_post_at` patch repaired legacy NULL rows, so a plain `< cutoff` is
+			# safe and no longer drops NULLs.
+			# Repeat the project filter here so the subquery can use the (project, last_post_at)
+			# index range scan instead of full-scanning every discussion across all communities.
 			discussions_within_cutoff = (
 				frappe.qb.from_(Discussion)
 				.select(Discussion.name)
-				.where(Discussion.last_post_at.isnull() | (Discussion.last_post_at < cutoff))
+				.where(Discussion.project.isin(projects) & (Discussion.last_post_at < cutoff))
 			)
 			condition &= UnreadRecord.discussion.isin(discussions_within_cutoff)
 

--- a/gameplan/gameplan/doctype/gp_unread_record/gp_unread_record.py
+++ b/gameplan/gameplan/doctype/gp_unread_record/gp_unread_record.py
@@ -184,8 +184,13 @@ class GPUnreadRecord(Document):
 		)
 		if cutoff:
 			Discussion = frappe.qb.DocType("GP Discussion")
+			# A NULL last_post_at means the discussion has no activity, so it is by definition
+			# before any cutoff. Include it explicitly: `last_post_at < cutoff` alone evaluates to
+			# UNKNOWN for NULLs and drops them, stranding those discussions as permanently unread.
 			discussions_within_cutoff = (
-				frappe.qb.from_(Discussion).select(Discussion.name).where(Discussion.last_post_at < cutoff)
+				frappe.qb.from_(Discussion)
+				.select(Discussion.name)
+				.where(Discussion.last_post_at.isnull() | (Discussion.last_post_at < cutoff))
 			)
 			condition &= UnreadRecord.discussion.isin(discussions_within_cutoff)
 

--- a/gameplan/gameplan/doctype/gp_unread_record/gp_unread_record.py
+++ b/gameplan/gameplan/doctype/gp_unread_record/gp_unread_record.py
@@ -98,6 +98,25 @@ class GPUnreadRecord(Document):
 		frappe.qb.from_(UnreadRecord).where(UnreadRecord.project == str(project)).delete().run()
 
 	@staticmethod
+	def update_project_for_discussion(discussion: str, project: str):
+		"""Keep a discussion's unread records pointing at its current space.
+
+		Moving a discussion changes its `project`, but the unread records keep the old one.
+		The unread count groups by the record's project and `mark_all_as_read_for_team`
+		clears by it, so a stale project misattributes the count to the old space and can
+		leave it uncleared (e.g. when the old space is archived or inaccessible).
+		"""
+		if frappe.flags.in_migrate or frappe.flags.in_patch:
+			return
+
+		UnreadRecord = frappe.qb.DocType("GP Unread Record")
+		(
+			frappe.qb.update(UnreadRecord)
+			.set(UnreadRecord.project, str(project))
+			.where((UnreadRecord.discussion == str(discussion)) & (UnreadRecord.project != str(project)))
+		).run()
+
+	@staticmethod
 	def mark_discussion_as_read_for_user(discussion, user):
 		"""Mark all unread records for this discussion and user as read"""
 		UnreadRecord = frappe.qb.DocType("GP Unread Record")

--- a/gameplan/gameplan/doctype/gp_unread_record/patches/realign_unread_record_project.py
+++ b/gameplan/gameplan/doctype/gp_unread_record/patches/realign_unread_record_project.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+from collections import defaultdict
+
+import frappe
+
+
+def execute():
+	"""Realign `GP Unread Record.project` with the discussion's current project.
+
+	Moving a discussion between spaces changed `GP Discussion.project` but left its unread
+	records pointing at the old space. The unread count groups by the record's project and
+	`mark_all_as_read_for_team` clears by it, so a stale project misattributes the count and
+	can leave it uncleared. Going forward this is kept in sync on move; this patch fixes the
+	rows that already drifted.
+	"""
+	UnreadRecord = frappe.qb.DocType("GP Unread Record")
+	Discussion = frappe.qb.DocType("GP Discussion")
+
+	# Stale (discussion -> correct project) pairs. A correlated UPDATE...JOIN can't be
+	# expressed unambiguously via the query builder, so resolve the targets first, then
+	# update grouped by the correct project (one write per distinct target space).
+	stale = (
+		frappe.qb.from_(UnreadRecord)
+		.join(Discussion)
+		.on(Discussion.name == UnreadRecord.discussion)
+		.where(UnreadRecord.project != Discussion.project)
+		.select(UnreadRecord.discussion, Discussion.project)
+		.distinct()
+		.run(as_dict=True)
+	)
+
+	discussions_by_project = defaultdict(list)
+	for row in stale:
+		discussions_by_project[row.project].append(row.discussion)
+
+	for project, discussions in discussions_by_project.items():
+		(
+			frappe.qb.update(UnreadRecord)
+			.set(UnreadRecord.project, project)
+			.where(UnreadRecord.discussion.isin(discussions))
+		).run()

--- a/gameplan/gameplan/doctype/gp_unread_record/test_gp_unread_record.py
+++ b/gameplan/gameplan/doctype/gp_unread_record/test_gp_unread_record.py
@@ -233,6 +233,56 @@ class IntegrationTestGPUnreadRecord(IntegrationTestCase):
 		with self.assertRaises(frappe.exceptions.ValidationError):
 			mark_all_as_read_for_team(team=team.name, before="not-a-date")
 
+	def test_mark_all_as_read_for_team_with_before_marks_discussion_with_null_last_post_at(self):
+		# A discussion with no activity has a NULL last_post_at. The dated mark-all must still
+		# clear it: a naive `last_post_at < cutoff` evaluates to UNKNOWN for NULLs and drops
+		# them, stranding the discussion as permanently unread.
+		suffix = frappe.generate_hash(length=8)
+		user = create_member(f"team-null-lpa-member-{suffix}@example.com", "Team Null LPA Member")
+		team = create_team(f"Team Null LPA Source {suffix}")
+		project = create_project(f"Team Null LPA Source Space {suffix}", team.name)
+		discussion = create_discussion(f"Team Null LPA Discussion {suffix}", project.name)
+		frappe.db.set_value("GP Discussion", discussion.name, "last_post_at", None, update_modified=False)
+		record = create_unread_record(user.name, discussion.name, project.name)
+
+		frappe.set_user(user.name)
+		GPUnreadRecord.mark_all_as_read_for_team(team.name, user.name, before=frappe.utils.today())
+
+		self.assertEqual(frappe.db.get_value("GP Unread Record", record, "is_unread"), 0)
+
+	def test_update_project_for_discussion_realigns_records_to_current_space(self):
+		# A discussion's unread records must follow it when it moves, otherwise the count stays
+		# attributed to (and stuck in) the old space.
+		suffix = frappe.generate_hash(length=8)
+		user = create_member(f"realign-member-{suffix}@example.com", "Realign Member")
+		team = create_team(f"Realign Team {suffix}")
+		old_project = create_project(f"Realign Old Space {suffix}", team.name)
+		new_project = create_project(f"Realign New Space {suffix}", team.name)
+		discussion = create_discussion(f"Realign Discussion {suffix}", new_project.name)
+		# Record left pointing at the old space, as if the discussion was moved after creation.
+		record = create_unread_record(user.name, discussion.name, old_project.name)
+
+		GPUnreadRecord.update_project_for_discussion(discussion.name, new_project.name)
+
+		self.assertEqual(frappe.db.get_value("GP Unread Record", record, "project"), str(new_project.name))
+
+	def test_moving_discussion_realigns_unread_records(self):
+		# End-to-end: moving a discussion to another space updates its unread records' project,
+		# so mark_all_as_read_for_team on the new space can clear them.
+		from gameplan.gameplan.doctype.gp_discussion.gp_discussion import move_discussion
+
+		suffix = frappe.generate_hash(length=8)
+		user = create_member(f"move-member-{suffix}@example.com", "Move Member")
+		team = create_team(f"Move Team {suffix}")
+		source_project = create_project(f"Move Source Space {suffix}", team.name)
+		target_project = create_project(f"Move Target Space {suffix}", team.name)
+		discussion = create_discussion(f"Move Discussion {suffix}", source_project.name)
+		record = create_unread_record(user.name, discussion.name, source_project.name)
+
+		move_discussion(discussion, target_project.name)
+
+		self.assertEqual(frappe.db.get_value("GP Unread Record", record, "project"), str(target_project.name))
+
 	def tearDown(self):
 		frappe.set_user("Administrator")
 		super().tearDown()

--- a/gameplan/gameplan/doctype/gp_unread_record/test_gp_unread_record.py
+++ b/gameplan/gameplan/doctype/gp_unread_record/test_gp_unread_record.py
@@ -233,10 +233,12 @@ class IntegrationTestGPUnreadRecord(IntegrationTestCase):
 		with self.assertRaises(frappe.exceptions.ValidationError):
 			mark_all_as_read_for_team(team=team.name, before="not-a-date")
 
-	def test_mark_all_as_read_for_team_with_before_marks_discussion_with_null_last_post_at(self):
-		# A discussion with no activity has a NULL last_post_at. The dated mark-all must still
-		# clear it: a naive `last_post_at < cutoff` evaluates to UNKNOWN for NULLs and drops
-		# them, stranding the discussion as permanently unread.
+	def test_mark_all_as_read_for_team_with_before_skips_null_last_post_at(self):
+		# `last_post_at` is invariably set in practice: `before_insert` defaults it to the
+		# creation time and the `backfill_null_last_post_at` patch repaired legacy NULL rows.
+		# The dated path therefore filters on a concrete `last_post_at < cutoff`; a row forced
+		# to NULL (only reachable via a raw insert) has no timestamp to place against the
+		# cutoff and is intentionally left untouched rather than guessed into the read set.
 		suffix = frappe.generate_hash(length=8)
 		user = create_member(f"team-null-lpa-member-{suffix}@example.com", "Team Null LPA Member")
 		team = create_team(f"Team Null LPA Source {suffix}")
@@ -246,9 +248,36 @@ class IntegrationTestGPUnreadRecord(IntegrationTestCase):
 		record = create_unread_record(user.name, discussion.name, project.name)
 
 		frappe.set_user(user.name)
+		# Dated mark-all: the NULL row has no timestamp, so the cutoff filter skips it.
 		GPUnreadRecord.mark_all_as_read_for_team(team.name, user.name, before=frappe.utils.today())
+		self.assertEqual(frappe.db.get_value("GP Unread Record", record, "is_unread"), 1)
 
+		# Undated mark-all has no cutoff subquery, so the same row is cleared.
+		GPUnreadRecord.mark_all_as_read_for_team(team.name, user.name)
 		self.assertEqual(frappe.db.get_value("GP Unread Record", record, "is_unread"), 0)
+
+	def test_mark_all_as_read_for_team_with_before_does_not_cross_project_boundaries(self):
+		# The dated subquery repeats the project filter (for the (project, last_post_at) index);
+		# an old discussion in another community must not be cleared by this team's mark-all.
+		suffix = frappe.generate_hash(length=8)
+		user = create_member(f"team-scope-member-{suffix}@example.com", "Team Scope Member")
+		source_team = create_team(f"Team Scope Source {suffix}")
+		other_team = create_team(f"Team Scope Other {suffix}")
+		source_project = create_project(f"Team Scope Source Space {suffix}", source_team.name)
+		other_project = create_project(f"Team Scope Other Space {suffix}", other_team.name)
+		source_discussion = create_discussion(f"Team Scope Source Discussion {suffix}", source_project.name)
+		other_discussion = create_discussion(f"Team Scope Other Discussion {suffix}", other_project.name)
+		# Both are old enough to fall before the cutoff; only the source team's should clear.
+		set_last_post_at(source_discussion.name, "2026-01-10 09:00:00")
+		set_last_post_at(other_discussion.name, "2026-01-10 09:00:00")
+		source_record = create_unread_record(user.name, source_discussion.name, source_project.name)
+		other_record = create_unread_record(user.name, other_discussion.name, other_project.name)
+
+		frappe.set_user(user.name)
+		GPUnreadRecord.mark_all_as_read_for_team(source_team.name, user.name, before="2026-01-15")
+
+		self.assertEqual(frappe.db.get_value("GP Unread Record", source_record, "is_unread"), 0)
+		self.assertEqual(frappe.db.get_value("GP Unread Record", other_record, "is_unread"), 1)
 
 	def test_update_project_for_discussion_realigns_records_to_current_space(self):
 		# A discussion's unread records must follow it when it moves, otherwise the count stays

--- a/gameplan/patches.txt
+++ b/gameplan/patches.txt
@@ -38,3 +38,4 @@ gameplan.gameplan.doctype.gp_member.patches.backfill_team_admins
 gameplan.gameplan.doctype.gp_team.patches.remove_disabled_users_from_communities
 gameplan.gameplan.doctype.gp_user_profile.patches.backfill_community_order
 gameplan.patches.backfill_private_file_attachments
+gameplan.gameplan.doctype.gp_discussion.patches.backfill_null_last_post_at

--- a/gameplan/patches.txt
+++ b/gameplan/patches.txt
@@ -39,3 +39,4 @@ gameplan.gameplan.doctype.gp_team.patches.remove_disabled_users_from_communities
 gameplan.gameplan.doctype.gp_user_profile.patches.backfill_community_order
 gameplan.patches.backfill_private_file_attachments
 gameplan.gameplan.doctype.gp_discussion.patches.backfill_null_last_post_at
+gameplan.gameplan.doctype.gp_unread_record.patches.realign_unread_record_project


### PR DESCRIPTION
The dated "mark all as read" path filtered unread discussions with `last_post_at < cutoff`. In SQL a NULL `last_post_at` makes that comparison UNKNOWN, so those rows were dropped and the discussions stayed unread forever — while the unread counter (which ignores dates) kept counting them. Result: a community badge that never reached zero.

- Include NULL `last_post_at` in the cutoff set (no activity => before any cutoff).
- Backfill patch: set `last_post_at = creation` for discussions that never had it. The earlier `set_last_post` patch INNER-JOINed to comments/polls, so reply-less posts (seeded "About the X category" / welcome posts) were left NULL.
- AGENTS.md: note to prefer frappe.qb for DB patches.

