### PR TITLE
refactor(permissions): return pypika criteria from query condition hooks

### DIFF
--- a/gameplan/permissions.py
+++ b/gameplan/permissions.py
@@ -161,13 +161,13 @@ def can_delete_content(user, doc):
 def team_query_conditions(user=None, **kwargs):
 	user = user or frappe.session.user
 	Team = frappe.qb.DocType("GP Team")
-	return criterion_sql(team_access_criterion(Team, user))
+	return team_access_criterion(Team, user)
 
 
 def project_query_conditions(user=None, **kwargs):
 	user = user or frappe.session.user
 	Project = frappe.qb.DocType("GP Project")
-	return criterion_sql(project_access_criterion(Project, user))
+	return project_access_criterion(Project, user)
 
 
 def discussion_query_conditions(user=None, **kwargs):
@@ -186,7 +186,7 @@ def page_query_conditions(user=None, **kwargs):
 	criterion = (Page.project.isnull() & (Page.owner == user)) | accessible_project_criterion(
 		Page.project, user
 	)
-	return criterion_sql(criterion)
+	return criterion
 
 
 def comment_query_conditions(user=None, **kwargs):
@@ -208,7 +208,7 @@ def comment_query_conditions(user=None, **kwargs):
 	criterion = (
 		(Comment.reference_doctype == "GP Discussion") & Comment.reference_name.isin(discussion_query)
 	) | ((Comment.reference_doctype == "GP Task") & Comment.reference_name.isin(task_query))
-	return criterion_sql(criterion)
+	return criterion
 
 
 def draft_query_conditions(user=None, **kwargs):
@@ -219,7 +219,7 @@ def draft_query_conditions(user=None, **kwargs):
 	# the controller get_list for non-virtual doctypes and so was returning every user's drafts.
 	user = user or frappe.session.user
 	Draft = frappe.qb.DocType("GP Draft")
-	return criterion_sql(Draft.owner == user)
+	return Draft.owner == user
 
 
 def content_project_query_conditions(doctype, user=None):
@@ -227,7 +227,7 @@ def content_project_query_conditions(doctype, user=None):
 	if is_global_admin(user):
 		return None
 	DocType = frappe.qb.DocType(doctype)
-	return criterion_sql(accessible_project_criterion(DocType.project, user))
+	return accessible_project_criterion(DocType.project, user)
 
 
 def team_access_criterion(Team, user=None):
@@ -310,10 +310,6 @@ def is_member_parent(parenttype, parent_field, user):
 		.where(Member.user == user)
 	)
 	return parent_field.isin(member_query)
-
-
-def criterion_sql(criterion):
-	return criterion.get_sql(quote_char="`", with_namespace=True) if criterion is not None else None
 
 
 def is_global_admin(user):


### PR DESCRIPTION
## What this does

Gameplan's `permission_query_conditions` hooks build the WHERE clause that limits which rows a user can see (spaces, discussions, pages, comments, drafts, etc.).

Until now each hook built a pypika criterion and then turned it into a SQL string itself, through a local `criterion_sql()` helper that called `criterion.get_sql(...)`. This PR returns the criterion directly and removes that helper.

## Why

`criterion_sql()` inlined values using pypika's own escaping, which only doubles single quotes. On MariaDB the backslash is also an escape character, so that escaping is not safe for arbitrary values.

Frappe now accepts a pypika term straight from these hooks and renders the values through the database driver's escaping (the same path the query builder already uses for bound parameters). So the hooks no longer need to render SQL themselves — they just describe the condition and let the framework render it safely.

The result is less code and safer value handling, with no change to who can see what.

## Depends on

Frappe PR frappe/frappe#40408 — adds pypika support to `permission_query_conditions`. This PR cannot be merged or pass server tests until that change is available in the frappe branch Gameplan's CI installs.

> [!WARNING]
> Gameplan CI installs frappe with `bench init` (no `--frappe-branch`), which uses frappe's default stable branch. frappe#40408 targets `develop`. The server tests here will stay red until the pypika support lands in the branch CI actually uses (either by backporting #40408 or by pointing CI at the branch that has it). Kept as a draft for that reason.

no-docs
