### PR TITLE
fix(theme): flatten the content island in light mode

### DIFF
--- a/frontend/src/components/DesktopLayout.vue
+++ b/frontend/src/components/DesktopLayout.vue
@@ -46,6 +46,6 @@ const onCommunityRoute = computed(() => {
 
 <style scoped>
 .gameplan-desktop-shell :deep([data-slot='desktop-shell-content']) {
-  @apply my-1 mr-1 rounded-lg bg-surface-base shadow-sm dark:m-0 dark:rounded-none dark:border-l dark:shadow-none;
+  @apply border-l bg-surface-base;
 }
 </style>

--- a/frontend/src/pages/Onboarding.vue
+++ b/frontend/src/pages/Onboarding.vue
@@ -78,10 +78,8 @@
         </div>
       </div>
     </div>
-    <div class="flex min-w-0 flex-1 py-1 pr-1 dark:p-0">
-      <div
-        class="flex min-w-0 flex-1 overflow-hidden rounded-lg bg-surface-base shadow-sm dark:rounded-none dark:border-l dark:shadow-none"
-      >
+    <div class="flex min-w-0 flex-1">
+      <div class="flex min-w-0 flex-1 overflow-hidden border-l bg-surface-base">
         <ScrollArea class="block min-h-0 flex-1" viewport-class="isolate bg-surface-base">
           <div class="body-container pt-14 pb-14">
             <div class="max-w-xl mx-auto">


### PR DESCRIPTION
Light mode rendered the main content area as a floating card — a 4px gutter to the sidebar surface, rounded corners, and a shadow. Dark mode already cancelled all of it in dc900cb2, so the two themes disagreed on the shell's basic shape.

This drops the island in light mode too.

The gutter and shadow were what separated content from the rail/sidebar, so the hairline left border dark mode used becomes unconditional. The whole `dark:` branch collapses with it:

```diff
-@apply my-1 mr-1 rounded-lg bg-surface-base shadow-sm dark:m-0 dark:rounded-none dark:border-l dark:shadow-none;
+@apply border-l bg-surface-base;
```

`Onboarding.vue` mirrors the shell in its live preview, so it gets the same treatment.

## Verification

Checked in the browser at 1440x900 on both themes:

- Light: content is edge-to-edge, no radius, no shadow, hairline border between sidebar and content.
- Dark: unchanged — computed styles still `margin: 0px`, `border-radius: 0px`, `box-shadow: none`, `border-left: 1px`.

Mobile is unaffected (`MobileShell` never had an island).