### PR TITLE
Fix: Images Saved Before Upload Completes Are Silently Lost

### DIFF
--- a/frontend/src/components/CommentsArea.vue
+++ b/frontend/src/components/CommentsArea.vue
@@ -196,7 +196,7 @@
                 variant: 'solid',
                 onClick: submitComment,
                 loading: comments.insert.loading,
-                disabled: commentEmpty,
+                disabled: commentEmpty || commentHasPendingUpload,
               }"
               :discardButtonProps="{
                 onClick: discardComment,
@@ -254,7 +254,8 @@ import {
 } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { useEventListener } from '@vueuse/core'
-import { useList, TabButtons, ErrorMessage, Button, Tooltip } from 'frappe-ui'
+import { useList, TabButtons, ErrorMessage, Button, Tooltip, toast } from 'frappe-ui'
+import { hasPendingImageUpload } from '@/utils'
 import CommentEditor from '@/components/editor/CommentEditor.vue'
 import Comment from './Comment.vue'
 import Activity from './Activity.vue'
@@ -484,6 +485,10 @@ const commentEmpty = computed(() => {
   return !draftData.value.content || draftData.value.content === '<p></p>'
 })
 
+// Block sending while an image is still uploading — its content carries a
+// transient blob:/data: src that the backend strips, which would drop the image.
+const commentHasPendingUpload = computed(() => hasPendingImageUpload(draftData.value.content))
+
 const editorObject = computed<Editor | null>(() => {
   return newCommentEditor.value?.editor || null
 })
@@ -631,6 +636,11 @@ function resetCommentState() {
 
 async function submitComment() {
   if (commentEmpty.value || comments.insert.loading) return
+  // Safety net for keyboard submit (Ctrl/Cmd+Enter) which bypasses the disabled button.
+  if (commentHasPendingUpload.value) {
+    toast.error('Please wait for the image to finish uploading')
+    return
+  }
 
   const comment = await comments.insert.submit({
     reference_doctype: props.doctype,

--- a/frontend/src/pages/NewDiscussion/useNewDiscussion.ts
+++ b/frontend/src/pages/NewDiscussion/useNewDiscussion.ts
@@ -6,6 +6,7 @@ import { useGroupedSpaceOptions } from '@/data/groupedSpaces'
 import { getSpace } from '@/data/spaces'
 import { useSessionUser, useUser } from '@/data/users'
 import { tags } from '@/data/tags'
+import { hasPendingImageUpload } from '@/utils'
 import type { GPDiscussion } from '@/types/doctypes'
 
 const PUBLISH_DRAFT = 'gameplan.gameplan.doctype.gp_draft.gp_draft.publish_draft'
@@ -120,6 +121,10 @@ export function useNewDiscussion() {
     }
     if (checkProject && !draftData.value.project) {
       errorMessage.value = 'Please select a space.'
+      return false
+    }
+    if (hasPendingImageUpload(draftData.value.content)) {
+      errorMessage.value = 'Please wait for the image to finish uploading.'
       return false
     }
     return true

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -13,6 +13,18 @@ export function getImgDimensions(
   })
 }
 
+/**
+ * True when editor content still holds an image whose upload hasn't resolved.
+ * The editor inserts a `blob:`/`data:` preview while uploading and swaps in the
+ * real `/private/files/...` URL once done. Saving before that swap persists a
+ * preview src that the backend sanitizer strips, leaving a broken, invisible
+ * image — so callers should block submission until this returns false.
+ */
+export function hasPendingImageUpload(html: string | null | undefined): boolean {
+  if (!html) return false
+  return /<img\b[^>]*\ssrc\s*=\s*["'](?:blob:|data:)/i.test(html)
+}
+
 export async function copyToClipboard(text: string): Promise<void> {
   try {
     // Use modern Clipboard API if available

--- a/gameplan/tests/test_sanitizer.py
+++ b/gameplan/tests/test_sanitizer.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# MIT License. See license.txt
+
+"""Tests for sanitize_content image handling.
+
+Regression for silent image loss: the editor inserts an image with a transient
+`blob:`/`data:` preview src while the upload is in flight and swaps in the real
+`/private/files/...` URL when it completes. If content is saved before that swap,
+`clean()` strips the preview src (blob:/data: are not allowed protocols), leaving
+a broken, invisible `<img>`. sanitize_content should drop such srcless images
+while preserving images that have a real src.
+"""
+
+from frappe.tests.utils import FrappeTestCase
+
+from gameplan.utils.sanitizer import sanitize_content
+
+
+class TestSanitizeContentImages(FrappeTestCase):
+	def test_keeps_private_file_image(self):
+		html = '<p><img src="/private/files/photo.png" width="300" height="109"></p>'
+		out = sanitize_content(html)
+		self.assertIn('src="/private/files/photo.png"', out)
+
+	def test_keeps_https_image(self):
+		html = '<img src="https://example.com/a.png">'
+		self.assertIn('src="https://example.com/a.png"', sanitize_content(html))
+
+	def test_drops_blob_preview_image(self):
+		# preview src is stripped by clean(); the now-srcless <img> must be removed
+		html = '<p><img src="blob:http://localhost:8000/abc-123" width="300" height="109"></p>'
+		out = sanitize_content(html)
+		self.assertNotIn("<img", out)
+
+	def test_drops_data_uri_image(self):
+		html = '<p><img src="data:image/png;base64,iVBORw0" width="300"></p>'
+		self.assertNotIn("<img", sanitize_content(html))
+
+	def test_does_not_drop_image_with_data_src_lookalike_attr(self):
+		# `data-src` must not be mistaken for a real `src`; this image has no src
+		# and should be removed, but the negative lookahead must still match it.
+		html = '<img data-src="/private/files/x.png" width="10">'
+		self.assertNotIn("<img", sanitize_content(html))

--- a/gameplan/utils/sanitizer.py
+++ b/gameplan/utils/sanitizer.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and Contributors
 
+import re
 from urllib.parse import urlparse
 
 from bleach import clean
@@ -62,6 +63,24 @@ def iframe_attribute_filter(tag, name, value):
 	return False
 
 
+# Matches an <img> tag that carries no `src` attribute. The negative lookahead
+# requires whitespace before `src=` so it does not match `data-src` and similar.
+_SRCLESS_IMG = re.compile(r"<img\b(?![^>]*\ssrc\s*=)[^>]*>", re.IGNORECASE)
+
+
+def remove_srcless_images(html):
+	"""Drop <img> tags that have no usable `src`.
+
+	The editor inserts an image with a temporary `blob:`/`data:` preview URL while
+	the upload is in flight and swaps in the real `/private/files/...` URL once it
+	completes. If content is saved before that swap (or the upload failed), the
+	preview src is stripped by `clean()` above (blob:/data: are not allowed
+	protocols), leaving a broken, invisible `<img>`. Remove it instead of
+	persisting an empty placeholder.
+	"""
+	return _SRCLESS_IMG.sub("", html)
+
+
 def sanitize_content(html):
 	"""
 	Sanitize HTML tags, attributes and style to prevent XSS attacks
@@ -103,4 +122,4 @@ def sanitize_content(html):
 		protocols={"cid", "http", "https", "mailto"},
 	)
 
-	return escaped_html
+	return remove_srcless_images(escaped_html)


### PR DESCRIPTION
### Problem
Adding a photo to a comment (or discussion) sometimes results in an invisible image — the post saves with no error, but nothing renders. The stored content ends up as:

<p><img data-align="center" height="109" width="300"></p>
Note the < img > has dimensions but no src — so it renders as nothing.

### Root cause
The editor inserts an image with a temporary blob:/data: preview URL while the upload is in flight, then swaps in the real /private/files/... URL once it completes.

If the content is saved before that swap finishes (or the upload fails), the preview src is still a blob:/data: URL. The backend sanitizer (gameplan/utils/sanitizer.py) only allows the cid/http/https/mailto protocols, so it strips the preview src — leaving a broken, srcless <img> that is persisted and never displays.

Confirmed via the sanitizer directly:
private file => <img src="/private/files/x.png" ...>   ← kept
https        => <img src="https://x.com/a.png">         ← kept
blob preview => <img width="300" height="109">          ← src stripped
data uri     => <img width="300">                        ← src stripped
The blob: result is byte-for-byte what gets stored in the broken comment.

### Fix (two layers)
**Frontend** — prevent saving an unresolved upload (the primary fix)

New shared helper hasPendingImageUpload(html) detects content that still holds a blob:/data: image src.
Comment composer (CommentsArea.vue): disables Send while an upload is pending, with a toast safety‑net for keyboard submit (Ctrl/Cmd+Enter).
Discussion composer (useNewDiscussion.ts): blocks Publish with a clear message.
**Backend** — never persist a broken placeholder (defense in depth)

sanitize_content now drops <img> tags left without a usable src. This covers both comments and discussions (both call sanitize_content), so even a client that bypasses the guard can't store an invisible image.
### Testing
gameplan/tests/test_sanitizer.py — 5 new tests (keeps /private/files + https; drops blob: + data:; not fooled by a data-src look‑alike). All pass.
Manually verified: a fully‑uploaded image still posts and renders correctly; submitting mid‑upload is now blocked instead of silently losing the image.
yarn build passes.
### Notes
The backend change is intentionally minimal and narrowly scoped (only removes media that has no src after sanitization).