### PR TITLE
Keep unread counts live, and replace refetch_resource with named events

### DIFF
--- a/frontend/src/data/notifications.ts
+++ b/frontend/src/data/notifications.ts
@@ -1,7 +1,14 @@
 import { useCall } from 'frappe-ui'
+import { onSocketEvent } from '@/socket'
 
 export let unreadNotifications = useCall({
   cacheKey: 'Unread Notifications Count',
   url: '/api/v2/method/gameplan.api.unread_notifications',
   initialData: 0,
+})
+
+// Keeps the rail badge live: the backend signals this user whenever a notification is created
+// for them or their notifications are marked read, including from another tab or device.
+onSocketEvent('gameplan:notification_count_changed', () => {
+  unreadNotifications.reload()
 })

--- a/frontend/src/data/unreadCount.ts
+++ b/frontend/src/data/unreadCount.ts
@@ -1,6 +1,8 @@
 import { useDoctype } from 'frappe-ui'
 import { GPProject } from '@/types/doctypes'
 import { reactive } from 'vue'
+import { useDebounceFn } from '@vueuse/core'
+import { onSocketEvent } from '@/socket'
 
 interface ProjectUnreadCount {
   [spaceId: string]: number
@@ -15,36 +17,68 @@ const participatingUnreadCounts = reactive<ParticipatingUnreadCount>({})
 
 // All unread-count APIs live on the GP Unread Record controller, called via runMethod so we
 // avoid hardcoded dotted module paths. Each `useDoctype` exposes ONE shared `runMethod`
-// (a single useCall instance), and concurrent calls on it race on shared request state and
-// cross-resolve. We therefore give each endpoint its own instance so they can safely overlap.
+// (a single useCall instance), so we give each endpoint its own instance and queue submissions
+// within it — see `queued` below for why overlapping on one instance is unsafe.
 const unreadCountApi = useDoctype('GP Unread Record')
 const participatingCountApi = useDoctype('GP Unread Record')
 const markReadApi = useDoctype('GP Unread Record')
 
+const submitQueues = new WeakMap<object, Promise<unknown>>()
+
+/**
+ * Run `submit` only once every earlier submission on the same API instance has settled.
+ *
+ * A single useCall instance cannot serve two calls at once. VueUse's fetch aborts the in-flight
+ * request when a second submit starts, and useCall resolves *every* submit from the same shared
+ * `data` ref — so the aborted caller resolves with whatever `data` happens to hold, which is the
+ * previous response rather than its own. Its refresh is silently dropped and a stale snapshot
+ * re-applied on top.
+ *
+ * Overlap is routine now that the server pushes: opening a discussion fires a targeted refresh
+ * from `trackVisit`'s callback at roughly the same moment the push fires a full reload, and one
+ * live signal fans out a `fetchParticipatingUnreadCount` per cached community at once — where
+ * the dropped-response effect is worst, since those calls differ only by subject and one
+ * community's count then lands under another's key.
+ *
+ * The real fix belongs in frappe-ui's useCall, which should resolve each submit with its own
+ * response; until then, one request in flight per instance keeps the counts honest.
+ */
+function queued<T>(api: object, submit: () => Promise<T>): Promise<T> {
+  const run = (submitQueues.get(api) ?? Promise.resolve()).then(submit, submit)
+  submitQueues.set(
+    api,
+    run.catch(() => {}),
+  )
+  return run
+}
+
 function loadProjectUnreadCounts(projects?: string[]) {
-  return unreadCountApi.runMethod
-    .submit({
-      method: 'get_unread_count',
-      // Autoincremented Space names can arrive on a freshly loaded document as
-      // numbers, while the whitelisted endpoint deliberately accepts list[str].
-      params: { projects: projects?.map(String) },
-    })
-    .then((data: ProjectUnreadCount) => {
-      // A full reload (no project filter) is authoritative: the backend omits spaces whose
-      // count is now zero, so clear stale positives before applying the response — otherwise
-      // a space that just dropped to zero keeps showing a phantom unread count.
-      if (!projects) {
-        for (const spaceId of Object.keys(unreadCounts)) {
-          if (!(spaceId in data)) unreadCounts[spaceId] = 0
+  return queued(unreadCountApi, () =>
+    unreadCountApi.runMethod
+      .submit({
+        method: 'get_unread_count',
+        // Autoincremented Space names can arrive on a freshly loaded document as
+        // numbers, while the whitelisted endpoint deliberately accepts list[str].
+        params: { projects: projects?.map(String) },
+      })
+      .then((data: ProjectUnreadCount | null) => {
+        const counts = data ?? {}
+        // A full reload (no project filter) is authoritative: the backend omits spaces whose
+        // count is now zero, so clear stale positives before applying the response — otherwise
+        // a space that just dropped to zero keeps showing a phantom unread count.
+        if (!projects) {
+          for (const spaceId of Object.keys(unreadCounts)) {
+            if (!(spaceId in counts)) unreadCounts[spaceId] = 0
+          }
         }
-      }
-      for (const [spaceId, count] of Object.entries(data)) {
-        // Counts cross the runMethod/JSON boundary as strings (MariaDB COUNT). Coerce to
-        // Number here so summing them (e.g. per community) adds instead of concatenating.
-        unreadCounts[spaceId] = Number(count) || 0
-      }
-      return data
-    })
+        for (const [spaceId, count] of Object.entries(counts)) {
+          // Counts cross the runMethod/JSON boundary as strings (MariaDB COUNT). Coerce to
+          // Number here so summing them (e.g. per community) adds instead of concatenating.
+          unreadCounts[spaceId] = Number(count) || 0
+        }
+        return counts
+      }),
+  )
 }
 
 // load unread count for all projects once
@@ -54,24 +88,23 @@ export function getProjectUnreadCount(spaceId: string) {
   return unreadCounts[spaceId] ?? 0
 }
 
-// Two watchers (CommunityMenu + Discussions) and the post-mark refresh all call
-// fetchParticipatingUnreadCount on the same shared runMethod instance, so their requests can
-// overlap and resolve out of order — an older response would then write a pre-mark count back
-// over a newer one. Track the latest request per team and apply only that response.
-const participatingRequestSeq: Record<string, number> = {}
-
-/** Fetch (and cache) the participating unread count for a community. */
+/**
+ * Fetch (and cache) the participating unread count for a community.
+ *
+ * Two watchers (CommunityMenu + Discussions), the post-mark refresh and the live refresh below
+ * all call this, and the live refresh fans out one call per cached community at once. Queueing
+ * keeps them from cross-resolving on the shared instance — without it, every community would
+ * end up displaying whichever count answered last.
+ */
 export function fetchParticipatingUnreadCount(team: string) {
-  const seq = (participatingRequestSeq[team] ?? 0) + 1
-  participatingRequestSeq[team] = seq
-  return participatingCountApi.runMethod
-    .submit({ method: 'get_participating_unread_count', params: { team } })
-    .then((count: number) => {
-      // A newer fetch for this team superseded us — drop this stale response.
-      if (participatingRequestSeq[team] !== seq) return participatingUnreadCounts[team] ?? 0
-      participatingUnreadCounts[team] = Number(count) || 0
-      return participatingUnreadCounts[team]
-    })
+  return queued(participatingCountApi, () =>
+    participatingCountApi.runMethod
+      .submit({ method: 'get_participating_unread_count', params: { team } })
+      .then((count: number) => {
+        participatingUnreadCounts[team] = Number(count) || 0
+        return participatingUnreadCounts[team]
+      }),
+  )
 }
 
 export function getParticipatingUnreadCount(team: string) {
@@ -126,3 +159,20 @@ export function markSpacesAsRead(spaceIds: string[]) {
 export function refreshUnreadCountForProjects(projects: string[]) {
   return loadProjectUnreadCounts(projects)
 }
+
+// The backend signals this after any create/mark-read change to GP Unread Record, so other tabs
+// (and spaces you're not currently viewing) pick up the change without a manual reload.
+// Debounced because one action fans out several signals — posting creates records for every
+// recipient and marks the thread read for the author — and each one costs a full map fetch plus
+// a request per cached community.
+onSocketEvent(
+  'gameplan:unread_counts_changed',
+  useDebounceFn(() => {
+    // Nothing awaits these; swallow failures so a dropped request doesn't surface as an
+    // unhandled rejection. The next signal (or a page load) refetches anyway.
+    Promise.allSettled([
+      loadProjectUnreadCounts(),
+      ...Object.keys(participatingUnreadCounts).map((team) => fetchParticipatingUnreadCount(team)),
+    ])
+  }, 500),
+)

--- a/frontend/src/data/users.ts
+++ b/frontend/src/data/users.ts
@@ -5,6 +5,7 @@ import { setCommunityOrder } from './communityOrder'
 import { loadQuickReactionSlots } from './reactionPreferences'
 import { setSidebarBadgeStyle, type SidebarBadgeStyle } from './sidebarPreferences'
 import { session } from './session'
+import { onSocketEvent } from '@/socket'
 
 export type EmailDigestFrequency = 'Off' | 'Weekly' | 'Fortnightly' | 'Monthly'
 export type EmailDigestDayOfWeek =
@@ -77,6 +78,14 @@ export let users = useCall<UserInfo[]>({
     }
   },
   immediate: false,
+})
+
+// A profile edit changes what everyone else renders (avatar, name, role), so the backend
+// broadcasts this to every session. Skipped until the list has actually loaded: `users` is
+// `immediate: false` and App.vue fetches it once the session is known, and reloading before
+// that would race that first fetch on the same instance.
+onSocketEvent('gameplan:users_changed', () => {
+  if (users.data) users.reload()
 })
 
 export function updateUserInfo(user: UserInfo) {

--- a/frontend/src/socket.ts
+++ b/frontend/src/socket.ts
@@ -1,10 +1,5 @@
 import { io, type Socket } from 'socket.io-client'
 import { socketio_port } from '../../../../sites/common_site_config.json'
-import { getCachedListResource, getCachedResource } from 'frappe-ui'
-
-type RefetchResourceEvent = {
-  cache_key?: string
-}
 
 /** Payload published by GP Activity on every new discussion/comment activity.
  * Mirrors gameplan/mixins/activity.py — keep field names in sync; a rename there
@@ -14,11 +9,60 @@ export type NewActivityEvent = {
   reference_name: string
 }
 
-type ReloadableResource = {
-  reload: () => void
+/**
+ * Every realtime event Gameplan's own backend publishes, and what each one carries.
+ *
+ * Mirrors gameplan/realtime.py — renaming an event means changing both sides. Each event
+ * names what changed, not what to refetch: the listener decides that, because only the
+ * client knows how it stores the data.
+ *
+ * Frappe's own events (`new_activity`, `doc_update`, ...) are not listed here. Components
+ * that want those still reach for `useSocket()` directly, since they are scoped to a
+ * document room the component subscribes to for its own lifetime.
+ */
+export type GameplanSocketEvents = {
+  'gameplan:unread_counts_changed': void
+  'gameplan:notification_count_changed': void
+  'gameplan:users_changed': void
 }
 
+type SocketEventName = keyof GameplanSocketEvents
+
+// The runtime twin of GameplanSocketEvents: `satisfies` makes TypeScript reject a name that
+// isn't in the type, and every key in the type must appear here or nothing dispatches it.
+const GAMEPLAN_SOCKET_EVENTS = [
+  'gameplan:unread_counts_changed',
+  'gameplan:notification_count_changed',
+  'gameplan:users_changed',
+] as const satisfies readonly SocketEventName[]
+
 let socket: Socket | null = null
+
+const listeners = new Map<SocketEventName, Set<(payload: any) => void>>()
+
+/**
+ * Listen for a backend event. Returns an unsubscribe function.
+ *
+ * Handlers live in this module's own registry rather than on the socket, which buys two
+ * things. Registration order does not matter: `initSocket()` runs inside `setupApp()`, long
+ * after module-level code in `data/*.ts` has run, so a bare `socket.on()` there would attach
+ * to nothing. And unsubscribing removes exactly one handler — `socket.off(event)` drops every
+ * listener for that event, so two components listening to the same one clobber each other.
+ */
+export function onSocketEvent<K extends SocketEventName>(
+  event: K,
+  handler: (payload: GameplanSocketEvents[K]) => void,
+) {
+  let handlers = listeners.get(event)
+  if (!handlers) {
+    handlers = new Set()
+    listeners.set(event, handlers)
+  }
+  handlers.add(handler)
+  return () => {
+    handlers.delete(handler)
+  }
+}
 
 export function initSocket() {
   let host = window.location.hostname
@@ -31,14 +75,20 @@ export function initSocket() {
     withCredentials: true,
     reconnectionAttempts: 5,
   })
-  socket.on('refetch_resource', (data: RefetchResourceEvent) => {
-    if (data.cache_key) {
-      let resource = getCachedResource(data.cache_key) || getCachedListResource(data.cache_key)
-      if (isReloadableResource(resource)) {
-        resource.reload()
-      }
-    }
-  })
+  // Attach one dispatcher per known event. socket.io keeps these across reconnects, so unlike
+  // document rooms (see subscribeToDoc) they never need re-attaching.
+  for (const event of GAMEPLAN_SOCKET_EVENTS) {
+    socket.on(event, (payload: never) => {
+      listeners.get(event)?.forEach((handler) => {
+        try {
+          handler(payload)
+        } catch (error) {
+          // One bad listener must not skip the rest, nor bubble into socket.io's handler.
+          console.error(`Listener for "${event}" failed`, error)
+        }
+      })
+    })
+  }
   return socket
 }
 
@@ -63,13 +113,4 @@ export function subscribeToDoc(doctype: string, name: string) {
     socket?.off('connect', subscribe)
     socket?.emit('doc_unsubscribe', doctype, name)
   }
-}
-
-function isReloadableResource(resource: unknown): resource is ReloadableResource {
-  return Boolean(
-    resource &&
-      typeof resource === 'object' &&
-      'reload' in resource &&
-      typeof resource.reload === 'function',
-  )
 }

--- a/gameplan/__init__.py
+++ b/gameplan/__init__.py
@@ -29,9 +29,3 @@ def is_admin(user=None):
 		return True
 	roles = frappe.get_roles(user)
 	return "Gameplan Admin" in roles or "System Manager" in roles
-
-
-def refetch_resource(cache_key: str | list, user=None):
-	frappe.publish_realtime(
-		"refetch_resource", {"cache_key": cache_key}, user=user or frappe.session.user, after_commit=True
-	)

--- a/gameplan/api.py
+++ b/gameplan/api.py
@@ -8,6 +8,7 @@ from frappe.query_builder.functions import Count
 from frappe.utils import split_emails, validate_email_address
 
 import gameplan
+from gameplan.realtime import notify_notification_count_changed
 from gameplan.utils import validate_type
 
 
@@ -214,7 +215,7 @@ def mark_all_notifications_as_read():
 		.set(Notification.read, 1)
 		.where((Notification.to_user == frappe.session.user) & (Notification.read == 0))
 	).run()
-	gameplan.refetch_resource("Unread Notifications Count", user=frappe.session.user)
+	notify_notification_count_changed(frappe.session.user)
 
 
 @frappe.whitelist(methods=["POST"])

--- a/gameplan/gameplan/doctype/gp_discussion_visit/gp_discussion_visit.py
+++ b/gameplan/gameplan/doctype/gp_discussion_visit/gp_discussion_visit.py
@@ -4,16 +4,9 @@
 import frappe
 from frappe.model.document import Document
 
-import gameplan
-
 
 class GPDiscussionVisit(Document):
-	def after_insert(self):
-		gameplan.refetch_resource("UnreadItems", user=self.user)
-
-	def on_change(self):
-		if self.has_value_changed("last_visit"):
-			gameplan.refetch_resource("UnreadItems", user=self.user)
+	pass
 
 
 def on_doctype_update():

--- a/gameplan/gameplan/doctype/gp_notification/gp_notification.py
+++ b/gameplan/gameplan/doctype/gp_notification/gp_notification.py
@@ -4,12 +4,12 @@
 import frappe
 from frappe.model.document import Document
 
-import gameplan
+from gameplan.realtime import notify_notification_count_changed
 
 
 class GPNotification(Document):
 	def after_insert(self):
-		gameplan.refetch_resource("Unread Notifications Count", user=self.to_user)
+		notify_notification_count_changed(self.to_user)
 
 	@staticmethod
 	def clear_notifications(discussion=None, comment=None, poll=None, task=None, user=None):
@@ -31,4 +31,4 @@ class GPNotification(Document):
 			query = query.where(Notification[field] == value)
 		query.run()
 
-		gameplan.refetch_resource("Unread Notifications Count", user=user)
+		notify_notification_count_changed(user)

--- a/gameplan/gameplan/doctype/gp_unread_record/gp_unread_record.py
+++ b/gameplan/gameplan/doctype/gp_unread_record/gp_unread_record.py
@@ -6,6 +6,9 @@ from datetime import timedelta
 import frappe
 from frappe.model.document import Document, bulk_insert
 
+import gameplan
+from gameplan.realtime import notify_unread_counts_changed
+
 
 class GPUnreadRecord(Document):
 	@staticmethod
@@ -35,6 +38,7 @@ class GPUnreadRecord(Document):
 			)
 
 		GPUnreadRecord._bulk_create_unread_records(records)
+		GPUnreadRecord._notify_unread_counts_changed(record.user for record in records)
 
 	@staticmethod
 	def create_unread_records_for_comment(comment_doc):
@@ -69,6 +73,7 @@ class GPUnreadRecord(Document):
 			)
 
 		GPUnreadRecord._bulk_create_unread_records(records)
+		GPUnreadRecord._notify_unread_counts_changed(record.user for record in records)
 
 	@staticmethod
 	def delete_unread_records_for_discussion(discussion: str):
@@ -129,7 +134,9 @@ class GPUnreadRecord(Document):
 				& (UnreadRecord.is_unread == 1)
 			)
 		)
-		return query.run(as_dict=1)
+		result = query.run(as_dict=1)
+		GPUnreadRecord._notify_unread_counts_changed(user)
+		return result
 
 	@staticmethod
 	def mark_discussion_as_unread_for_user(discussion, user):
@@ -148,13 +155,14 @@ class GPUnreadRecord(Document):
 			frappe.db.set_value(
 				"GP Unread Record", discussion_level_record, "is_unread", 1, update_modified=False
 			)
+			GPUnreadRecord._notify_unread_counts_changed(user)
 			return discussion_level_record
 
 		project = frappe.db.get_value("GP Discussion", discussion, "project")
 		if not project:
 			return
 
-		return (
+		name = (
 			frappe.get_doc(
 				{
 					"doctype": "GP Unread Record",
@@ -168,6 +176,8 @@ class GPUnreadRecord(Document):
 			.insert(ignore_permissions=True)
 			.name
 		)
+		GPUnreadRecord._notify_unread_counts_changed(user)
+		return name
 
 	@staticmethod
 	def mark_all_as_read_for_project(project, user):
@@ -183,7 +193,9 @@ class GPUnreadRecord(Document):
 				& (UnreadRecord.is_unread == 1)
 			)
 		)
-		return query.run(as_dict=1)
+		result = query.run(as_dict=1)
+		GPUnreadRecord._notify_unread_counts_changed(user)
+		return result
 
 	@staticmethod
 	def mark_all_as_read_for_team(team, user, before=None):
@@ -218,6 +230,7 @@ class GPUnreadRecord(Document):
 		(frappe.qb.update(UnreadRecord).set(UnreadRecord.is_unread, 0).where(condition)).run()
 
 		GPUnreadRecord.update_project_visits_for_mark_all_read(projects, user, cutoff)
+		GPUnreadRecord._notify_unread_counts_changed(user)
 		return projects
 
 	@staticmethod
@@ -392,8 +405,6 @@ class GPUnreadRecord(Document):
 	@staticmethod
 	def _get_project_members(project_name):
 		"""Get all users who have access to the project"""
-		import gameplan
-
 		project = frappe.db.get_value("GP Project", project_name, ["name", "is_private"], as_dict=True)
 
 		all_users = set()
@@ -423,6 +434,16 @@ class GPUnreadRecord(Document):
 		all_users.update(guest_users)
 
 		return list(all_users)
+
+	@staticmethod
+	def _notify_unread_counts_changed(users):
+		"""Signal each user's open tabs that their unread counts are stale.
+
+		Without this, `frontend/src/data/unreadCount.ts` only refreshes after this tab's own
+		mark-as-read/visit calls, so another tab (or a space getting a new unread discussion
+		while you're looking elsewhere) stays stale until a manual reload.
+		"""
+		notify_unread_counts_changed(users)
 
 	@staticmethod
 	def _bulk_create_unread_records(records):

--- a/gameplan/gameplan/doctype/gp_user_profile/gp_user_profile.py
+++ b/gameplan/gameplan/doctype/gp_user_profile/gp_user_profile.py
@@ -10,10 +10,10 @@ from frappe.model.naming import append_number_if_name_exists
 from frappe.query_builder.functions import Count
 from frappe.website.utils import cleanup_page_name
 
-import gameplan
 from gameplan.api import get_user_info, require_admin
 from gameplan.extends.client import check_permissions
 from gameplan.mixins.attachments import HasAttachments
+from gameplan.realtime import notify_users_changed
 
 PROFILE_BENTO_CARD_TYPES = {"Card", "Blank"}
 PROFILE_BENTO_CARD_SIZES = {"1x1", "1x2", "2x1", "2x2", "4x1", "4x2"}
@@ -48,7 +48,7 @@ class GPUserProfile(HasAttachments, Document):
 		self.image_background_color = None
 		self.original_image = None
 		self.save()
-		gameplan.refetch_resource("Users")
+		notify_users_changed()
 
 	@frappe.whitelist(methods=["POST"])
 	def change_user_role(self, role):

--- a/gameplan/realtime.py
+++ b/gameplan/realtime.py
@@ -15,7 +15,13 @@ never announces a change that did not happen. Frappe dedupes identical (event, m
 room) triples within a request, so publishing the same event twice for one user emits once.
 """
 
-from frappe.realtime import publish_to_user, publish_to_website
+from frappe import realtime
+
+# `realtime.publish_realtime` rather than the newer named helpers (`publish_to_user`,
+# `publish_to_website`): those only exist on frappe develop, and Gameplan is also tested
+# against v16, where importing them fails at module load. Going through the module object
+# instead of importing the function also keeps `patch("frappe.realtime.publish_realtime")`
+# effective in tests, since the lookup happens at call time.
 
 # `gameplan:` namespaces these against frappe's own realtime events (`list_update`,
 # `doc_update`, ...) and against other apps sharing the site.
@@ -29,12 +35,12 @@ def notify_unread_counts_changed(users: str | list[str]):
 	if isinstance(users, str):
 		users = [users]
 	for user in {user for user in users if user}:
-		publish_to_user(user, UNREAD_COUNTS_CHANGED, after_commit=True)
+		realtime.publish_realtime(UNREAD_COUNTS_CHANGED, user=user, after_commit=True)
 
 
 def notify_notification_count_changed(user: str):
 	"""Tell one user that their unread notification count moved."""
-	publish_to_user(user, NOTIFICATION_COUNT_CHANGED, after_commit=True)
+	realtime.publish_realtime(NOTIFICATION_COUNT_CHANGED, user=user, after_commit=True)
 
 
 def notify_users_changed():
@@ -48,4 +54,4 @@ def notify_users_changed():
 	and Gameplan members are Website Users, so a plain roomless broadcast would reach
 	nobody here. Every socket joins the website room.
 	"""
-	publish_to_website(USERS_CHANGED, after_commit=True)
+	realtime.publish_realtime(USERS_CHANGED, room=realtime.get_website_room(), after_commit=True)

--- a/gameplan/realtime.py
+++ b/gameplan/realtime.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2025, Frappe Technologies Pvt Ltd and contributors
+# For license information, please see license.txt
+
+"""Realtime events Gameplan publishes to the browser.
+
+One function per event, and each event names *what changed* rather than what the client
+should refetch — the client owns that decision. The previous `refetch_resource` helper
+inverted this: it named a frappe-ui `createResource` cache key, so the server had to know
+how the client stored its data. When the frontend moved to `useCall`/`useList` those keys
+stopped resolving and every push became a silent no-op, with nothing to fail loudly.
+
+Event names are mirrored by `GameplanSocketEvents` in frontend/src/socket.ts; renaming one
+means changing both sides. Everything is published `after_commit` so a rolled-back request
+never announces a change that did not happen. Frappe dedupes identical (event, message,
+room) triples within a request, so publishing the same event twice for one user emits once.
+"""
+
+from frappe.realtime import publish_to_user, publish_to_website
+
+# `gameplan:` namespaces these against frappe's own realtime events (`list_update`,
+# `doc_update`, ...) and against other apps sharing the site.
+UNREAD_COUNTS_CHANGED = "gameplan:unread_counts_changed"
+NOTIFICATION_COUNT_CHANGED = "gameplan:notification_count_changed"
+USERS_CHANGED = "gameplan:users_changed"
+
+
+def notify_unread_counts_changed(users: str | list[str]):
+	"""Tell each given user that their space and community unread counts moved."""
+	if isinstance(users, str):
+		users = [users]
+	for user in {user for user in users if user}:
+		publish_to_user(user, UNREAD_COUNTS_CHANGED, after_commit=True)
+
+
+def notify_notification_count_changed(user: str):
+	"""Tell one user that their unread notification count moved."""
+	publish_to_user(user, NOTIFICATION_COUNT_CHANGED, after_commit=True)
+
+
+def notify_users_changed():
+	"""Tell every open session that the shared user list changed (name, avatar, role).
+
+	Broadcast rather than per-user on purpose: a profile edit changes what *other* people
+	render, so telling only the editor — as the old `refetch_resource("Users")` call did,
+	since it defaulted to the session user — leaves every other session stale.
+
+	The *website* room, not the site room. Only System Users join the site room ("all"),
+	and Gameplan members are Website Users, so a plain roomless broadcast would reach
+	nobody here. Every socket joins the website room.
+	"""
+	publish_to_website(USERS_CHANGED, after_commit=True)

--- a/gameplan/tests/features/test_realtime_events.py
+++ b/gameplan/tests/features/test_realtime_events.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2026, Frappe Technologies Pvt Ltd and Contributors
+# See license.txt
+
+"""The events Gameplan publishes so open tabs update themselves.
+
+These replace `refetch_resource`, which named a frappe-ui `createResource` cache key and
+asked the client to reload whatever sat under it. Once the frontend moved to `useCall`,
+those keys resolved to nothing and every push became a silent no-op — the notification
+badge and the shared user list stopped updating live and no test noticed, because the
+old tests only checked that a cache key had been published.
+
+So these assert at `frappe.realtime.publish_realtime`: the event name and the room it
+lands in, which is what determines whether a browser actually hears it.
+"""
+
+from unittest.mock import patch
+
+import frappe
+
+from gameplan.realtime import (
+	NOTIFICATION_COUNT_CHANGED,
+	UNREAD_COUNTS_CHANGED,
+	USERS_CHANGED,
+	notify_unread_counts_changed,
+	notify_users_changed,
+)
+from gameplan.tests.base import GameplanTestCase
+
+
+def events_named(publish_realtime, event):
+	return [call for call in publish_realtime.call_args_list if call.args and call.args[0] == event]
+
+
+class TestRealtimeEvents(GameplanTestCase):
+	def test_a_new_notification_tells_its_recipient(self):
+		with patch("frappe.realtime.publish_realtime") as publish_realtime:
+			frappe.get_doc(
+				doctype="GP Notification",
+				to_user=self.second_member.name,
+				from_user=self.member.name,
+				type="Mention",
+				message="Hello",
+			).insert(ignore_permissions=True)
+
+		[call] = events_named(publish_realtime, NOTIFICATION_COUNT_CHANGED)
+		self.assertEqual(call.kwargs.get("user"), self.second_member.name)
+
+	def test_clearing_notifications_tells_that_user(self):
+		from gameplan.gameplan.doctype.gp_notification.gp_notification import GPNotification
+
+		with patch("frappe.realtime.publish_realtime") as publish_realtime:
+			GPNotification.clear_notifications(user=self.member.name)
+
+		[call] = events_named(publish_realtime, NOTIFICATION_COUNT_CHANGED)
+		self.assertEqual(call.kwargs.get("user"), self.member.name)
+
+	def test_the_user_list_change_reaches_website_users_not_just_desk_users(self):
+		"""Gameplan members are Website Users, and only System Users join the site room.
+
+		A roomless `publish_realtime` lands in the site room ("all"), so it would reach
+		nobody here — the same silent-no-op shape this whole module exists to prevent.
+		"""
+		with patch("frappe.realtime.publish_realtime") as publish_realtime:
+			notify_users_changed()
+
+		[call] = events_named(publish_realtime, USERS_CHANGED)
+		self.assertEqual(call.kwargs.get("room"), frappe.realtime.get_website_room())
+		self.assertIsNone(call.kwargs.get("user"))
+
+	def test_every_event_is_held_until_the_transaction_commits(self):
+		"""A rolled-back request must not tell the browser about a change that never landed."""
+		with patch("frappe.realtime.publish_realtime") as publish_realtime:
+			notify_unread_counts_changed(self.member.name)
+			notify_users_changed()
+
+		for call in publish_realtime.call_args_list:
+			self.assertTrue(call.kwargs.get("after_commit"), f"{call.args[0]} is not after_commit")
+
+	def test_one_call_notifies_each_distinct_user_once(self):
+		users = [self.member.name, self.second_member.name, self.member.name, None, ""]
+
+		with patch("frappe.realtime.publish_realtime") as publish_realtime:
+			notify_unread_counts_changed(users)
+
+		notified = sorted(
+			call.kwargs.get("user") for call in events_named(publish_realtime, UNREAD_COUNTS_CHANGED)
+		)
+		self.assertEqual(notified, sorted([self.member.name, self.second_member.name]))

--- a/gameplan/tests/features/test_unread.py
+++ b/gameplan/tests/features/test_unread.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2025, Frappe Technologies Pvt Ltd and Contributors
 # See license.txt
 
+from unittest.mock import patch
+
 import frappe
 
 from gameplan.gameplan.doctype.gp_unread_record.api import (
@@ -8,8 +10,23 @@ from gameplan.gameplan.doctype.gp_unread_record.api import (
 	get_unread_count,
 )
 from gameplan.gameplan.doctype.gp_unread_record.gp_unread_record import GPUnreadRecord
+from gameplan.realtime import UNREAD_COUNTS_CHANGED
 from gameplan.tests.base import GameplanTestCase
 from gameplan.tests.fixtures import create_community, create_discussion, create_member, create_space
+
+
+def unread_count_events(publish_realtime):
+	"""The users told their unread counts changed, in the order they were told.
+
+	Asserts at `frappe.realtime.publish_realtime` — the wire boundary every named publisher
+	funnels into — rather than at Gameplan's own helper, so the event name and target room
+	that actually ship are covered. Posting also publishes `new_activity`, hence the filter.
+	"""
+	return [
+		call.kwargs.get("user")
+		for call in publish_realtime.call_args_list
+		if call.args and call.args[0] == UNREAD_COUNTS_CHANGED
+	]
 
 
 class TestUnread(GameplanTestCase):
@@ -313,6 +330,63 @@ class TestUnread(GameplanTestCase):
 
 		self.assertEqual(frappe.db.get_value("GP Unread Record", record, "project"), str(target_project.name))
 
+	def test_mark_discussion_as_read_notifies_that_user_over_realtime(self):
+		"""Without this push, another open tab's sidebar/rail unread dot stays stale until
+		a manual reload — see the `gameplan:unread_counts_changed` listener in
+		frontend/src/data/unreadCount.ts."""
+		suffix = frappe.generate_hash(length=8)
+		user = create_member(f"rt-read-member-{suffix}@example.com", "RT Read Member")
+		team = create_community(f"RT Read Team {suffix}")
+		project = create_space(f"RT Read Space {suffix}", team.name)
+		discussion = create_discussion(f"RT Read Discussion {suffix}", project.name)
+		create_unread_record(user.name, discussion.name, project.name)
+
+		with patch("frappe.realtime.publish_realtime") as publish_realtime:
+			GPUnreadRecord.mark_discussion_as_read_for_user(discussion.name, user.name)
+
+		self.assertEqual(unread_count_events(publish_realtime), [user.name])
+
+	def test_mark_discussion_as_unread_notifies_that_user_over_realtime(self):
+		suffix = frappe.generate_hash(length=8)
+		user = create_member(f"rt-unread-member-{suffix}@example.com", "RT Unread Member")
+		team = create_community(f"RT Unread Team {suffix}")
+		project = create_space(f"RT Unread Space {suffix}", team.name)
+		discussion = create_discussion(f"RT Unread Discussion {suffix}", project.name)
+		create_unread_record(user.name, discussion.name, project.name)
+		GPUnreadRecord.mark_discussion_as_read_for_user(discussion.name, user.name)
+
+		with patch("frappe.realtime.publish_realtime") as publish_realtime:
+			GPUnreadRecord.mark_discussion_as_unread_for_user(discussion.name, user.name)
+
+		self.assertEqual(unread_count_events(publish_realtime), [user.name])
+
+	def test_mark_all_as_read_for_project_notifies_that_user_over_realtime(self):
+		suffix = frappe.generate_hash(length=8)
+		user = create_member(f"rt-project-member-{suffix}@example.com", "RT Project Member")
+		team = create_community(f"RT Project Team {suffix}")
+		project = create_space(f"RT Project Space {suffix}", team.name)
+		discussion = create_discussion(f"RT Project Discussion {suffix}", project.name)
+		create_unread_record(user.name, discussion.name, project.name)
+
+		with patch("frappe.realtime.publish_realtime") as publish_realtime:
+			GPUnreadRecord.mark_all_as_read_for_project(project.name, user.name)
+
+		self.assertEqual(unread_count_events(publish_realtime), [user.name])
+
+	def test_mark_all_as_read_for_team_notifies_that_user_over_realtime(self):
+		suffix = frappe.generate_hash(length=8)
+		user = create_member(f"rt-team-member-{suffix}@example.com", "RT Team Member")
+		team = create_community(f"RT Team Team {suffix}")
+		project = create_space(f"RT Team Space {suffix}", team.name)
+		discussion = create_discussion(f"RT Team Discussion {suffix}", project.name)
+		create_unread_record(user.name, discussion.name, project.name)
+
+		frappe.set_user(user.name)
+		with patch("frappe.realtime.publish_realtime") as publish_realtime:
+			GPUnreadRecord.mark_all_as_read_for_team(team.name, user.name)
+
+		self.assertEqual(unread_count_events(publish_realtime), [user.name])
+
 
 class TestUnreadRecordLifecycle(GameplanTestCase):
 	"""Who gets an unread record, who does not, and what the counters then report.
@@ -504,6 +578,32 @@ class TestUnreadRecordLifecycle(GameplanTestCase):
 		# outside the space sees it at all.
 		self.assertEqual(GPUnreadRecord.get_participating_unread_count(self.reader.name), 0)
 		self.assertEqual(GPUnreadRecord.get_participating_unread_count(self.outsider.name), 0)
+
+	def test_posting_a_discussion_notifies_every_recipient_over_realtime(self):
+		"""Without this push, a space's unread dot only updates for tabs that happen to
+		reload — see the `gameplan:unread_counts_changed` listener in
+		frontend/src/data/unreadCount.ts. (The space's implicit Administrator member,
+		auto-added by GPProject.before_insert, is also notified here since these fixtures
+		are built as Administrator; that's incidental to this test, not the behavior
+		under test.)"""
+		with patch("frappe.realtime.publish_realtime") as publish_realtime:
+			self.post_discussion(self.member)
+
+		notified_users = set(unread_count_events(publish_realtime))
+		self.assertTrue({self.second_member.name, self.reader.name} <= notified_users)
+		self.assertNotIn(self.member.name, notified_users)
+
+	def test_posting_a_comment_notifies_every_recipient_over_realtime(self):
+		discussion = self.post_discussion(self.member)
+
+		with patch("frappe.realtime.publish_realtime") as publish_realtime:
+			self.post_comment(self.second_member, discussion)
+
+		# The thread author (member) and the reader are notified of the new unread comment;
+		# the commenter (second_member) is notified too, but via a different path — posting
+		# also runs track_visit(), which marks the thread read for the replier themselves.
+		notified_users = set(unread_count_events(publish_realtime))
+		self.assertTrue({self.member.name, self.reader.name, self.second_member.name} <= notified_users)
 
 	def test_the_participating_count_endpoint_answers_for_the_session_user(self):
 		theirs = self.post_discussion(self.second_member, "Theirs")


### PR DESCRIPTION
## What this does

Makes unread badges update by themselves, and replaces the mechanism we used for
"tell the browser something changed".

Before, the unread count in your sidebar only refreshed when *you* did something in
*that* tab. A second tab, or a space you were not looking at, stayed wrong until you
reloaded. Now the server tells your browser when your unread state changes.

## The old mechanism had already stopped working

While wiring this up I found that `refetch_resource` — the helper we used for these
pushes — has been doing nothing for a while.

It worked by naming a frappe-ui `createResource` cache key and asking the browser to
reload whatever was stored under it. But `getCachedResource` only knows about resources
made with `createResource`. The frontend moved to `useCall` some time ago, which stores
things elsewhere. So the lookup found nothing and the push quietly did nothing. No error,
no warning.

Two things were broken by this and nobody noticed:

- the notification badge did not update until you reloaded the page
- other people's name and avatar changes did not show up until you reloaded

I checked both in a browser before and after. Both work now.

## What replaced it

Each thing that changes now sends a named event saying **what changed**, and the browser
side decides what to refetch:

| Event | Sent when |
| --- | --- |
| `gameplan:unread_counts_changed` | unread records are created or marked read |
| `gameplan:notification_count_changed` | a notification is created or cleared |
| `gameplan:users_changed` | someone edits their profile |

Backend side lives in `gameplan/realtime.py`, one function per event. Frontend side is
`onSocketEvent` in `socket.ts`. The list of events is fixed on both sides, so a typo or a
stale name is now a build error instead of silence.

## One bug worth calling out

The user-list event goes to everyone, and the obvious way to broadcast in frappe reaches
only Desk users. Gameplan members are website users, so that version would have reached
nobody — exactly the silent failure this PR is removing. It sends to the website room
instead, and a test pins that.

## Also in here

Requests for unread counts are now queued so two of them never overlap. They share one
request slot, and when they overlap the loser drops its refresh and puts a stale count
back. That did not matter much while only your own clicks triggered a fetch. It matters
once the server can trigger one at any moment, and the live refresh asks for every
community you have open at once.

## Testing

- 464 backend tests pass. 11 are new: 6 covering the unread pushes, 5 covering the events
  and the room they land in.
- Checked all three events in a browser by triggering each from the command line with the
  app open and untouched, and watching the UI update on its own.

## Known gaps, not addressed here

- The unread push fires on every discussion open, even when the discussion was already
  read and nothing changed.
- Posting in a public space sends one message per user on the site. Fine for a small site,
  heavy for a large one.
- Deleting or moving a discussion changes other people's counts but sends nothing.
