### PR TITLE
fix(ci): grant the UI job contents: write so the frontend coverage badge publishes

### DIFF
--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -162,9 +162,10 @@ jobs:
           if-no-files-found: warn
           retention-days: 7
 
+      # Not continue-on-error, for the reason spelled out in ui-test.yml: a badge
+      # that silently fails to publish is a 404 in the README with no signal.
       - name: Publish coverage badge
         if: ${{ steps.report.outputs.built == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
-        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash .github/scripts/publish_badge.sh "${RUNNER_TEMP}/coverage.svg" badges-backend

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -18,13 +18,18 @@ jobs:
     if: ${{ github.repository_owner == 'frappe' }}
     timeout-minutes: 60
 
-    # contents: write pushes the regenerated README badge on develop;
-    # pull-requests: write posts the coverage comment. Fork pull requests get a
-    # read-only token regardless, which is why the comment step is best-effort
-    # and the job summary always carries the same report.
+    # Stays contents: read. This job checks out and executes pull-request code, so
+    # a repo-write token here would be a write credential handed to code under
+    # review. Badge publishing needs that token, so it lives in the push-only
+    # `badge` job below and this one just hands the rendered SVG over as an
+    # artifact. Fork pull requests get a read-only token regardless, which is why
+    # the comment step is best-effort and the job summary always carries the report.
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
+
+    outputs:
+      badge: ${{ steps.report.outputs.built }}
 
     strategy:
       fail-fast: false
@@ -162,13 +167,13 @@ jobs:
           if-no-files-found: warn
           retention-days: 7
 
-      # Not continue-on-error, for the reason spelled out in ui-test.yml: a badge
-      # that silently fails to publish is a 404 in the README with no signal.
-      - name: Publish coverage badge
+      - name: Upload coverage badge
+        uses: actions/upload-artifact@v4
         if: ${{ steps.report.outputs.built == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: bash .github/scripts/publish_badge.sh "${RUNNER_TEMP}/coverage.svg" badges-backend
+        with:
+          name: backend-badge
+          path: ${{ runner.temp }}/coverage.svg
+          retention-days: 1
 
       - name: Stop server
         if: ${{ always() }}
@@ -179,3 +184,25 @@ jobs:
       - name: Show bench output
         if: ${{ always() }}
         run: cat ~/frappe-bench/bench_start.log || true
+
+  # Separated from the test job on purpose — see the permissions comment above.
+  # Publishing needs contents: write, and the test job runs pull-request code.
+  # This job runs only on a push to develop, where the code is already merged.
+  badge:
+    name: Publish coverage badge
+    runs-on: ubuntu-latest
+    needs: test
+    if: ${{ needs.test.outputs.badge == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: backend-badge
+          path: badge
+
+      - env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash .github/scripts/publish_badge.sh badge/coverage.svg badges-backend

--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -18,14 +18,17 @@ jobs:
     if: ${{ github.repository_owner == 'frappe' }}
     timeout-minutes: 60
 
-    # contents: write force-pushes the frontend badge to its orphan branch on
-    # develop; pull-requests: write posts the test report. Both are needed here
-    # because a job-level block replaces the workflow-level one outright rather
-    # than adding to it — declaring only contents: write would silently drop the
-    # ability to comment. Fork pull requests get a read-only token regardless.
+    # Stays contents: read. This job checks out and executes pull-request code —
+    # install.sh, the frontend build, the specs themselves — so a repo-write token
+    # here would be a write credential handed to code under review. Badge
+    # publishing needs that token, so it lives in the push-only `badge` job below
+    # and this one just hands the rendered SVG over as an artifact.
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
+
+    outputs:
+      badge: ${{ steps.report.outputs.built }}
 
     strategy:
       fail-fast: false
@@ -167,17 +170,13 @@ jobs:
             --body-file "${RUNNER_TEMP}/frontend-section.md" \
             --footer "<sub>Updated for commit ${{ github.event.pull_request.head.sha }}.</sub>"
 
-      # Deliberately NOT continue-on-error. It was, and that hid a 403 from a
-      # missing contents: write for a whole release cycle: the step reported
-      # success, published nothing, and the README badge 404'd with no signal
-      # anywhere. This only runs on a push to develop, where the suite has
-      # already passed and reddening the run blocks nobody — a stale badge is
-      # worth exactly one red run to find out about.
-      - name: Publish frontend coverage badge
+      - name: Upload coverage badge
+        uses: actions/upload-artifact@v4
         if: ${{ steps.report.outputs.built == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: bash .github/scripts/publish_badge.sh "${RUNNER_TEMP}/frontend-coverage.svg" badges-frontend
+        with:
+          name: frontend-badge
+          path: ${{ runner.temp }}/frontend-coverage.svg
+          retention-days: 1
 
       # Staged into one directory so the artifact's internal layout does not depend on
       # where upload-artifact decides the common ancestor of its inputs is. JUnit lives
@@ -221,3 +220,30 @@ jobs:
       - name: Show bench output
         if: ${{ always() }}
         run: cat ~/frappe-bench/bench_start.log || true
+
+  # Separated from the test job on purpose. Publishing needs contents: write, and
+  # the test job executes pull-request code — granting it there would hand a
+  # repo-write credential to code under review. This job runs only on a push to
+  # develop, where the code is already merged, and touches nothing but the badge.
+  #
+  # Not continue-on-error: the first version was, and it reported success while a
+  # 403 published nothing, leaving the README badge 404ing with no signal. Here
+  # the suite has already passed, so a red run blocks nobody.
+  badge:
+    name: Publish frontend coverage badge
+    runs-on: ubuntu-latest
+    needs: test
+    if: ${{ needs.test.outputs.badge == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: frontend-badge
+          path: badge
+
+      - env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash .github/scripts/publish_badge.sh badge/frontend-coverage.svg badges-frontend

--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -18,6 +18,15 @@ jobs:
     if: ${{ github.repository_owner == 'frappe' }}
     timeout-minutes: 60
 
+    # contents: write force-pushes the frontend badge to its orphan branch on
+    # develop; pull-requests: write posts the test report. Both are needed here
+    # because a job-level block replaces the workflow-level one outright rather
+    # than adding to it — declaring only contents: write would silently drop the
+    # ability to comment. Fork pull requests get a read-only token regardless.
+    permissions:
+      contents: write
+      pull-requests: write
+
     strategy:
       fail-fast: false
 
@@ -158,9 +167,14 @@ jobs:
             --body-file "${RUNNER_TEMP}/frontend-section.md" \
             --footer "<sub>Updated for commit ${{ github.event.pull_request.head.sha }}.</sub>"
 
+      # Deliberately NOT continue-on-error. It was, and that hid a 403 from a
+      # missing contents: write for a whole release cycle: the step reported
+      # success, published nothing, and the README badge 404'd with no signal
+      # anywhere. This only runs on a push to develop, where the suite has
+      # already passed and reddening the run blocks nobody — a stale badge is
+      # worth exactly one red run to find out about.
       - name: Publish frontend coverage badge
         if: ${{ steps.report.outputs.built == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
-        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash .github/scripts/publish_badge.sh "${RUNNER_TEMP}/frontend-coverage.svg" badges-frontend

--- a/TESTING.md
+++ b/TESTING.md
@@ -261,13 +261,19 @@ Both consumers are self-contained — no Codecov, no shields.io:
   would have them clobbering each other. The badges therefore always show `develop`,
   not the branch you are reading.
 
-  Publishing needs `contents: write` **on the job**, not just the workflow — a
-  job-level `permissions:` block replaces the workflow-level one outright instead
-  of adding to it, so a job that declares `pull-requests: write` and forgets
-  `contents: write` cannot push the badge. That failure is a 403 at `git push`,
-  long after the suite is green, which is why these steps are not
-  `continue-on-error`: the first version was, and it reported success while
-  publishing nothing and leaving the README badge 404ing.
+  Publishing lives in a **separate `badge` job** in each workflow, gated on a push
+  to `develop` and holding the only `contents: write` in the file. The test job
+  stays `contents: read` and hands the rendered SVG over as an artifact, because
+  it checks out and executes pull-request code — `install.sh`, the frontend build,
+  the specs — and a repo-write token there would be a write credential handed to
+  code under review. Note that a job-level `permissions:` block *replaces* the
+  workflow-level one rather than adding to it, so a job needing both has to say
+  both.
+
+  The badge jobs are deliberately not `continue-on-error`. The first version was,
+  and it reported success while a 403 published nothing, leaving the README badge
+  404ing with no signal anywhere. By the time they run the suite has passed, so a
+  red run blocks nobody and is the only thing that says the badge is stale.
 
 ## 3. E2E tests (Cypress)
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -261,6 +261,14 @@ Both consumers are self-contained — no Codecov, no shields.io:
   would have them clobbering each other. The badges therefore always show `develop`,
   not the branch you are reading.
 
+  Publishing needs `contents: write` **on the job**, not just the workflow — a
+  job-level `permissions:` block replaces the workflow-level one outright instead
+  of adding to it, so a job that declares `pull-requests: write` and forgets
+  `contents: write` cannot push the badge. That failure is a 403 at `git push`,
+  long after the suite is green, which is why these steps are not
+  `continue-on-error`: the first version was, and it reported success while
+  publishing nothing and leaving the README badge 404ing.
+
 ## 3. E2E tests (Cypress)
 
 E2E specs drive a real browser against a real backend. They cover the happy path a


### PR DESCRIPTION
The frontend coverage badge in the README 404s — `badges-frontend` was never created.

## Cause

`ui-test.yml` grants only `contents: read`, so `publish_badge.sh` failed at push:

```
remote: Permission to frappe/gameplan.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/frappe/gameplan.git/': The requested URL returned error: 403
```

The backend badge published fine — its job declares `contents: write`. `badges-backend` exists and serves a valid SVG (`http 200`, `image/svg+xml`, "coverage: 83.7%"); `badges-frontend` returns 404.

Note the job-level `permissions:` block **replaces** the workflow-level one rather than adding to it, so the job has to spell out `pull-requests: write` as well or it loses the ability to post the test report.

## Why it was invisible

Both badge steps were `continue-on-error: true`, so the step reported **success** while publishing nothing. Nothing in the run, the summary, or the checks said the badge was stale — the only symptom was a broken image in the README.

That flag is now removed from both. These steps only run on a push to `develop`, where the suite has already passed and a red run blocks nobody, so a failed publish is worth exactly one red run to learn about. This is the same silent-failure shape as the two bugs found while building this (frontend coverage silently collecting nothing; the backend JUnit file silently unparseable), so it is worth not repeating.

## Verification

- Reproduced from the actual run log of the post-merge push to `develop` (403 above).
- Backend badge confirmed live and rendering, which proves the mechanism itself works and isolates the fault to permissions.
- After this merges, the push to `develop` should create `badges-frontend`; I will confirm the URL returns 200 rather than assume it.