### PR TITLE
fix: support Gameplan actions on Frappe v16

### DIFF
--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -5,7 +5,8 @@ cd ~ || exit
 echo "Setting Up Bench..."
 
 pip install frappe-bench
-bench -v init frappe-bench --skip-assets --python "$(which python)"
+bench -v init frappe-bench --skip-assets --python "$(which python)" \
+  --frappe-branch "${FRAPPE_BRANCH:-develop}"
 cd ./frappe-bench || exit
 
 bench -v setup requirements

--- a/.github/workflows/server-tests-v16.yml
+++ b/.github/workflows/server-tests-v16.yml
@@ -88,3 +88,105 @@ jobs:
       - name: Show bench output
         if: ${{ always() }}
         run: cat ~/frappe-bench/bench_start.log || true
+
+  migrate:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'frappe' }}
+    timeout-minutes: 60
+
+    name: Existing Site Migration (Frappe v16)
+
+    services:
+      mariadb:
+        image: mariadb:10.6
+        env:
+          MARIADB_ROOT_PASSWORD: 123
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
+
+    steps:
+      - name: Clone candidate and history
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Select deployed baseline
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          candidate_sha="$(git rev-parse HEAD)"
+          baseline_sha="${PR_BASE_SHA}"
+
+          if ! git cat-file -e "${baseline_sha}^{commit}" 2>/dev/null; then
+            baseline_sha="${BEFORE_SHA}"
+          fi
+          if ! git cat-file -e "${baseline_sha}^{commit}" 2>/dev/null; then
+            baseline_sha="$(git rev-parse HEAD^)"
+          fi
+
+          echo "Testing migration from ${baseline_sha} to ${candidate_sha}"
+          git branch -f ci-migration-candidate "${candidate_sha}"
+          git switch -C ci-migration-baseline "${baseline_sha}"
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.14"
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 24
+          check-latest: true
+
+      - name: Add to Hosts
+        run: |
+          echo "127.0.0.1 gameplan.test" | sudo tee -a /etc/hosts
+
+      - name: Cache pip
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-v16-migrate-${{ hashFiles('**/*requirements.txt', '**/pyproject.toml', '**/setup.py') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-v16-
+            ${{ runner.os }}-pip-
+
+      - name: Install baseline and seed existing data
+        env:
+          FRAPPE_BRANCH: version-16
+        run: |
+          bash ${GITHUB_WORKSPACE}/.github/helper/install_dependencies.sh
+          bash ${GITHUB_WORKSPACE}/.github/helper/install.sh
+          cd ~/frappe-bench
+          bench --site gameplan.test execute gameplan.demo.demo.generate
+
+      - name: Update existing site to candidate
+        run: |
+          git -C "${GITHUB_WORKSPACE}" switch ci-migration-candidate
+          git -C ~/frappe-bench/apps/gameplan fetch "${GITHUB_WORKSPACE}" ci-migration-candidate
+          git -C ~/frappe-bench/apps/gameplan checkout -B ci-migration-candidate FETCH_HEAD
+
+          cd ~/frappe-bench
+          bench setup requirements
+          CI=Yes bench build --app gameplan
+          bench --site gameplan.test migrate
+          bench --site gameplan.test migrate
+
+      - name: Run migration and v16 boundary tests
+        working-directory: /home/runner/frappe-bench
+        run: |
+          bench --site gameplan.test run-tests --module gameplan.tests.test_community_migrations
+          bench --site gameplan.test run-tests --module gameplan.tests.test_attachments
+          bench --site gameplan.test run-tests --module gameplan.tests.test_v16_api_compat
+
+      - name: Stop server
+        if: ${{ always() }}
+        run: |
+          ps -ef | grep "[f]rappe serve" | awk '{print $2}' | xargs kill -s SIGINT || true
+          sleep 5
+
+      - name: Show bench output
+        if: ${{ always() }}
+        run: cat ~/frappe-bench/bench_start.log || true

--- a/.github/workflows/server-tests-v16.yml
+++ b/.github/workflows/server-tests-v16.yml
@@ -163,6 +163,12 @@ jobs:
           bash "${RUNNER_TEMP}/install_gameplan.sh"
           cd ~/frappe-bench
           bench --site gameplan.test execute gameplan.demo.demo.generate
+          discussion_count="$(bench --site gameplan.test execute frappe.db.count --args '["GP Discussion"]')"
+          if ! [[ "${discussion_count}" =~ ^[1-9][0-9]*$ ]]; then
+            echo "Expected the baseline fixture to contain discussions, got: ${discussion_count}"
+            exit 1
+          fi
+          echo "BASELINE_DISCUSSION_COUNT=${discussion_count}" >> "${GITHUB_ENV}"
 
       - name: Update existing site to candidate
         run: |
@@ -175,6 +181,12 @@ jobs:
           CI=Yes bench build --app gameplan
           bench --site gameplan.test migrate
           bench --site gameplan.test migrate
+
+          discussion_count="$(bench --site gameplan.test execute frappe.db.count --args '["GP Discussion"]')"
+          if [ "${discussion_count}" -ne "${BASELINE_DISCUSSION_COUNT}" ]; then
+            echo "Discussion count changed during migration: ${BASELINE_DISCUSSION_COUNT} -> ${discussion_count}"
+            exit 1
+          fi
 
       - name: Run migration and v16 boundary tests
         working-directory: /home/runner/frappe-bench

--- a/.github/workflows/server-tests-v16.yml
+++ b/.github/workflows/server-tests-v16.yml
@@ -127,6 +127,8 @@ jobs:
           fi
 
           echo "Testing migration from ${baseline_sha} to ${candidate_sha}"
+          cp .github/helper/install_dependencies.sh "${RUNNER_TEMP}/install_dependencies.sh"
+          cp .github/helper/install.sh "${RUNNER_TEMP}/install_gameplan.sh"
           git branch -f ci-migration-candidate "${candidate_sha}"
           git switch -C ci-migration-baseline "${baseline_sha}"
 
@@ -157,8 +159,8 @@ jobs:
         env:
           FRAPPE_BRANCH: version-16
         run: |
-          bash ${GITHUB_WORKSPACE}/.github/helper/install_dependencies.sh
-          bash ${GITHUB_WORKSPACE}/.github/helper/install.sh
+          bash "${RUNNER_TEMP}/install_dependencies.sh"
+          bash "${RUNNER_TEMP}/install_gameplan.sh"
           cd ~/frappe-bench
           bench --site gameplan.test execute gameplan.demo.demo.generate
 

--- a/.github/workflows/server-tests-v16.yml
+++ b/.github/workflows/server-tests-v16.yml
@@ -1,0 +1,90 @@
+name: Server Tests (Frappe v16)
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches: [develop]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: server-tests-v16-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'frappe' }}
+    timeout-minutes: 60
+
+    name: Python Unit Tests (Frappe v16)
+
+    services:
+      mariadb:
+        image: mariadb:10.6
+        env:
+          MARIADB_ROOT_PASSWORD: 123
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
+
+    steps:
+      - name: Clone
+        uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.14"
+
+      - name: Check for valid Python & Merge Conflicts
+        run: |
+          python -m compileall -q -f "${GITHUB_WORKSPACE}"
+          if grep -lr --exclude-dir=node_modules "^<<<<<<< " "${GITHUB_WORKSPACE}"
+              then echo "Found merge conflicts"
+              exit 1
+          fi
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 24
+          check-latest: true
+
+      - name: Add to Hosts
+        run: |
+          echo "127.0.0.1 gameplan.test" | sudo tee -a /etc/hosts
+
+      - name: Cache pip
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-v16-${{ hashFiles('**/*requirements.txt', '**/pyproject.toml', '**/setup.py') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-v16-
+            ${{ runner.os }}-pip-
+
+      - name: Install Dependencies
+        run: |
+          bash ${GITHUB_WORKSPACE}/.github/helper/install_dependencies.sh
+          bash ${GITHUB_WORKSPACE}/.github/helper/install.sh
+        env:
+          FRAPPE_BRANCH: version-16
+          BEFORE: ${{ env.GITHUB_EVENT_PATH.before }}
+          AFTER: ${{ env.GITHUB_EVENT_PATH.after }}
+
+      - name: Run Tests
+        working-directory: /home/runner/frappe-bench
+        run: |
+          bench --site gameplan.test run-tests --app gameplan
+
+      - name: Stop server
+        if: ${{ always() }}
+        run: |
+          ps -ef | grep "[f]rappe serve" | awk '{print $2}' | xargs kill -s SIGINT || true
+          sleep 5
+
+      - name: Show bench output
+        if: ${{ always() }}
+        run: cat ~/frappe-bench/bench_start.log || true

--- a/README.md
+++ b/README.md
@@ -58,6 +58,18 @@ It takes care of installation, setup, upgrades, monitoring, maintenance and supp
 	</a>
 </div>
 
+## Supported versions
+
+Gameplan supports Frappe v16 and newer only. Use the following branch pairings:
+
+| Gameplan | Frappe | Recommended for |
+| --- | --- | --- |
+| `develop` | `version-16` | Stable Frappe v16 installations |
+| `develop` | `develop` | Testing upcoming Frappe releases |
+
+Gameplan does not have a separate `version-16` branch. Its `develop` branch is the supported branch for
+both pairings. Frappe v15 and older releases are not supported.
+
 ## Development setup
 ### Docker
 You need Docker, docker-compose and git setup on your machine. Refer [Docker documentation](https://docs.docker.com/). After that, run the following commands:
@@ -78,31 +90,63 @@ Use the following credentials to log in:
 
 ### Local Development (without Docker)
 
-This app depends on the `develop` branch of [frappe](https://github.com/frappe/frappe).
-
 #### Prerequisites
-- Frappe-bench set up locally ([installation guide](https://frappeframework.com/docs/v14/user/en/installation))
-- Node.js and yarn
+
+- The dependencies required by Frappe v16, including Python 3.14, Node.js 24, and Yarn 1.22. See the
+  current [Frappe installation guide](https://docs.frappe.io/framework/user/en/installation).
+- Bench CLI
 - The local frappe-ui copy is included in `./frappe-ui/` for development
 
 #### Step 1: Set up the Backend
 
-1. In your frappe-bench directory, run the following commands in separate terminal sessions:
-    ```sh
-    # Terminal 1 - Start the Frappe server
-    cd frappe-bench
-    bench start
-    ```
+Create a Frappe v16 bench and install Gameplan's `develop` branch:
 
-2. Open a new terminal session for the remaining setup:
-    ```sh
-    cd frappe-bench
-    bench new-site gameplan.test
-    bench get-app gameplan
-    bench --site gameplan.test install-app gameplan
-    bench --site gameplan.test add-to-hosts
-    bench --site gameplan.test browse --user Administrator
-    ```
+```sh
+bench init --frappe-branch version-16 frappe-bench
+cd frappe-bench
+bench new-site gameplan.test
+bench get-app --branch develop https://github.com/frappe/gameplan
+bench --site gameplan.test install-app gameplan
+bench --site gameplan.test add-to-hosts
+bench build --apps gameplan
+```
+
+Start the development processes in one terminal:
+
+```sh
+bench start
+```
+
+In another terminal, create an authenticated browser session when needed:
+
+```sh
+bench --site gameplan.test browse --user Administrator
+```
+
+To test against the next Frappe release instead, initialize the bench with
+`--frappe-branch develop`. Keep Gameplan on `develop` in both cases.
+
+#### Move an existing Gameplan installation from `main` to `develop`
+
+Back up the site first, then switch only Gameplan to its supported branch. If the bench is still on an
+older Frappe release, switch Frappe to `version-16` as well:
+
+```sh
+cd frappe-bench
+bench --site gameplan.test backup
+bench switch-to-branch develop gameplan
+# Run the next command only when moving the bench to stable Frappe v16.
+# Keep Frappe on develop when testing the upcoming release.
+bench switch-to-branch version-16 frappe
+bench setup requirements
+bench --site gameplan.test migrate
+bench build --apps gameplan
+bench restart
+```
+
+Replace `gameplan.test` with the real site name. Review custom apps before switching a shared bench,
+because every installed app must support Frappe v16. There is no Gameplan `version-16` branch to switch
+to.
 
 #### Step 2: Set up the Frontend
 
@@ -111,72 +155,40 @@ This app depends on the `develop` branch of [frappe](https://github.com/frappe/f
     cd frappe-bench/apps/gameplan
     ```
 
-2. Initialize and update the frappe-ui submodule (required):
+2. Initialize the pinned frappe-ui submodule:
     ```sh
-    # If frappe-ui is not initialized
-    git submodule init
-    git submodule update
-
-    # To pull the latest version of frappe-ui
-    git submodule update --remote
+    git submodule update --init --recursive
     ```
 
 3. Install frontend dependencies:
     ```sh
-    yarn install
+    yarn install --frozen-lockfile
     ```
 
-4. **Optional: For local frappe-ui development**, install frappe-ui dependencies (use `yarn` in frappe-ui):
-    ```sh
-    cd frappe-ui
-    yarn install
-    cd ..
-    ```
-
-5. Start the Vite development server:
+4. Start the Vite development server with the published frappe-ui package:
     ```sh
     yarn dev
     ```
 
+5. **Optional: For frappe-ui contributors**, install the submodule dependencies and use the local
+   checkout:
+    ```sh
+    (cd frappe-ui && yarn install --frozen-lockfile)
+    yarn dev:frappe-ui
+    ```
+
 6. Access the application at `http://gameplan.test:8080/g`
 
-#### How Local Vite Aliasing Works
+#### How local frappe-ui development works
 
-Gameplan uses a custom Vite configuration to support local development with a bundled copy of frappe-ui. Here's how it works:
-
-- The `./frappe-ui/` directory is a local copy of the frappe-ui library bundled with Gameplan
-- During development (`vite dev`), Vite automatically detects if local frappe-ui dependencies are installed
-- If they are installed, Vite aliases all imports of `frappe-ui` to use the local copy instead of the npm package
-
-**Alias Configuration**:
-The Vite config (`frontend/vite.config.js`) implements smart aliasing:
-
-```javascript
-// Development mode: Uses local frappe-ui if node_modules exist
-const useLocalFrappeUI = isDev && existsSync(path.join(localFrappeUIPath, 'node_modules'))
-
-// CSS must be aliased before the general module alias
-const localFrappeUIAliases = useLocalFrappeUI ? {
-  'frappe-ui/style.css': path.resolve(localFrappeUIPath, 'src', 'style.css'),
-  'frappe-ui': localFrappeUIPath,
-} : {}
-```
-
-**Dependency Resolution**:
-- TipTap packages are specially handled to resolve from the local frappe-ui's `node_modules` when using the local copy
-- This prevents version conflicts between frappe-ui and gameplan dependencies
-- The config automatically falls back to the npm package if local frappe-ui is not available
-
-**When to Install frappe-ui Dependencies**:
-- Only needed if you're modifying frappe-ui components or contributing to frappe-ui development
-- Use `yarn install` in the `frappe-ui` directory
-- For normal Gameplan development, the npm package version will be used automatically
-- If you see a warning about frappe-ui dependencies not being installed, run `cd frappe-ui && yarn install` only if you need local development
+`yarn dev` uses the published frappe-ui version pinned in `frontend/package.json`. The
+`yarn dev:frappe-ui` command replaces that installed package with a symlink to the pinned `./frappe-ui/`
+submodule for library development. Running `yarn dev` again restores the published package.
 
 **Contributing to frappe-ui**:
 - The `frappe-ui` directory is a Git submodule pointing to the [frappe/frappe-ui](https://github.com/frappe/frappe-ui) repository
 - If you make changes to frappe-ui, you must submit them as a separate Pull Request to the [frappe-ui repository](https://github.com/frappe/frappe-ui)
-- Changes to frappe-ui submodule commits in Gameplan are intentionally not committed to keep the submodule independently versioned
+- Update the submodule only through a reviewed Gameplan change; do not use `git submodule update --remote`
 - Test your frappe-ui changes locally with Gameplan before submitting a PR
 
 #### Frontend Development Environment

--- a/frontend/src/data/spaces.ts
+++ b/frontend/src/data/spaces.ts
@@ -8,19 +8,18 @@ import { readOnlyMode } from './readOnlyMode'
 
 interface Member extends Pick<GPMember, 'user'> {}
 
-export interface Space
-  extends Pick<
-    GPProject,
-    | 'name'
-    | 'title'
-    | 'icon'
-    | 'team'
-    | 'archived_at'
-    | 'is_private'
-    | 'modified'
-    | 'tasks_count'
-    | 'discussions_count'
-  > {
+export interface Space extends Pick<
+  GPProject,
+  | 'name'
+  | 'title'
+  | 'icon'
+  | 'team'
+  | 'archived_at'
+  | 'is_private'
+  | 'modified'
+  | 'tasks_count'
+  | 'discussions_count'
+> {
   team_title: string
   members: Member[]
 }
@@ -98,10 +97,10 @@ export function getSpaceUnreadCount(spaceId: string) {
 const spaceDoctype = useDoctype<GPProject>('GP Project')
 
 export function joinSpace(space: Space) {
-  return spaceDoctype.runDocMethod
+  return spaceDoctype.runMethod
     .submit({
-      method: 'join',
-      name: space.name,
+      method: 'join_spaces',
+      params: { spaces: [space.name] },
     })
     .then(() => {
       joinedSpaces.reload()
@@ -122,10 +121,10 @@ export function joinSpaces(spaceIds: string[]) {
 }
 
 export function leaveSpace(space: Space) {
-  return spaceDoctype.runDocMethod
+  return spaceDoctype.runMethod
     .submit({
-      method: 'leave',
-      name: space.name,
+      method: 'leave_spaces',
+      params: { spaces: [space.name] },
     })
     .then(() => {
       joinedSpaces.reload()

--- a/frontend/src/data/unreadCount.ts
+++ b/frontend/src/data/unreadCount.ts
@@ -95,10 +95,10 @@ export function markCommunityAsRead(team: string, before?: string) {
 const Project = useDoctype<GPProject>('GP Project')
 
 export function markSpaceAsRead(spaceId: string) {
-  return Project.runDocMethod
+  return Project.runMethod
     .submit({
-      name: spaceId,
       method: 'mark_all_as_read',
+      params: { spaces: [spaceId] },
     })
     .then(() => {
       return refreshUnreadCountForProjects([spaceId])

--- a/frontend/src/pages/Drafts.vue
+++ b/frontend/src/pages/Drafts.vue
@@ -274,6 +274,7 @@ function deleteDrafts() {
 // the bare GP Draft row can't express, so the client just renders and routes.
 let drafts = useCall<DraftRow[]>({
   url: '/api/v2/method/gameplan.gameplan.doctype.gp_draft.gp_draft.get_my_drafts',
+  method: 'POST',
   // get_my_drafts is owner-scoped on the server; scope the client cache to the session user
   // too, so a same-tab account switch can't briefly show the previous user's draft rows.
   cacheKey: ['drafts', session.user],

--- a/frontend/src/pages/Drafts.vue
+++ b/frontend/src/pages/Drafts.vue
@@ -229,7 +229,7 @@ function cancelBulkDelete() {
 }
 
 let deleteDraftsCall = useCall<DeleteDraftsResponse, { names: string[] }>({
-  url: '/api/v2/document/GP Draft/bulk_delete',
+  url: '/api/v2/method/GP Draft/bulk_delete',
   method: 'POST',
   immediate: false,
 })

--- a/frontend/src/pages/Space.vue
+++ b/frontend/src/pages/Space.vue
@@ -114,9 +114,9 @@ watch(
 )
 
 onMounted(() => {
-  spaces.runDocMethod.submit({
+  spaces.runMethod.submit({
     method: 'track_visit',
-    name: props.spaceId,
+    params: { space: props.spaceId },
   })
 })
 </script>

--- a/gameplan/gameplan/doctype/gp_draft/gp_draft.py
+++ b/gameplan/gameplan/doctype/gp_draft/gp_draft.py
@@ -254,6 +254,39 @@ def commit_draft(name: str, reference_doctype: str, reference_name: str):
 	draft.commit(reference_doctype, reference_name)
 
 
+@frappe.whitelist(methods=["POST"])
+def bulk_delete(names: list[str]):
+	"""Delete drafts with the same per-document permission checks as Frappe's v17 API."""
+	if not isinstance(names, list):
+		frappe.throw("'names' must be a list", frappe.ValidationError)
+
+	deleted = []
+	failed = []
+	for name in names:
+		if not isinstance(name, str | int):
+			failed.append({"name": name, "error": "'name' must be a string or integer"})
+			continue
+
+		name = str(name)
+		frappe.db.savepoint("bulk_delete_drafts")
+		try:
+			draft = frappe.get_doc("GP Draft", name)
+			draft.check_permission("delete")
+			draft.delete()
+			deleted.append(name)
+		except Exception as exc:
+			frappe.db.rollback(save_point="bulk_delete_drafts")
+			failed.append({"name": name, "error": str(exc)})
+
+	return {
+		"deleted": deleted,
+		"failed": failed,
+		"total": len(names),
+		"success_count": len(deleted),
+		"failure_count": len(failed),
+	}
+
+
 def remove_query_params_from_images(content):
 	# replace strings like src="/path/to/image.jpg?fid=param" with src="/path/to/image.jpg"
 	# because when we publish draft, images linked to the draft are deleted

--- a/gameplan/gameplan/doctype/gp_draft/gp_draft.py
+++ b/gameplan/gameplan/doctype/gp_draft/gp_draft.py
@@ -110,7 +110,7 @@ def find_my_draft(
 	return frappe.get_doc("GP Draft", name).as_dict()
 
 
-@frappe.whitelist(methods=["GET"])
+@frappe.whitelist(methods=["POST"])
 def get_my_drafts():
 	"""Return the current user's new-content drafts, enriched for the Drafts list.
 
@@ -141,15 +141,15 @@ def get_my_drafts():
 		ignore_permissions=False,
 	).run(as_dict=True)
 
-	# A rare create race can leave multiple drafts for one reply. Keep the response stable without
-	# trying to self-heal here: Frappe rolls back writes at the end of GET requests, so deleting a
-	# stale sibling would appear to succeed while leaving the database unchanged.
+	# A rare create race can leave multiple drafts for one reply. This endpoint is POST-only so the
+	# stale siblings are committed as deleted instead of reappearing after the newest draft is used.
 	seen = set()
 	deduped = []
 	for r in rows:
 		if r.type == "Comment" and r.reference_name:
 			key = (r.reference_doctype, r.reference_name)
 			if key in seen:
+				frappe.delete_doc("GP Draft", r.name, ignore_permissions=False, delete_permanently=True)
 				continue
 			seen.add(key)
 		deduped.append(r)

--- a/gameplan/gameplan/doctype/gp_draft/gp_draft.py
+++ b/gameplan/gameplan/doctype/gp_draft/gp_draft.py
@@ -110,7 +110,7 @@ def find_my_draft(
 	return frappe.get_doc("GP Draft", name).as_dict()
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["GET"])
 def get_my_drafts():
 	"""Return the current user's new-content drafts, enriched for the Drafts list.
 
@@ -141,16 +141,15 @@ def get_my_drafts():
 		ignore_permissions=False,
 	).run(as_dict=True)
 
-	# Collapse duplicate comment singletons (a rare create race can leave more than one row for
-	# one reply): rows are newest-first, so keep the first per (reference_doctype, reference_name)
-	# and delete the stale siblings — the Drafts list then shows one entry per reply.
+	# A rare create race can leave multiple drafts for one reply. Keep the response stable without
+	# trying to self-heal here: Frappe rolls back writes at the end of GET requests, so deleting a
+	# stale sibling would appear to succeed while leaving the database unchanged.
 	seen = set()
 	deduped = []
 	for r in rows:
 		if r.type == "Comment" and r.reference_name:
 			key = (r.reference_doctype, r.reference_name)
 			if key in seen:
-				frappe.delete_doc("GP Draft", r.name, ignore_permissions=False, delete_permanently=True)
 				continue
 			seen.add(key)
 		deduped.append(r)

--- a/gameplan/gameplan/doctype/gp_draft/gp_draft.py
+++ b/gameplan/gameplan/doctype/gp_draft/gp_draft.py
@@ -255,7 +255,10 @@ def commit_draft(name: str, reference_doctype: str, reference_name: str):
 
 @frappe.whitelist(methods=["POST"])
 def bulk_delete(names: list[str]):
-	"""Delete drafts with the same per-document permission checks as Frappe's v17 API."""
+	"""Frappe v16 shim for the per-DocType bulk-delete endpoint added in v17.
+
+	Remove this duplicate once Gameplan's minimum supported Frappe version is v17.
+	"""
 	if not isinstance(names, list):
 		frappe.throw("'names' must be a list", frappe.ValidationError)
 

--- a/gameplan/gameplan/doctype/gp_project/gp_project.py
+++ b/gameplan/gameplan/doctype/gp_project/gp_project.py
@@ -107,8 +107,10 @@ class GPProject(ManageMembersMixin, Archivable, Document):
 		if name:
 			frappe.delete_doc("GP Guest Access", name)
 
-	@frappe.whitelist()
+	@frappe.whitelist(methods=["POST"])
 	def track_visit(self):
+		if not can_view_space(frappe.session.user, self):
+			frappe.throw("Not permitted", frappe.PermissionError)
 		if frappe.flags.read_only:
 			return
 
@@ -144,7 +146,7 @@ class GPProject(ManageMembersMixin, Archivable, Document):
 				self.save(ignore_permissions=True)
 				break
 
-	@frappe.whitelist()
+	@frappe.whitelist(methods=["POST"])
 	def join(self):
 		if not can_view_space(frappe.session.user, self):
 			frappe.throw("Not permitted", frappe.PermissionError)
@@ -155,8 +157,10 @@ class GPProject(ManageMembersMixin, Archivable, Document):
 			self.append("members", {"user": user})
 			self.save(ignore_permissions=True)
 
-	@frappe.whitelist()
+	@frappe.whitelist(methods=["POST"])
 	def leave(self):
+		if not can_view_space(frappe.session.user, self):
+			frappe.throw("Not permitted", frappe.PermissionError)
 		user = frappe.session.user
 		for member in self.members:
 			if member.user == user:
@@ -173,9 +177,11 @@ class GPProject(ManageMembersMixin, Archivable, Document):
 		):
 			frappe.delete_doc("GP Pinned Project", pin, ignore_permissions=True)
 
-	@frappe.whitelist()
+	@frappe.whitelist(methods=["POST"])
 	def mark_all_as_read(self):
 		"""Mark all discussions as read using a project-level timestamp."""
+		if not can_view_space(frappe.session.user, self):
+			frappe.throw("Not permitted", frappe.PermissionError)
 		user = frappe.session.user
 		project_name = self.name
 		now = frappe.utils.now()
@@ -279,6 +285,11 @@ def leave_spaces(spaces: list[str] = None):
 		return
 	for space in spaces:
 		frappe.get_doc("GP Project", space).leave()
+
+
+@frappe.whitelist(methods=["POST"])
+def track_visit(space: str):
+	frappe.get_doc("GP Project", space).track_visit()
 
 
 @frappe.whitelist(methods=["POST"])

--- a/gameplan/install.py
+++ b/gameplan/install.py
@@ -15,8 +15,8 @@ def check_frappe_version():
 	from semantic_version import Version
 
 	frappe_version = Version(__version__)
-	if (frappe_version.major or 0) < 15:
-		raise SystemExit("Gameplan requires Frappe Framework version 15 or above")
+	if (frappe_version.major or 0) < 16:
+		raise SystemExit("Gameplan requires Frappe Framework version 16 or above")
 
 
 def download_rembg_model():

--- a/gameplan/tests/test_get_request_transactions.py
+++ b/gameplan/tests/test_get_request_transactions.py
@@ -107,9 +107,7 @@ class TestGetRequestTransactions(FrappeAPITestCase):
 		self.login_as(user.name)
 
 		with patch("frappe.delete_doc", side_effect=AssertionError("GET attempted draft cleanup")) as delete:
-			response = self.get(
-				self.method("gameplan.gameplan.doctype.gp_draft.gp_draft.get_my_drafts")
-			)
+			response = self.get(self.method("gameplan.gameplan.doctype.gp_draft.gp_draft.get_my_drafts"))
 
 		self.assertEqual(response.status_code, 200, response.text)
 		delete.assert_not_called()

--- a/gameplan/tests/test_get_request_transactions.py
+++ b/gameplan/tests/test_get_request_transactions.py
@@ -1,8 +1,6 @@
 # Copyright (c) 2026, Frappe Technologies Pvt Ltd and Contributors
 # See license.txt
 
-from unittest.mock import patch
-
 import frappe
 from frappe.auth import CookieManager, LoginManager
 from frappe.tests.test_api import FrappeAPITestCase
@@ -82,8 +80,8 @@ class TestGetRequestTransactions(FrappeAPITestCase):
 		self.assertEqual(frappe.db.get_value("GP Invitation", invitation.name, "status"), "Accepted")
 		self.assertTrue(frappe.db.get_value("GP Invitation", invitation.name, "accepted_at"))
 
-	def test_get_my_drafts_deduplicates_response_without_cleanup(self):
-		"""A GET returns one row per reply without attempting a rolled-back delete."""
+	def test_get_my_drafts_post_persists_duplicate_cleanup(self):
+		"""The POST returns the newest reply draft and permanently removes stale duplicates."""
 		suffix = frappe.generate_hash(length=8)
 		user = create_member(f"get_drafts_{suffix}@example.com", "GET Drafts")
 		self.users.append(user.name)
@@ -106,14 +104,12 @@ class TestGetRequestTransactions(FrappeAPITestCase):
 		frappe.db.commit()
 		self.login_as(user.name)
 
-		with patch("frappe.delete_doc", side_effect=AssertionError("GET attempted draft cleanup")) as delete:
-			response = self.get(self.method("gameplan.gameplan.doctype.gp_draft.gp_draft.get_my_drafts"))
+		response = self.post(self.method("gameplan.gameplan.doctype.gp_draft.gp_draft.get_my_drafts"), {})
 
 		self.assertEqual(response.status_code, 200, response.text)
-		delete.assert_not_called()
 		self.assertEqual([draft["name"] for draft in response.json["message"]], [newer.name])
 		frappe.db.rollback()
 		stored = frappe.get_all(
 			"GP Draft", filters={"owner": user.name, **fields}, order_by="modified desc", pluck="name"
 		)
-		self.assertEqual(stored, [newer.name, older.name])
+		self.assertEqual(stored, [newer.name])

--- a/gameplan/tests/test_get_request_transactions.py
+++ b/gameplan/tests/test_get_request_transactions.py
@@ -1,0 +1,121 @@
+# Copyright (c) 2026, Frappe Technologies Pvt Ltd and Contributors
+# See license.txt
+
+from unittest.mock import patch
+
+import frappe
+from frappe.auth import CookieManager, LoginManager
+from frappe.tests.test_api import FrappeAPITestCase
+from frappe.utils import get_test_client, set_request, today
+
+from gameplan.tests.utils import create_discussion, create_member, create_project, create_team
+
+
+class TestGetRequestTransactions(FrappeAPITestCase):
+	"""Guard Gameplan endpoints whose transaction behavior differs for GET requests."""
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		self.TEST_CLIENT = get_test_client()
+		self.drafts = []
+		self.invitations = []
+		self.teams = []
+		self.users = []
+		self.addCleanup(self.cleanup_committed_fixtures)
+
+	def login_as(self, user: str):
+		set_request(path="/")
+		frappe.local.cookie_manager = CookieManager()
+		frappe.local.login_manager = LoginManager()
+		frappe.local.login_manager.login_as(user)
+		self.TEST_CLIENT.set_cookie(key="sid", value=frappe.session.sid)
+		frappe.set_user("Administrator")
+		frappe.db.commit()
+
+	def cleanup_committed_fixtures(self):
+		frappe.set_user("Administrator")
+		frappe.db.rollback()
+		for invitation in self.invitations:
+			if frappe.db.exists("GP Invitation", invitation):
+				frappe.delete_doc("GP Invitation", invitation, ignore_permissions=True, force=True)
+		for draft in self.drafts:
+			if frappe.db.exists("GP Draft", draft):
+				frappe.delete_doc("GP Draft", draft, ignore_permissions=True, force=True)
+		for team in self.teams:
+			if frappe.db.exists("GP Team", team):
+				frappe.delete_doc("GP Team", team, ignore_permissions=True, force=True)
+		for user in self.users:
+			if frappe.db.exists("User", user):
+				frappe.delete_doc("User", user, ignore_permissions=True, force=True)
+		frappe.db.commit()
+
+	def test_existing_user_invitation_acceptance_persists_after_get(self):
+		"""The email link remains a GET because both successful branches commit explicitly.
+
+		An established user follows the login branch, whose session creation commits the accepted
+		invitation before Frappe's end-of-request GET rollback runs.
+		"""
+		suffix = frappe.generate_hash(length=8)
+		user = create_member(f"get_invitation_{suffix}@example.com", "GET Invitation")
+		self.users.append(user.name)
+		frappe.db.set_value("User", user.name, "last_password_reset_date", today())
+
+		key = frappe.generate_hash(length=24)
+		invitation = frappe.get_doc(
+			doctype="GP Invitation",
+			email=user.name,
+			role="Gameplan Member",
+			key=key,
+			status="Pending",
+			invited_by="Administrator",
+		)
+		# Avoid sending email while preserving the exact document consumed by the endpoint.
+		invitation.db_insert()
+		self.invitations.append(invitation.name)
+		frappe.db.commit()
+
+		response = self.get(f"{self.method('gameplan.api.accept_invitation')}?key={key}")
+
+		self.assertEqual(response.status_code, 302, response.text)
+		self.assertEqual(response.headers["Location"], "/g")
+		frappe.db.rollback()
+		self.assertEqual(frappe.db.get_value("GP Invitation", invitation.name, "status"), "Accepted")
+		self.assertTrue(frappe.db.get_value("GP Invitation", invitation.name, "accepted_at"))
+
+	def test_get_my_drafts_deduplicates_response_without_cleanup(self):
+		"""A GET returns one row per reply without attempting a rolled-back delete."""
+		suffix = frappe.generate_hash(length=8)
+		user = create_member(f"get_drafts_{suffix}@example.com", "GET Drafts")
+		self.users.append(user.name)
+		team = create_team(f"GET Drafts {suffix}")
+		self.teams.append(team.name)
+		project = create_project(f"GET Drafts Space {suffix}", team.name)
+		discussion = create_discussion(f"GET Drafts Discussion {suffix}", project.name)
+
+		frappe.set_user(user.name)
+		fields = {
+			"type": "Comment",
+			"mode": "New",
+			"reference_doctype": "GP Discussion",
+			"reference_name": str(discussion.name),
+		}
+		older = frappe.get_doc(doctype="GP Draft", content="older", **fields).insert()
+		newer = frappe.get_doc(doctype="GP Draft", content="newer", **fields).insert()
+		self.drafts.extend([older.name, newer.name])
+		frappe.set_user("Administrator")
+		frappe.db.commit()
+		self.login_as(user.name)
+
+		with patch("frappe.delete_doc", side_effect=AssertionError("GET attempted draft cleanup")) as delete:
+			response = self.get(
+				self.method("gameplan.gameplan.doctype.gp_draft.gp_draft.get_my_drafts")
+			)
+
+		self.assertEqual(response.status_code, 200, response.text)
+		delete.assert_not_called()
+		self.assertEqual([draft["name"] for draft in response.json["message"]], [newer.name])
+		frappe.db.rollback()
+		stored = frappe.get_all(
+			"GP Draft", filters={"owner": user.name, **fields}, order_by="modified desc", pluck="name"
+		)
+		self.assertEqual(stored, [newer.name, older.name])

--- a/gameplan/tests/test_install.py
+++ b/gameplan/tests/test_install.py
@@ -1,0 +1,16 @@
+from unittest import TestCase
+from unittest.mock import patch
+
+from gameplan.install import check_frappe_version
+
+
+class TestInstall(TestCase):
+	def test_frappe_15_is_rejected(self):
+		with patch("frappe.__version__", "15.99.0"):
+			with self.assertRaisesRegex(SystemExit, "version 16 or above"):
+				check_frappe_version()
+
+	def test_frappe_16_and_newer_are_supported(self):
+		for version in ("16.0.0-dev", "16.28.0", "17.0.0-dev"):
+			with self.subTest(version=version), patch("frappe.__version__", version):
+				check_frappe_version()

--- a/gameplan/tests/test_v16_api_compat.py
+++ b/gameplan/tests/test_v16_api_compat.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2026, Frappe Technologies Pvt Ltd and Contributors
+# See license.txt
+
+import frappe
+from frappe.auth import CookieManager, LoginManager
+from frappe.tests.test_api import FrappeAPITestCase
+from frappe.utils import get_test_client, set_request
+
+from gameplan.tests.utils import create_member, create_team
+
+
+class TestV16APICompatibility(FrappeAPITestCase):
+	"""Exercise browser routes that Frappe v16 checks before controller methods run."""
+
+	version = "v2"
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		self.TEST_CLIENT = get_test_client()
+		self.teams = []
+		self.drafts = []
+		self.users = []
+		self.addCleanup(self.cleanup_committed_fixtures)
+		suffix = frappe.generate_hash(length=8)
+		self.member = create_member(f"api_boundary_member_{suffix}@example.com", "API Boundary Member")
+		self.other_member = create_member(
+			f"api_boundary_other_{suffix}@example.com", "API Boundary Other Member"
+		)
+		self.users.extend([self.member.name, self.other_member.name])
+
+	def login_as(self, user: str):
+		set_request(path="/")
+		frappe.local.cookie_manager = CookieManager()
+		frappe.local.login_manager = LoginManager()
+		frappe.local.login_manager.login_as(user)
+		self.TEST_CLIENT.set_cookie(key="sid", value=frappe.session.sid)
+		frappe.set_user("Administrator")
+
+	def create_space(self):
+		team = create_team(f"API Boundary {frappe.generate_hash(length=8)}")
+		self.teams.append(team.name)
+		return frappe.get_doc("GP Project", {"team": team.name})
+
+	def create_draft(self, owner: str, content: str):
+		frappe.set_user(owner)
+		draft = frappe.get_doc(doctype="GP Draft", type="Discussion", mode="New", content=content).insert()
+		self.drafts.append(draft.name)
+		frappe.set_user("Administrator")
+		return draft
+
+	def cleanup_committed_fixtures(self):
+		frappe.set_user("Administrator")
+		frappe.db.rollback()
+		for draft in self.drafts:
+			if frappe.db.exists("GP Draft", draft):
+				frappe.delete_doc("GP Draft", draft, ignore_permissions=True, force=True)
+		for team in self.teams:
+			if frappe.db.exists("GP Team", team):
+				frappe.delete_doc("GP Team", team, ignore_permissions=True, force=True)
+		for user in self.users:
+			if frappe.db.exists("User", user):
+				frappe.delete_doc("User", user, ignore_permissions=True, force=True)
+		frappe.db.commit()
+
+	def test_member_space_actions_cross_the_http_permission_boundary(self):
+		space = self.create_space()
+		space_id = str(space.name)
+		frappe.set_user(self.member.name)
+		self.assertTrue(space.has_permission("read"))
+		self.assertFalse(space.has_permission("write"))
+		frappe.set_user("Administrator")
+		frappe.db.commit()
+		self.login_as(self.member.name)
+
+		join = self.post(self.method("GP Project", "join_spaces"), {"spaces": [space_id]})
+		self.assertEqual(join.status_code, 200, join.text)
+		frappe.db.rollback()
+		self.assertTrue(frappe.db.exists("GP Member", {"parent": space_id, "user": self.member.name}))
+
+		visit = self.post(self.method("GP Project", "track_visit"), {"space": space_id})
+		self.assertEqual(visit.status_code, 200, visit.text)
+		frappe.db.rollback()
+		self.assertTrue(frappe.db.exists("GP Project Visit", {"project": space_id, "user": self.member.name}))
+
+		mark_read = self.post(self.method("GP Project", "mark_all_as_read"), {"spaces": [space_id]})
+		self.assertEqual(mark_read.status_code, 200, mark_read.text)
+		frappe.db.rollback()
+		self.assertTrue(
+			frappe.db.get_value(
+				"GP Project Visit",
+				{"project": space_id, "user": self.member.name},
+				"mark_all_read_at",
+			)
+		)
+
+		leave = self.post(self.method("GP Project", "leave_spaces"), {"spaces": [space_id]})
+		self.assertEqual(leave.status_code, 200, leave.text)
+		frappe.db.rollback()
+		self.assertFalse(frappe.db.exists("GP Member", {"parent": space_id, "user": self.member.name}))
+
+	def test_bulk_delete_drafts_checks_each_document_permission_over_http(self):
+		own_drafts = [
+			self.create_draft(self.member.name, "First draft"),
+			self.create_draft(self.member.name, "Second draft"),
+		]
+		other_draft = self.create_draft(self.other_member.name, "Another member's draft")
+		frappe.db.commit()
+		self.login_as(self.member.name)
+
+		response = self.post(
+			self.method("GP Draft", "bulk_delete"),
+			{"names": [own_drafts[0].name, other_draft.name, own_drafts[1].name]},
+		)
+
+		self.assertEqual(response.status_code, 200, response.text)
+		result = response.json["data"]
+		self.assertCountEqual(result["deleted"], [draft.name for draft in own_drafts])
+		self.assertEqual(result["success_count"], 2)
+		self.assertEqual(result["failure_count"], 1)
+		self.assertEqual(result["failed"][0]["name"], other_draft.name)
+		frappe.db.rollback()
+		self.assertFalse(frappe.db.exists("GP Draft", own_drafts[0].name))
+		self.assertFalse(frappe.db.exists("GP Draft", own_drafts[1].name))
+		self.assertTrue(frappe.db.exists("GP Draft", other_draft.name))

--- a/gameplan/tests/test_v16_api_compat.py
+++ b/gameplan/tests/test_v16_api_compat.py
@@ -35,6 +35,7 @@ class TestV16APICompatibility(FrappeAPITestCase):
 		frappe.local.login_manager.login_as(user)
 		self.TEST_CLIENT.set_cookie(key="sid", value=frappe.session.sid)
 		frappe.set_user("Administrator")
+		frappe.db.commit()
 
 	def create_space(self):
 		team = create_team(f"API Boundary {frappe.generate_hash(length=8)}")

--- a/gameplan/tests/test_v16_api_compat.py
+++ b/gameplan/tests/test_v16_api_compat.py
@@ -99,6 +99,17 @@ class TestV16APICompatibility(FrappeAPITestCase):
 		frappe.db.rollback()
 		self.assertFalse(frappe.db.exists("GP Member", {"parent": space_id, "user": self.member.name}))
 
+	def test_member_is_included_by_add_to_apps_screen_hook_over_http(self):
+		"""Frappe boot calls the configured hook with no arguments for each app."""
+		frappe.db.commit()
+		self.login_as(self.member.name)
+
+		response = self.get(self.method("frappe.apps.get_apps"))
+
+		self.assertEqual(response.status_code, 200, response.text)
+		apps = response.json["data"]
+		self.assertIn("gameplan", [app["name"] for app in apps])
+
 	def test_bulk_delete_drafts_checks_each_document_permission_over_http(self):
 		own_drafts = [
 			self.create_draft(self.member.name, "First draft"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ description = "Team discussion and collaboration tool"
 requires-python = ">=3.10"
 readme = "README.md"
 dynamic = ["version"]
-dependencies = ["bleach~=6.3.0", "bleach-allowlist~=1.0.3"]
+dependencies = ["bleach~=6.3.0", "bleach-allowlist~=1.0.3", "tinycss2>=1.5.0"]
 
 [build-system]
 requires = ["flit_core >=3.4,<4"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ description = "Team discussion and collaboration tool"
 requires-python = ">=3.10"
 readme = "README.md"
 dynamic = ["version"]
-dependencies = ["faker==37.3.0", "bleach[css]~=6.3.0", "bleach-allowlist~=1.0.3"]
+dependencies = ["bleach~=6.3.0", "bleach-allowlist~=1.0.3"]
 
 [build-system]
 requires = ["flit_core >=3.4,<4"]
@@ -33,7 +33,7 @@ indent-style = "tab"
 docstring-code-format = true
 
 [tool.bench.frappe-dependencies]
-frappe = ">=16.0.0-dev,<=17.0.0-dev"
+frappe = ">=16.0.0-dev"
 
 [tool.bench.assets]
 build_dir = "./frontend"


### PR DESCRIPTION
## What changed

- add a dedicated MariaDB server-test workflow pinned to Frappe `version-16`
- exercise ordinary-member space actions through real HTTP permission boundaries
- add a v16-compatible bulk draft deletion endpoint with per-document permission checks
- cover `can_access_gameplan` through Frappe's actual `add_to_apps_screen` hook boundary
- add an existing-site migration job that:
  - installs the PR base on Frappe v16
  - seeds representative Gameplan data
  - updates the same site to the candidate
  - builds and migrates twice
  - verifies data survives and reruns migration/compatibility tests
- make `get_my_drafts` POST-only and permanently remove stale duplicate comment drafts while returning the newest one
- require Frappe v16+ in installer and Bench metadata
- remove the unused Faker pin, replace the conflicting `bleach[css]` extra with plain Bleach, and declare `tinycss2>=1.5` directly for both Frappe v16 and develop
- document the one-branch policy: Gameplan `develop` supports Frappe `version-16` and newer; there is no Gameplan `version-16` maintenance branch

## Why

The old suite called controller methods directly and therefore missed Frappe v16's API permission checks. Browsers hit API v2, where ordinary members were blocked before legitimate join/leave/read/visit actions reached Gameplan. Frappe v16 also lacks the v17 bulk-delete document route.

Issue #491 was caused by pairing Frappe v16 with Gameplan `main`. Gameplan `develop` retains the correct v16 import; the new hook-boundary test prevents that regression.

## GET transaction verification

Both invitation paths were reproduced through real Frappe v16.28 HTTP requests and checked from a fresh process:

- new user: 302 to password setup, invitation persisted as Accepted
- established user: 302 to `/g`, invitation persisted as Accepted

Those paths commit through password/session creation, so invitation behavior was left unchanged and regression-tested.

The draft-list GET returned only the newest duplicate row, but fresh-process inspection showed that both rows remained because Frappe rolled back the attempted deletion. Draft listing is now POST-only, and an authenticated HTTP regression test proves the stale sibling is deleted persistently while the newest draft is returned.

## Validation

Against Frappe v16.28.0:

- 179/179 Gameplan backend tests passed
- authenticated permission-boundary, hook, invitation, duplicate-cleanup, and bulk-delete tests passed
- dependency resolver, `pip check`, and `bench validate-dependencies` passed
- production build passed (3,289 modules)
- Ruff check/format, workflow YAML parsing, compileall, and `git diff --check` passed
- all six PR checks passed, including Frappe v16 tests and existing-site migration
