### PR TITLE
Fix: Enable Reactions On Polls

### DIFF
--- a/gameplan/gameplan/doctype/gp_poll/gp_poll.py
+++ b/gameplan/gameplan/doctype/gp_poll/gp_poll.py
@@ -5,10 +5,12 @@ import frappe
 from frappe.model.document import Document
 from frappe.utils import flt
 
+from gameplan.mixins.reactions import HasReactions
+
 from .gp_poll_attributes import GPPollAttributes
 
 
-class GPPoll(Document, GPPollAttributes):
+class GPPoll(HasReactions, Document, GPPollAttributes):
 	on_delete_set_null = ["GP Discussion"]
 
 	def before_insert(self):
@@ -22,6 +24,7 @@ class GPPoll(Document, GPPollAttributes):
 
 	def validate(self):
 		self.total_votes = len(self.votes)
+		self.de_duplicate_reactions()
 
 	def after_insert(self):
 		self.update_discussion_meta()


### PR DESCRIPTION
Reactions on polls returned "not found" because `GPPoll` never inherited the `HasReactions` mixin, even though the frontend calls the react method and the doctype has a reactions table. This adds the mixin and de-duplicates reactions on validate.

Test: added a 🔥 reaction to a poll as a member: add/remove now work; previously the endpoint 404'd.