### PR TITLE
fix: aborted reaction requests + sidebar scrollbar blocking buttons

### DIFF
--- a/frontend/src/components/ScrollBar.vue
+++ b/frontend/src/components/ScrollBar.vue
@@ -1,11 +1,11 @@
 <template>
   <ScrollAreaScrollbar
-    class="flex select-none touch-none p-0.5 z-20 bg-transparent transition-colors duration-150 ease-out hover:bg-black/5 dark:hover:bg-white/5 data-[orientation=vertical]:w-2.5 data-[orientation=horizontal]:flex-col data-[orientation=horizontal]:h-2.5"
+    class="flex select-none touch-none p-0.5 z-20 pointer-events-none bg-transparent transition-colors duration-150 ease-out data-[orientation=vertical]:w-2.5 data-[orientation=horizontal]:flex-col data-[orientation=horizontal]:h-2.5"
     orientation="vertical"
   >
     <ScrollAreaThumb
-      class="flex-1 bg-gray-400 dark:bg-gray-700 rounded-lg relative transition-opacity duration-150 ease-out before:content-[''] before:absolute before:top-1/2 before:left-1/2 before:-translate-x-1/2 before:-translate-y-1/2 before:w-full before:h-full before:min-w-[44px] before:min-h-[44px]"
-      :class="isThumbVisible ? 'opacity-100' : 'opacity-0'"
+      class="flex-1 bg-gray-400 dark:bg-gray-700 rounded-lg relative transition-opacity duration-150 ease-out before:content-[''] before:absolute before:top-1/2 before:left-1/2 before:-translate-x-1/2 before:-translate-y-1/2 before:w-full before:h-full before:min-h-[44px]"
+      :class="isThumbVisible ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'"
     />
   </ScrollAreaScrollbar>
 </template>

--- a/frontend/src/data/reactions.ts
+++ b/frontend/src/data/reactions.ts
@@ -197,10 +197,16 @@ export function useReactions(options: UseReactionsOptions) {
       .join(', ')
 
   const batchRequestErrors = computed(() => {
-    if (!react.error) {
+    const error = react.error
+    // A rapid second reaction makes useFetch abort the still-in-flight first
+    // request (it calls abort() at the start of every execute). That surfaces a
+    // DOMException "signal is aborted without reason". The cancelled operations
+    // aren't lost — they stay in pendingReactions (cleared only on success) and
+    // are resent in the next batch — so an abort isn't a real failure to report.
+    if (!error || error.name === 'AbortError') {
       return []
     }
-    const message = react.error?.message || 'Unable to update reactions'
+    const message = error.message || 'Unable to update reactions'
     return [message]
   })
 


### PR DESCRIPTION
Two small, independent UI fixes.

### fix(reactions): don't show aborted requests as errors
Aborted reaction requests were surfacing as error banners. Aborts are expected (e.g. rapid toggling / navigation) and should be ignored rather than reported.

### fix(sidebar): stop overlay scrollbar from blocking header buttons
The custom overlay scrollbar sat over the scroll content (`z-20`) and expanded the thumb's hit area 44px horizontally via `before:min-w`, so the **New space** plus button at the top-right of the space sidebar was hard to click.

- Make the scrollbar track `pointer-events-none`; only the visible thumb is interactive (`pointer-events-auto` gated on `isThumbVisible`).
- Drop `before:min-w-[44px]` so the touch target no longer reaches sideways into content; keep `before:min-h-[44px]` for a comfortable vertical drag target.
- Remove the now-dead track hover highlight.

Tradeoff: clicking an empty part of the track to page-scroll no longer works — only thumb-drag does, which is standard overlay-scrollbar behavior.