### PR TITLE
Mutation testing: harness, nightly CI, and the bugs it found

### DIFF
--- a/.github/workflows/mutation-nightly.yml
+++ b/.github/workflows/mutation-nightly.yml
@@ -1,0 +1,372 @@
+name: Mutation Nightly
+
+# A BUDGETED, RESUMABLE GRIND.
+#
+# The full corpus is about 2 hours of mutant evaluation (measured: 1139 mutants, mean
+# 6.8s, p90 10.9s) plus a baseline pass per module, which is too close to the Actions
+# ceiling to run in one job alongside provisioning. Instead this runs for a fixed slice of
+# wall clock each night, resuming from a journal carried between runs in the Actions
+# cache, and works through the target map least-recently-measured first. A few nights
+# cover everything; then it starts again on whatever changed or produced no verdict.
+#
+# Two rejected alternatives, recorded so they are not re-proposed: a diff-only nightly is
+# silent on quiet days (and quiet days are when regressions land unnoticed), and a
+# rotating-module nightly lets a regression in one module wait two weeks to surface.
+#
+# The budget is enforced INSIDE the harness (--budget-seconds), never by killing the job.
+# The harness mutates source files in place; a process killed between "apply" and
+# "restore" leaves a mutant on disk. timeout-minutes below is therefore a backstop set
+# well above the budget, not the mechanism.
+
+on:
+  schedule:
+    - cron: "0 2 * * *"
+  workflow_dispatch:
+    inputs:
+      budget-seconds:
+        description: "Seconds of mutation work before stopping cleanly"
+        required: false
+        default: "2700"
+
+permissions:
+  contents: read
+
+# Two nightlies at once would mutate the same source tree in two checkouts and, worse,
+# race to save the same journal cache - the loser's night of work is simply lost.
+concurrency:
+  group: mutation-nightly
+  cancel-in-progress: false
+
+env:
+  SITE: gameplan.test
+  BENCH: /home/runner/frappe-bench
+  # Rolling cache key. See the restore/save steps for why it is not a fixed string.
+  #
+  # v2, not v1: v1 caches were taken of the WHOLE .mutation/ directory and may contain
+  # crash-recovery sidecars from an interrupted run. Restoring one of those onto a fresh
+  # runner wedges the campaign permanently (see the restore step), so the lineage is
+  # abandoned rather than inherited. Bump this again if the journal format ever breaks.
+  #
+  # Cost of the bump, so it is not mistaken for a fault: the first few nights rebuild the
+  # corpus from scratch and exit 4 (stopped on budget) until they catch up. Verdicts from
+  # a v1 journal would have been re-measured anyway - they predate the test fingerprint,
+  # so nothing records which suite produced them.
+  JOURNAL_CACHE_PREFIX: mutation-journal-v2-
+
+jobs:
+  grind:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'frappe' }}
+    # Budget (45m) + provisioning (~15m) + reporting, with room to spare so the runner
+    # never hard-kills the harness mid-mutant.
+    timeout-minutes: 90
+
+    name: Mutation campaign (budgeted)
+
+    steps:
+      - name: Clone
+        uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.14"
+
+      # frappe v17-dev's engine check rejects Node 20, and --skip-assets does not skip
+      # the `yarn install --check-files` that runs with it.
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 24
+          check-latest: true
+
+      - name: Add to Hosts
+        run: echo "127.0.0.1 ${SITE}" | sudo tee -a /etc/hosts
+
+      - name: Cache pip
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/*requirements.txt', '**/pyproject.toml', '**/setup.py') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+            ${{ runner.os }}-
+
+      # install_sqlite.sh creates the site fresh and BUILDS THE FRONTEND ASSETS, waiting
+      # for the build before it returns. Both matter here:
+      #   * never `bench migrate` a SQLite site - frappe/patches/v16_0/hash_oauth_bearer_tokens.py
+      #     has no sqlite branch and dies;
+      #   * without built assets the email-digest tests error, that module's baseline goes
+      #     red, and the harness skips the whole module while the job still looks like it
+      #     ran. That trap cost a module's entire score once already, so the assets are
+      #     asserted below and a red baseline fails this job loudly.
+      - name: Install Dependencies
+        run: |
+          bash "${GITHUB_WORKSPACE}/.github/helper/install_dependencies.sh"
+          bash "${GITHUB_WORKSPACE}/.github/helper/install_sqlite.sh"
+
+      - name: Assert the bench is fit to mutate
+        run: |
+          manifest="${BENCH}/sites/assets/assets.json"
+          if [ ! -s "${manifest}" ]; then
+            echo "::error::${manifest} is missing or empty - bench build did not finish."
+            echo "Tests that render a page would error, the baseline would go red, and the"
+            echo "harness would skip those modules while still reporting a completed run."
+            exit 1
+          fi
+          # The harness refuses to mutate a file it could not restore with `git checkout --`,
+          # so a non-git copy of the app makes every target "dirty" and the campaign never
+          # starts. Fail here, where the reason is obvious.
+          if ! git -C "${BENCH}/apps/gameplan" rev-parse --is-inside-work-tree > /dev/null 2>&1; then
+            echo "::error::${BENCH}/apps/gameplan is not a git checkout; the harness cannot"
+            echo "guarantee it could undo a mutant after a hard crash and will refuse to run."
+            exit 1
+          fi
+          mkdir -p "${BENCH}/apps/gameplan/.mutation"
+
+      # JOURNAL PERSISTENCE - the crux of the whole design.
+      #
+      # .mutation/ is gitignored and Actions runners are ephemeral, so without this the
+      # nightly restarts from zero every night and never gets past the first module.
+      #
+      # WHAT IS CACHED: the two journal files, NEVER the directory.
+      #
+      # .mutation/ also holds backup/<slug>.orig + .json (crash-recovery sidecars) and
+      # campaign.lock. Both are bound to one working tree and one process, and caching
+      # them transplants them onto the next runner, where they are lies: the sidecar
+      # describes a crash in a tree that no longer exists, and the lock names a pid on
+      # another machine. The harness then does exactly what it should - it refuses to
+      # touch a file whose contents match neither the backup nor the recorded mutant -
+      # and the campaign exits 1 every night, on a poison it re-caches every night,
+      # failing every pull request too, until someone purges the cache by hand.
+      #
+      # Only the journals are legitimately transferable: they are append-only records of
+      # completed work, meaningful on any machine. Everything else stays behind.
+      #
+      # The key is rolling: it embeds run_id/run_attempt, so the exact key NEVER matches an
+      # existing cache and the restore always falls through to `restore-keys`, which does a
+      # prefix match and returns the MOST RECENTLY CREATED cache under that prefix - i.e.
+      # last night's journal. The save step then writes a brand-new entry under today's
+      # unique key. That is what makes the cache round-trip.
+      #
+      # The obvious alternative - one fixed key with actions/cache@v4 - is the classic trap:
+      # after the first night the key hits, and a hit means the post-save step does nothing,
+      # so the journal is frozen at night one for ever.
+      #
+      # First run of all: no cache under the prefix, restore is a no-op, and the harness
+      # starts the corpus from scratch. Nothing here needs to know which case it is in,
+      # which is why there is no `if:` on any of it.
+      #
+      # THE PATH LIST IS PART OF THE CACHE'S IDENTITY. actions/cache derives an entry's
+      # version from the raw `path` input, so a restore only matches entries saved under
+      # the same list, byte for byte. mutation-pr.yml restores from this same lineage:
+      # add a file here, or reorder these two lines, without making the identical edit
+      # there, and every pull request silently misses the seed journal and measures from
+      # scratch - green, and indistinguishable from a legitimate first run. Pinned by
+      # test_mutation_ci.py::CachedStateTest.
+      - name: Restore the mutation journal
+        id: journal-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ${{ env.BENCH }}/apps/gameplan/.mutation/journal.jsonl
+            ${{ env.BENCH }}/apps/gameplan/.mutation/verify.jsonl
+          key: ${{ env.JOURNAL_CACHE_PREFIX }}${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            ${{ env.JOURNAL_CACHE_PREFIX }}
+
+      - name: Snapshot what the journal restored
+        run: |
+          journal="${BENCH}/apps/gameplan/.mutation/journal.jsonl"
+          # Guarantees the save step below always has a file to save, whatever happens to
+          # the campaign - including a job cancelled mid-mutant.
+          touch "${journal}"
+          # The "before" snapshot is what `report --new-since` subtracts, so the summary can
+          # show what THIS night decided (new mutants AND changed verdicts) instead of
+          # republishing a 1000-line corpus report that is identical to yesterday's.
+          cp "${journal}" "${RUNNER_TEMP}/before.jsonl"
+          if [ -s "${journal}" ]; then
+            echo "Resuming from $(wc -l < "${journal}") journalled mutant(s)."
+            echo "Restored from cache key: ${{ steps.journal-restore.outputs.cache-matched-key }}"
+          else
+            echo "No journal restored - this run starts the corpus from scratch."
+          fi
+
+      # `set +e` because every exit code here is meaningful and the gate step below is what
+      # decides which of them are failures. In particular exit 4 (stopped on budget) is the
+      # expected outcome most nights and must not end the job.
+      - name: Run the budgeted campaign
+        id: campaign
+        working-directory: /home/runner/frappe-bench
+        env:
+          BUDGET_SECONDS: ${{ github.event.inputs.budget-seconds || '2700' }}
+        run: |
+          set +e
+          ./env/bin/python -m gameplan.tests.mutation run \
+            --tier all \
+            --site "${SITE}" \
+            --timeout 300 \
+            --budget-seconds "${BUDGET_SECONDS}" \
+            --yes
+          status=$?
+          set -e
+          echo "status=${status}" >> "$GITHUB_OUTPUT"
+          echo "budget=${BUDGET_SECONDS}" >> "$GITHUB_OUTPUT"
+          echo "Campaign exited ${status}."
+
+      # Immediately after the run and unconditionally: a night's work that is not cached is
+      # a night's work repeated. Even an aborted campaign journalled real verdicts, and its
+      # non-verdicts are retryable by construction, so saving is always correct.
+      # Skipped only if the campaign never ran at all (provisioning failed), in which case
+      # there is nothing to save and a failing save would just mask the real error.
+      - name: Save the mutation journal
+        if: ${{ always() && steps.campaign.conclusion != 'skipped' }}
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ${{ env.BENCH }}/apps/gameplan/.mutation/journal.jsonl
+            ${{ env.BENCH }}/apps/gameplan/.mutation/verify.jsonl
+          key: ${{ env.JOURNAL_CACHE_PREFIX }}${{ github.run_id }}-${{ github.run_attempt }}
+
+      # --prune-stale everywhere: the journal is cumulative and mutant keys are
+      # content-derived, so a refactor leaves verdicts about statements that no longer
+      # exist. Kept, they inflate the published percentage and print survivor line numbers
+      # into code that has moved.
+      - name: Publish the report
+        if: ${{ always() }}
+        id: report
+        working-directory: /home/runner/frappe-bench
+        run: |
+          set +e
+          ./env/bin/python -m gameplan.tests.mutation report --format json --prune-stale \
+            > "${RUNNER_TEMP}/report.json"
+          json_status=$?
+          ./env/bin/python -m gameplan.tests.mutation report --format md --prune-stale \
+            > "${RUNNER_TEMP}/report.md"
+          ./env/bin/python -m gameplan.tests.mutation report --format md --prune-stale \
+            --new-since "${RUNNER_TEMP}/before.jsonl" > "${RUNNER_TEMP}/tonight.md"
+          tonight_status=$?
+          # What the night DID, which is not the same question as what it decided: a night
+          # that re-measures 400 mutants and confirms every verdict decides nothing, and
+          # would otherwise read exactly like a night whose campaign never started.
+          work="$(./env/bin/python -m gameplan.tests.mutation work \
+            --since "${RUNNER_TEMP}/before.jsonl")"
+          set -e
+          echo "status=${json_status}" >> "$GITHUB_OUTPUT"
+          {
+            echo "## Mutation nightly"
+            echo
+            echo "Campaign exit code: \`${{ steps.campaign.outputs.status }}\` (4 = stopped on budget, work remains)"
+            echo "Budget: \`${{ steps.campaign.outputs.budget }}\`s"
+            echo
+            if [ "${json_status}" -eq 0 ]; then
+              ./env/bin/python -c "import json,sys; s=json.load(open(sys.argv[1])); o=s['overall']; print('**Corpus: %s** - %d/%d killed, %d with no verdict, across %d module(s).' % ('n/a' if o['score'] is None else '%.0f%%' % (o['score'] * 100), o['killed'], o['scored'], o['unscored'], len(s['modules'])))" "${RUNNER_TEMP}/report.json"
+            else
+              echo "> The cumulative report produced no score (exit ${json_status}). See the job log."
+            fi
+            echo
+            echo "### Decided tonight"
+            echo
+            echo "New mutants and CHANGED verdicts only. A mutant that was killed yesterday and"
+            echo "survives today appears here - that is the regression this job exists to catch."
+            echo
+            echo "${work}"
+            echo
+            # The rendered table is printed on EVERY path, including the ones below that
+            # add an interpretation. It is the only place a module that measured nothing is
+            # named, so an arm that discards it hides exactly the thing worth reading.
+            case "${tonight_status}" in
+              0) ;;
+              5)
+                echo "No new mutants and no verdict changed. Whatever ran tonight agreed with"
+                echo "the journal, so there is no regression to look at."
+                echo
+                ;;
+              3)
+                echo "> Every mutant decided tonight produced a NON-verdict (exit 3): they timed"
+                echo "> out, or the site never got far enough to judge them. Degraded, not a result."
+                echo
+                ;;
+              *)
+                echo "> The \"decided tonight\" report itself failed (exit ${tonight_status}). See the job log."
+                echo
+                ;;
+            esac
+            cat "${RUNNER_TEMP}/tonight.md" || true
+            echo
+            echo "The full cumulative report (every survivor) is in the \`mutation-journal\` artifact."
+          } >> "$GITHUB_STEP_SUMMARY"
+          cat "${RUNNER_TEMP}/report.md" || true
+
+      - name: Upload the journal
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: mutation-journal
+          path: |
+            ${{ env.BENCH }}/apps/gameplan/.mutation/journal.jsonl
+            ${{ runner.temp }}/report.md
+            ${{ runner.temp }}/report.json
+            ${{ runner.temp }}/tonight.md
+          if-no-files-found: warn
+          retention-days: 14
+
+      # WHAT MAKES THIS JOB RED
+      #
+      # Only a broken signal. A low mutation score is a fact about the test suite that a
+      # human reads off the summary above; failing on it would either be ignored or gamed,
+      # and it is deliberately not gated (no --fail-under anywhere in this workflow).
+      #
+      # Red:  campaign exit 1 (aborted, or refused to start)
+      #       campaign exit 2 (bad invocation - this workflow is misconfigured)
+      #       campaign exit 3 (nothing measured at all)
+      #       report non-zero (no scoreable result in the journal)
+      #       any module skipped (red baseline, missing source, unbackupable file): it has
+      #       no current score, and a silently unmeasured module is what this job is for
+      # Green: campaign exit 0 (corpus complete or nothing pending)
+      #        campaign exit 4 (stopped on budget - the design working as intended)
+      - name: Gate on the mutation signal
+        if: ${{ always() }}
+        working-directory: /home/runner/frappe-bench
+        run: |
+          failed=0
+
+          case "${{ steps.campaign.outputs.status }}" in
+            0) echo "Campaign completed everything that was pending." ;;
+            4) echo "Campaign stopped on budget with work remaining. Resuming tomorrow." ;;
+            # Exit 1 covers every "refused to run or gave up" path, and this gate cannot
+            # tell them apart - so it names them instead of asserting one.
+            1) echo "::error::Campaign exited 1: it aborted or refused to start. Read the campaign step's log for which - the no-verdict circuit breaker, an orphaned backup from a crashed run, a lock held by another process, or uncommitted changes in a target file."; failed=1 ;;
+            2) echo "::error::Campaign refused to start (bad arguments). This workflow needs fixing."; failed=1 ;;
+            # Exit 3 has three causes and this gate cannot tell them apart either, so it
+            # names them rather than asserting one. Budget-before-baseline became a real
+            # cause once a test-file edit started invalidating a whole module at a time.
+            3) echo "::error::Campaign measured nothing. Read the campaign step's log for which - every targeted module was skipped (red baseline, missing source, or an unbackupable file), or the budget expired before a single baseline pass finished. This is not a score of 0%."; failed=1 ;;
+            *) echo "::error::Campaign exited with unexpected status '${{ steps.campaign.outputs.status }}'."; failed=1 ;;
+          esac
+
+          if [ "${{ steps.report.outputs.status }}" != "0" ]; then
+            echo "::error::The report has no scoreable result (exit ${{ steps.report.outputs.status }})."
+            failed=1
+          else
+            # A skipped module drops out of the corpus ENTIRELY while the run still looks
+            # successful, so it has to be surfaced from the report rather than from the
+            # exit code (which only fails when EVERY module was skipped).
+            skipped=$(./env/bin/python -c "import json,sys; s=json.load(open(sys.argv[1]))['skipped_modules']; print('\n'.join(f'{m} [{i[\"kind\"]}]: {i[\"reason\"]}' for m, i in sorted(s.items())))" "${RUNNER_TEMP}/report.json")
+            if [ -n "${skipped}" ]; then
+              echo "::error::These modules measured nothing and have no current score:"
+              echo "${skipped}"
+              failed=1
+            fi
+          fi
+
+          exit "${failed}"
+
+      - name: Stop server
+        if: ${{ always() }}
+        run: |
+          ps -ef | grep "[f]rappe serve" | awk '{print $2}' | xargs kill -s SIGINT || true
+          sleep 5
+
+      - name: Show bench output
+        if: ${{ always() }}
+        run: cat ~/frappe-bench/bench_start.log || true

--- a/.github/workflows/mutation-pr.yml
+++ b/.github/workflows/mutation-pr.yml
@@ -1,0 +1,369 @@
+name: Mutation (PR)
+
+# DIFF-SCOPED MUTATION TESTING.
+#
+# Mutates only the source files this pull request changed that are also mutation targets,
+# on a tight budget so it stays a PR-speed signal.
+#
+# IT DOES NOT GATE ON A SCORE, ON PURPOSE.
+# A percentage threshold on a five-minute sample of one file is a number that gets gamed
+# (add a test that kills a trivial mutant) or ignored (re-run until it passes). What is
+# genuinely useful is the list of survivors in code the author just wrote, so that goes in
+# the job summary where they will read it while reviewing. The only things that turn this
+# job red are a broken signal - the harness aborted, was misconfigured, or measured
+# nothing at all when it had work to do.
+#
+# AND IT NEVER CLAIMS MORE THAN IT MEASURED. "The report produced no score" has three
+# causes with three different meanings, and the summary below distinguishes all three; a
+# job that collapses them tells the author their pull request changed no mutable behaviour
+# when what actually happened is that its one measurement timed out.
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mutation-pr-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  SITE: gameplan.test
+  BENCH: /home/runner/frappe-bench
+  # Read-only here: the nightly owns this cache, and a PR must never write to it.
+  JOURNAL_CACHE_PREFIX: mutation-journal-v2-
+
+jobs:
+  # Answers "is there anything here to mutate?" on a bare checkout in well under a minute.
+  # It has to run before provisioning, or every frontend-only pull request pays fifteen
+  # minutes of bench setup to be told there was nothing to do. gameplan/tests/__init__.py
+  # imports frappe, so the mapping cannot be reached through the package on a bare
+  # checkout; scope.py is written to run as a plain script for exactly this step.
+  scope:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'frappe' }}
+    timeout-minutes: 10
+    name: Diff scope
+
+    outputs:
+      targets: ${{ steps.scope.outputs.targets }}
+      has-targets: ${{ steps.scope.outputs.has-targets }}
+
+    steps:
+      - name: Clone
+        uses: actions/checkout@v3
+        with:
+          # The merge-base below needs both sides of the pull request.
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.14"
+
+      - name: Map the diff to mutation targets
+        id: scope
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          merge_base="$(git merge-base "${BASE_SHA}" "${HEAD_SHA}" || echo "${BASE_SHA}")"
+          git diff --name-only "${merge_base}" "${HEAD_SHA}" > "${RUNNER_TEMP}/changed.txt"
+          echo "Changed files:"
+          cat "${RUNNER_TEMP}/changed.txt"
+
+          python gameplan/tests/mutation/scope.py \
+            --changed-files-from "${RUNNER_TEMP}/changed.txt" > "${RUNNER_TEMP}/targets.txt"
+
+          targets="$(tr '\n' ' ' < "${RUNNER_TEMP}/targets.txt")"
+          echo "targets=${targets}" >> "$GITHUB_OUTPUT"
+
+          if [ -s "${RUNNER_TEMP}/targets.txt" ]; then
+            echo "has-targets=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has-targets=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Say so when there is nothing to mutate
+        if: ${{ steps.scope.outputs.has-targets == 'false' }}
+        run: |
+          {
+            echo "## Mutation (PR)"
+            echo
+            echo "No mutation targets in this diff - nothing measured, nothing claimed."
+            echo
+            echo "This job mutates a source file only when the pull request changes it (or one"
+            echo "of its mapped test modules) AND it appears in \`TIER1\`/\`TIER2\` in"
+            echo "\`gameplan/tests/mutation/config.py\`."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  mutate:
+    needs: scope
+    if: ${{ github.repository_owner == 'frappe' && needs.scope.outputs.has-targets == 'true' }}
+    runs-on: ubuntu-latest
+    # A 10-minute budget plus ~15 minutes of provisioning, with headroom so the runner
+    # never hard-kills the harness mid-mutant and strands a mutated file.
+    timeout-minutes: 45
+
+    name: Mutate changed targets
+
+    steps:
+      - name: Clone
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.14"
+
+      # frappe v17-dev's engine check rejects Node 20, and --skip-assets does not skip
+      # the `yarn install --check-files` that runs with it.
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 24
+          check-latest: true
+
+      - name: Add to Hosts
+        run: echo "127.0.0.1 ${SITE}" | sudo tee -a /etc/hosts
+
+      - name: Cache pip
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/*requirements.txt', '**/pyproject.toml', '**/setup.py') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+            ${{ runner.os }}-
+
+      # Creates the SQLite site fresh (never `bench migrate` one - the v16 oauth-token
+      # patch has no sqlite branch) and builds the frontend assets, waiting for them.
+      - name: Install Dependencies
+        run: |
+          bash "${GITHUB_WORKSPACE}/.github/helper/install_dependencies.sh"
+          bash "${GITHUB_WORKSPACE}/.github/helper/install_sqlite.sh"
+
+      # Without assets, any test that renders a page errors, the module's baseline goes
+      # red, and the harness skips it while the job still looks like it ran.
+      - name: Assert the bench is fit to mutate
+        run: |
+          manifest="${BENCH}/sites/assets/assets.json"
+          if [ ! -s "${manifest}" ]; then
+            echo "::error::${manifest} is missing or empty - bench build did not finish."
+            exit 1
+          fi
+          # A non-git copy of the app makes every target look unrecoverable and the harness
+          # refuses to start. Fail here, where the reason is obvious.
+          if ! git -C "${BENCH}/apps/gameplan" rev-parse --is-inside-work-tree > /dev/null 2>&1; then
+            echo "::error::${BENCH}/apps/gameplan is not a git checkout; the harness will refuse to run."
+            exit 1
+          fi
+          mkdir -p "${BENCH}/apps/gameplan/.mutation"
+
+      # Read-only restore of the nightly's journal; there is no save step in this workflow.
+      # A miss (first ever nightly, evicted cache, fork pull request) is fine: the run then
+      # measures from scratch within its budget and the report says how much it covered.
+      #
+      # Only the journal files are restored - never backup/ or campaign.lock, which are
+      # bound to the machine that wrote them. See the nightly's restore step for what
+      # happens when they are not.
+      #
+      # Seeding is safe without any "did the tests change?" guard: the harness stores the
+      # fingerprint of the test files behind every verdict and re-measures the ones whose
+      # tests moved (scope.test_fingerprint), so a pull request that edits an assertion
+      # invalidates exactly the verdicts that assertion produced.
+      #
+      # `key` is deliberately outside JOURNAL_CACHE_PREFIX. It never matches (this workflow
+      # writes no cache), and keeping it out of the nightly's namespace means adding a save
+      # step here later cannot silently hand a PR's journal to the nightly's prefix match.
+      #
+      # The `path` list, by contrast, is part of the cache entry's IDENTITY and must stay
+      # byte-identical to the nightly's. actions/cache derives an entry's version from the
+      # raw path strings, so a list that differs by one line - or by the order of these
+      # two - matches nothing the nightly ever saved.
+      # The failure is silent: this job just measures from scratch and prints the same
+      # "No seed journal" line a legitimate first run prints. Pinned by
+      # test_mutation_ci.py::CachedStateTest.
+      - name: Restore the nightly journal
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ${{ env.BENCH }}/apps/gameplan/.mutation/journal.jsonl
+            ${{ env.BENCH }}/apps/gameplan/.mutation/verify.jsonl
+          key: mutation-pr-lookup-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            ${{ env.JOURNAL_CACHE_PREFIX }}
+
+      - name: Recompute the diff and snapshot the seed journal
+        id: prepare
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          merge_base="$(git merge-base "${BASE_SHA}" "${HEAD_SHA}" || echo "${BASE_SHA}")"
+          git diff --name-only "${merge_base}" "${HEAD_SHA}" > "${RUNNER_TEMP}/changed.txt"
+
+          journal="${BENCH}/apps/gameplan/.mutation/journal.jsonl"
+          touch "${journal}"
+          # The "before" snapshot is what `report --new-since` subtracts, so the summary
+          # shows what THIS run decided rather than the whole restored corpus.
+          cp "${journal}" "${RUNNER_TEMP}/before.jsonl"
+          if [ -s "${journal}" ]; then
+            echo "Seeded with $(wc -l < "${journal}") journalled mutant(s) from the nightly."
+          else
+            echo "No seed journal; measuring from scratch."
+          fi
+
+      # --timeout well under --budget-seconds, deliberately. When they are equal, ONE hung
+      # test module consumes the entire allowance, and the author gets either a red check
+      # they cannot act on or a green one that measured nothing. The budget also has to
+      # cover a baseline pass: permissions.py maps to four test modules, so its baseline
+      # alone is four sequential bench invocations before the first mutant runs.
+      - name: Mutate the changed targets
+        id: campaign
+        working-directory: /home/runner/frappe-bench
+        run: |
+          set +e
+          ./env/bin/python -m gameplan.tests.mutation run \
+            --tier all \
+            --site "${SITE}" \
+            --timeout 150 \
+            --budget-seconds 600 \
+            --changed-files-from "${RUNNER_TEMP}/changed.txt" \
+            --yes
+          status=$?
+          set -e
+          echo "status=${status}" >> "$GITHUB_OUTPUT"
+          echo "Campaign exited ${status}."
+
+      - name: Publish the report
+        if: ${{ always() }}
+        id: report
+        working-directory: /home/runner/frappe-bench
+        run: |
+          set +e
+          ./env/bin/python -m gameplan.tests.mutation report \
+            --format md --prune-stale \
+            --new-since "${RUNNER_TEMP}/before.jsonl" \
+            > "${RUNNER_TEMP}/report.md"
+          md_status=$?
+          ./env/bin/python -m gameplan.tests.mutation report \
+            --format json --prune-stale \
+            --new-since "${RUNNER_TEMP}/before.jsonl" \
+            > "${RUNNER_TEMP}/report.json"
+          json_status=$?
+          # What this run DID. A pull request that edits a mapped test file invalidates
+          # every verdict of the module behind it and re-measures as many as the budget
+          # allows; if they all come back unchanged the report is empty, and without this
+          # line the summary cannot tell that apart from a run that measured nothing.
+          work="$(./env/bin/python -m gameplan.tests.mutation work \
+            --since "${RUNNER_TEMP}/before.jsonl")"
+          set -e
+          echo "status=${md_status}" >> "$GITHUB_OUTPUT"
+          echo "json-status=${json_status}" >> "$GITHUB_OUTPUT"
+          {
+            echo "## Mutation (PR)"
+            echo
+            echo "Targets: \`${{ needs.scope.outputs.targets }}\`"
+            echo
+            echo "${work}"
+            echo
+            # Three different reasons for a non-zero status, three different statements.
+            # Only the first of them is a claim about the pull request.
+            case "${md_status}" in
+              0)
+                echo "Survivors below are mutations of code this pull request touched that the"
+                echo "test suite did not notice. This job never fails on the score - treat them"
+                echo "as review notes."
+                echo
+                cat "${RUNNER_TEMP}/report.md"
+                ;;
+              # Bounded to the mutants this run actually reached. The claim it replaces
+              # generalised from the sample to the whole diff - a statement about every
+              # mutant in the changed targets, which a budgeted run that re-measured 20 of
+              # 273 has not earned. The work line above says how many that was; the budget
+              # note below says whether it ran out.
+              5)
+                echo "No new or changed verdicts: every mutant this run reached already had the"
+                echo "same verdict in the nightly journal."
+                ;;
+              3)
+                echo "**No verdict.** Mutants were run, and not one of them produced a result -"
+                echo "they timed out, or the site never got far enough to judge them. Nothing is"
+                echo "claimed about this pull request; the table below is what was attempted."
+                echo
+                cat "${RUNNER_TEMP}/report.md"
+                ;;
+              *)
+                echo "**The report itself failed** (exit ${md_status}). No measurement was"
+                echo "published and nothing is claimed about this pull request. See the job log."
+                ;;
+            esac
+            if [ "${{ steps.campaign.outputs.status }}" = "4" ]; then
+              echo
+              echo "> Stopped on its 10-minute budget with mutants still pending, so this is a"
+              echo "> sample rather than a full measurement of the changed files."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+          cat "${RUNNER_TEMP}/report.md" || true
+
+      # Red only for a broken signal, never for a low score - see the header comment.
+      - name: Gate on the mutation signal
+        if: ${{ always() }}
+        working-directory: /home/runner/frappe-bench
+        run: |
+          failed=0
+
+          case "${{ steps.campaign.outputs.status }}" in
+            0) echo "Nothing left pending in the changed targets." ;;
+            4) echo "Stopped on budget: a partial but real sample. Not a failure." ;;
+            1) echo "::error::Exited 1: aborted or refused to start. Read the campaign step's log for which - the no-verdict circuit breaker, an orphaned backup, a held lock, or uncommitted changes in a target."; failed=1 ;;
+            2) echo "::error::Refused to start (bad arguments). This workflow needs fixing."; failed=1 ;;
+            3) echo "::error::Measured nothing despite having targets. Either the site is broken, a baseline is red, or the budget was too small to finish one baseline pass. This is not a score of 0%."; failed=1 ;;
+            *) echo "::error::Unexpected status '${{ steps.campaign.outputs.status }}'."; failed=1 ;;
+          esac
+
+          # The gate the nightly has and this job was missing. A pull request that changes
+          # two targets, one of which is skipped on a red baseline, still exits 0 from the
+          # campaign: the other module measured fine. Without this, the summary shows a
+          # clean score for one file and says nothing at all about the other.
+          #
+          # Read from the JSON whatever the report's exit code was: the report renders
+          # before it gates, on every path including an empty result set, so the summary is
+          # always parseable and a failure to parse it is a real failure.
+          #
+          # Restricted to THIS pull request's targets. The report is over the whole seeded
+          # journal, so a module the nightly is currently unable to measure appears in it
+          # too - and blaming a pull request for a module it never touched is how a gate
+          # gets ignored. The nightly owns the corpus-wide version of this check.
+          if ! skipped=$(./env/bin/python -c "import json,sys; s=json.load(open(sys.argv[1]))['skipped_modules']; t=set(sys.argv[2].split()); print('\n'.join(f'{m} [{i[\"kind\"]}]: {i[\"reason\"]}' for m, i in sorted(s.items()) if m in t))" "${RUNNER_TEMP}/report.json" "${{ needs.scope.outputs.targets }}"); then
+            echo "::error::The report produced no readable summary (exit ${{ steps.report.outputs.json-status }})."
+            failed=1
+          elif [ -n "${skipped}" ]; then
+            echo "::error::These changed modules measured nothing and have no current score:"
+            echo "${skipped}"
+            failed=1
+          fi
+
+          # Report exit 3 is "mutants ran and not one produced a verdict" - a broken signal,
+          # and red in the nightly for the identical condition. Exit 5 ("nothing was due")
+          # is not: it is the ordinary outcome of a pull request whose targets were already
+          # settled, and the summary claims nothing on it.
+          if [ "${{ steps.report.outputs.json-status }}" = "3" ]; then
+            echo "::error::Every mutant this run evaluated produced a non-verdict (timeouts, or a site that never judged them). Nothing was measured; this is not a score of 0%."
+            failed=1
+          fi
+
+          exit "${failed}"
+
+      - name: Stop server
+        if: ${{ always() }}
+        run: |
+          ps -ef | grep "[f]rappe serve" | awk '{print $2}' | xargs kill -s SIGINT || true
+          sleep 5
+
+      - name: Show bench output
+        if: ${{ always() }}
+        run: cat ~/frappe-bench/bench_start.log || true

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ gameplan/www/g.html
 build
 frontend/components.d.ts
 sites/
+.mutation/

--- a/HANDOFF-mutation.md
+++ b/HANDOFF-mutation.md
@@ -1,0 +1,411 @@
+# Mutation testing — handoff
+
+**Written:** 2026-07-29
+**Updated:** 2026-07-31 — harness fixed, corpus re-measured honestly, nightly CI landed, ten product bugs closed.
+**Status:** harness trustworthy, CI running, seven modules re-measured with zero no-verdict rows.
+
+---
+
+## 1. Environment
+
+| Thing | Value |
+|---|---|
+| Bench | `~/frappe-bench` (a **second, SQLite-only** bench built for this work) |
+| Site | `gp-sqlite.test`, admin password `admin`, `allow_tests: true` |
+| frappe | `netchampfaris/frappe` @ `fix/sqlite-last-query` |
+| gameplan | branch `feat/mutation-testing` |
+| Harness | `gameplan/tests/mutation/` |
+| Journal | `.mutation/journal.jsonl` |
+| Node | 24.x via nvm, bench via pipx |
+
+`AGENTS.md` names `gameplan-demo.test`; that site does **not** exist in this bench. Use
+`gp-sqlite.test` here.
+
+**The frappe branch is not optional.** It carries `fix(sqlite): publish last_query on the SQLite
+driver`. Stock develop will likely fail on SQLite.
+
+Every session needs:
+
+```bash
+export NVM_DIR=$HOME/.nvm; . $NVM_DIR/nvm.sh; nvm use 24
+export PATH=$HOME/.local/bin:$PATH
+cd ~/frappe-bench
+```
+
+---
+
+## 2. How the harness works
+
+Two stages, by design:
+
+- **Stage 1 (`run`)** — mutates a source file in place, runs *only that module's own tests*, restores
+  the file. Answers: *does this module's own test file pin its behaviour?*
+- **Stage 2 (`verify`)** — re-runs each stage-1 survivor against the *full* suite, to catch survivors
+  that some other module's tests kill.
+
+```bash
+env/bin/python -m gameplan.tests.mutation run    [--tier 1|2|all] [--module PATH] [--site NAME]
+                                                 [--timeout N] [--limit N] [--budget-seconds N]
+                                                 [--order round-robin] [--journal PATH] [--yes]
+env/bin/python -m gameplan.tests.mutation report [--journal PATH] [--format text|md|json]
+env/bin/python -m gameplan.tests.mutation verify [--journal PATH] [--site NAME] [--timeout N]
+env/bin/python -m gameplan.tests.mutation restore   # recover source files after a hard crash
+```
+
+Run it with the bench python from `~/frappe-bench`. Execution is **serial on purpose**: every worker
+shares one source tree, so concurrent in-place mutation would corrupt other workers' runs.
+
+### The status vocabulary is the load-bearing part
+
+`config.py` defines one source of truth and two aliases of it:
+
+```
+NO_VERDICT_STATUSES & KILLED_STATUSES == frozenset()   never counted as a kill
+NO_VERDICT_STATUSES <= NON_SCORING_STATUSES            never reaches the score
+NO_VERDICT_STATUSES <= RETRYABLE_STATUSES              never cached as done
+```
+
+Anything that is *not* a judgement made by the test suite — a timeout, a wedged site, a mutant that
+broke the import, a run that died mid-flight — belongs in `NO_VERDICT_STATUSES`. Adding a status
+anywhere else is how the original inflation bug happened (§3). The three relations above are
+asserted by `gameplan/tests/platform/test_mutation_classification.py`; if you add a status, that test
+tells you where it belongs.
+
+Exit codes: `0` ok, `1` aborted, `2` usage, `3` nothing measured, `4` budget exhausted. `4` is
+**green** — stopping on budget is the intended nightly outcome. `3` is not: it means the run burned
+its budget without landing a single verdict.
+
+---
+
+## 3. The harness was inflating its own score
+
+Every number in this document's earlier drafts came from a harness that counted infrastructure
+failures as kills. Timeouts, wedged sites, any subprocess output containing the substring
+`ImportError`, and mid-run deaths were all recorded as permanent, non-retryable **kills** — the most
+favourable verdict, cached forever, never retried. The circuit breaker that was supposed to catch a
+run going bad watched statuses the code never wrote, so it could not fire.
+
+Fixed in `79e5ba98` (15 defects). "No verdict from the suite" is now its own class: never scored,
+always retried, and it trips the breaker after `MAX_CONSECUTIVE_NO_VERDICT`.
+
+**Consequence: every number measured before `79e5ba98` is an upper bound of unknown tightness.**
+Do not retype a table into this file — regenerate it:
+
+```bash
+env/bin/python -m gameplan.tests.mutation report --format md
+```
+
+### Re-measured under the fixed harness
+
+Five modules, 485 mutants, **zero no-verdict rows** — every mutant got a real verdict from the
+suite, so these are honest stage-1 floors rather than low-denominator artefacts.
+
+| Module | Mutants | Killed | Score | Old figure |
+|---|---|---|---|---|
+| `permissions.py` | 273 | 171 | 63% | 44% |
+| `gp_discussion/api.py` | 74 | 65 | 88% | 82% |
+| `gp_poll.py` | 54 | 45 | 83% | 87% |
+| `gp_project.py` | 46 | 30 | 65% | 42% |
+| `mixins/reactions.py` | 38 | 32 | 84% | 81% |
+
+Three things the deltas hide, and none of them should be dropped when quoting the numbers:
+
+- **The denominators changed for four of five modules**, so the percentages are not like-for-like.
+  `mutators.py` gained new mutator kinds in the same branch, and three source files changed.
+- **`gp_poll` did not regress.** It dropped because the fix *added* code: 9 new mutants. On the 45
+  mutants common to both runs the score went *up* (89% vs 87%), and the one old survivor that
+  disappeared is exactly the boundary comparison the fix replaced.
+- **`gp_project` 42% → 65% is about half real.** The genuine gain is in `get_unread_count`. But
+  deleting `as_dict` and `get_meta_tags` took 8 never-killed survivors out of the denominator.
+  Deleting untested code raises a mutation score without testing anything — watch for this, it is
+  the easiest way to fake progress here.
+
+And one negative result worth keeping: **`permissions.py` did not move.** Its verdict set is
+identical to the pre-branch run, function by function and status by status. The 235 lines of tests
+added to its two mapped test files killed **zero** additional mutants. The 44% → 63% jump is
+entirely the harness getting honest.
+
+After the coverage round, two modules were re-measured again: `mixins/reactions.py` reached
+**100% (38/38)** and `gp_project.py` **83% (38/46)**, both with zero no-verdict rows.
+
+### The prediction that failed
+
+Seven `ignore_permissions=True → False` mutants survived across `gp_project.py` and
+`reactions.py`. The reasoning was sound as far as it went — *a surviving mutant on a security flag
+is the harness asking whether the flag does anything* — and following it found a real problem: four
+per-user doctypes were not scoped to their user, so their rows were reachable through the generic
+document and list routes regardless of whose they were (§5).
+
+The prediction that followed was that fixing those permissions would make the mutants killable.
+**It was measured, and it was wrong: zero of the six in `gp_project.py` died.** Those call sites
+only ever write the *caller's own* row — `track_visit` and `mark_all_as_read` both build it from
+`frappe.session.user` — so the new hook permits them either way. What the hooks close is the
+neighbouring surface where the row belongs to somebody else, which those lines never touch.
+
+Two things to take from this. The mutants were a good *pointer* and a bad *test*: they told you
+where to look and could not tell you whether the fix worked, and only a re-measure separated those.
+And the same re-measure caught the fix having missed `GP Pinned Project`, a doctype of exactly the
+same shape — including a new survivor of the same kind in the `archive()` line this branch had just
+rewritten. Predict what a change will do to the score, then go and check; the gap between the two is
+where the information is.
+
+Two things about the numbers that were already wrong before that, and are worth knowing as a
+cautionary tale: the first table grouped by *basename*, silently merging the two files named
+`api.py`, and it claimed `mixins/reactions.py` was 100% when the journal said 59%. `reactions.py`
+was then dropped from the work list on the strength of that wrong number — and it turned out to hold
+a real product bug (§5, notification bug).
+
+**Read stage-1 scores as a floor, not a verdict.** They mean "not caught by this module's own test
+file", which is weaker than "not caught by anything".
+
+---
+
+## 4. Coverage gaps closed
+
+### Digest login links — `fd92a2ef`
+
+`gameplan/email_digest.py:144` — `open_digest_preferences` is `@frappe.whitelist(allow_guest=True)`
+and calls `frappe.local.login_manager.login_as(user)`. Its second gate,
+`is_valid_digest_login_link`, had **0 of 15 mutants killed**: every branch could be inverted
+silently, including "expired link accepted" and "disabled user accepted".
+
+This was never a live vulnerability — `verify_request()`'s HMAC check is the primary defence and
+nobody can forge a link without the site secret. What it meant is that the defence-in-depth layer
+had nothing holding it in place: a refactor could delete the expiry or `enabled` check and the whole
+suite would stay green.
+
+`TestDigestLoginLink` in `gameplan/tests/features/test_email_digest.py` closes it — 12 tests, all 23
+digest-link mutants dead.
+
+Two of those tests need explaining, because the obvious version of each does not kill its mutant:
+
+- **`assertIs(result, False)`, not `assertFalse`.** The `return-none` mutator turns `return False`
+  into `return None`, and `assertFalse(None)` passes. Three mutants hinge on this (L517, L521, L525).
+  (The commit message for `fd92a2ef` says six; three is correct.)
+- **The `or -> and` mutant needs the clock stubbed.** Under the mutant, a missing `expires` falls
+  through to `get_datetime(None) < now_datetime()` — "now" compared against a "now" sampled
+  microseconds later — so it still returns False *by accident* and survives a plain assertion. The
+  test patches `gameplan.email_digest.now_datetime` and asserts it is **never called**: a missing
+  field must be rejected on its own merits, before the clock is consulted. That is the real
+  invariant, and it happens to be what kills the mutant.
+
+### The rest — `8d6eda90`
+
+Coverage across six backend modules, plus the harness's own first tests
+(`gameplan/tests/platform/test_mutation_*.py` — classification, safety, mutators, report, cli, ci).
+The harness had none before; it was measuring the codebase while being unmeasured itself.
+
+Suite went 545 → 1067 tests over this branch.
+
+---
+
+## 5. Product bugs found by triage
+
+Triaging survivors turned up real defects, not just missing assertions. That is the argument for
+this whole exercise: a survivor is a question about the code, and sometimes the answer is that the
+code is wrong. Details in the commits; the notable shapes:
+
+- **`get_unread_count` could not run on SQLite at all** — `query1 + query2` renders a parenthesised
+  compound `UNION`, which SQLite rejects. It only looked fine because the empty case short-circuits
+  first.
+- **`get_joined_spaces` returned duplicates** — one query plucked the id as an `int`, the other as a
+  `str`, so `{33, "33"}` has two elements and `set()` deduped nothing.
+- **`merge_with_project` did not check the merge target** — the v2 route checks write on the source
+  only, and `validate_rename=False` skipped the framework's "you need write permission on the target
+  to merge" check. A user who could manage one Space could merge it into a Space they had no rights
+  to.
+- **Poll close boundary disagreed between two modules** — at the exact instant of `stopped_at` the
+  feed hid a poll the doctype would still accept a vote on.
+- **Withdrawing a reaction re-lit the post owner's bell** — `notify_reactions` used
+  `len(previous) == len(self)` as a proxy for "someone reacted". Removal changes the length too, so
+  it notified again; and an emoji *swap* keeps the length equal, so a genuine new reaction notified
+  nobody.
+- **Client-supplied `order_by` with no allow-list** — an arbitrary field reached the query builder,
+  and a three-token value made the tuple unpack raise, i.e. a 500 on a whitelisted endpoint.
+
+Three of these (merge permission, poll boundary, reaction notification) were deliberately left
+**un-tested** by triage, because the only test that kills the mutant is one that pins the bug. When
+a survivor is telling you the code is wrong, write the fix, not the assertion.
+
+Two more turned up in the second pass, and both are worth understanding as *shapes* rather than as
+individual bugs:
+
+- **Cross-user state was readable and writable by anyone.** `GP Notification`, `GP Project Visit`
+  and `GP Discussion Visit` granted Member and Guest read/write/create with `if_owner` unset and had
+  no permission hooks, so any signed-in user could read, enumerate and overwrite anyone else's
+  notifications, visit history and read-state through the generic `/api/v2` document route. What
+  pointed at it was seven surviving `ignore_permissions=True → False` mutants: **a surviving mutant
+  on a security flag is the harness asking whether the flag does anything**, and here it did not —
+  the role already held everything the flag could have been suppressing. Fixed with query-condition
+  and `has_permission` hooks in `per_user_state.py`, not `if_owner`, which is actively wrong here
+  because a notification's `owner` is whoever *triggered* it.
+- **`archive()` orphaned other users' pins**, regenerating the exact invalid state that an existing
+  cleanup patch was written to fix.
+
+Both were found by reading the line a survivor pointed at, not by the mutant itself proving them.
+That is the honest description of what this technique does: it does not find bugs, it tells you
+which lines nobody has ever checked, and a surprising number of those turn out to be wrong.
+
+### And two that did not survive scrutiny
+
+Reported by triage, then disproved on re-derivation. Both are recorded because the *reason* they
+were wrong generalises:
+
+- **"Guests can enumerate every Community on the site."** Does not reproduce. The report was based
+  on `frappe.get_all`, which defaults to `ignore_permissions=True` and is not a route any client can
+  reach. Every user-facing door — `frappe.get_list`, `frappe.client.get_list`, and the
+  `get_list_query` path — filters correctly. It was a coverage gap, not a leak.
+- **"`content_has_permission`'s trailing `return True` is unreachable."** It is reachable and
+  load-bearing: `frappe.permissions.get_doc_permissions` calls the hook with `ptype=None` to build
+  the whole permission dict, and returning False there collapses it to `{None: 0}`.
+
+Before acting on any claim that something is dead or leaking, reproduce it through a route a client
+can actually take. `get_all` and `get_list` differ in exactly the way that matters.
+
+---
+
+## 6. CI — `2d12798e`
+
+Two jobs.
+
+**`.github/workflows/mutation-nightly.yml`** — cron, `--budget-seconds 2700` (~45 min), resuming
+from a cached journal and rotating least-recently-measured modules first, so the corpus is covered
+over several nights rather than one ~2h job pinned against the Actions ceiling. `timeout-minutes: 90`
+is a backstop only: the budget is enforced *inside* the harness, between mutants, never mid-mutant —
+a SIGKILL at the wrong moment is exactly what the restore guard exists to prevent. Gated on
+`github.repository_owner == 'frappe'` so forks do not run it.
+
+**`.github/workflows/mutation-pr.yml`** — mutates only the targets the diff touches and reports into
+`$GITHUB_STEP_SUMMARY` rather than gating on a score. A percentage threshold on a five-minute sample
+gets gamed or ignored; the useful artefact is the list of survivors in code the author just wrote.
+
+Two flaws that adversarial review caught before merge, both worth remembering because they are the
+same class of mistake:
+
+- **Never cache the `.mutation/` directory — only the journal files.** Caching the directory
+  transplanted crash sidecars and the campaign lock onto the next runner. A cancelled run left them
+  behind, an `always()` save cached them, and the next night's fresh clone refused to start. Self-
+  sustaining, and red on every PR too, under a gate message blaming the circuit breaker.
+- **Mutant identity is derived from source, so nothing invalidated a verdict when the *tests*
+  changed.** Deleting an assertion would never be re-measured; the nightly would look green while
+  doing less work every night, blind to the one regression it exists to catch. Verdicts now carry a
+  fingerprint of the test modules that produced them — including the shared helpers in
+  `tests/base.py` and `tests/fixtures.py` that decide what those tests actually assert
+  (`scope.py::_support_closure` resolves first-party imports transitively).
+
+A third review found skip records were immortal: currency was inferred from *position* in a list
+callers could filter, so the PR job resurrected weeks-old red baselines. Currency is data now — a
+module that measures writes a record superseding its own skip.
+
+`scope.py` deliberately has zero relative imports, so CI can run it as a plain script against a bare
+checkout.
+
+---
+
+## 7. Claims from the first draft that did not survive checking
+
+Recorded because they cost time, and because the pattern (a plausible mechanism, asserted once, then
+inherited as fact) is worth recognising.
+
+- **"An unexplained 6.4-hour stall in verify."** No such stall exists. The hypothesis was an orphan
+  holding the SQLite lock — but that is self-contradicting: an orphan blocking the run would *produce*
+  the `killed-timeout` record whose absence was the evidence. `communicate(timeout=)` is passed on
+  both halves of the call. Probes at 3s, 8s and 30s caps were honoured to within 0.4s with zero
+  orphans. What actually blocked stage 2 was mundane: **the test suite was red** (two
+  `OutgoingEmailError` failures, since fixed).
+- **"verify costs ~56 hours."** ~27h. The estimate used a stale suite time.
+- **`mixins/reactions.py` at 100%.** 59%.
+- **`permissions.py` has 433 mutable sites.** 412.
+- **"545 tests."** 557 at the time; 960 now.
+
+---
+
+## 8. Gotchas
+
+- **Assets must be built, or modules skip silently.** A missing `sites/assets/assets.json` makes
+  `bundled_asset()` return `None.get(...)`, which makes `test_email_digest` red — and a red baseline
+  makes the harness **skip the whole module** (`baseline RED -> skipping module`). It journals a
+  `baseline-skip` row and moves on, so the campaign *looks* like it ran. Fix: `bench build --app
+  frappe` (~7s). Check for `baseline-skip` rows before trusting any score.
+- **A journal key is derived from source only** (`mutant_key`: path, mutator, function, segments,
+  ordinal). The test fingerprint added in `2d12798e` handles CI invalidation, but for a one-off
+  local re-measure the simplest route is still `--journal <fresh-path>`, then append those rows to
+  the main journal — last record wins per key, so the re-run supersedes cleanly. To re-run one
+  specific mutant, seed a journal with every row *except* that key and let resume leave it pending.
+- **Never `bench migrate` a SQLite site.** `frappe/patches/v16_0/hash_oauth_bearer_tokens.py:51`
+  calls `multisql` with no sqlite branch and no `*` fallback, and dies. It never fires on a *fresh*
+  site because `installer.py::set_all_patches_as_completed()` marks patches done without running
+  them — so always `bench new-site`, never migrate an old one. Not worth fixing upstream: CI creates
+  sites fresh.
+- **Node must be ≥ 24.** frappe v17-dev's engine check rejects 20, and `--skip-assets` does not skip
+  `yarn install --check-files`, so the check still fires during `bench get-app`.
+- **Do not edit tests, or any mutation target, while a campaign is running.** The tests are the
+  measuring instrument; changing them mid-run makes mutants evaluated before and after
+  incomparable. And the restore guard has the *source* files checked out — an edit lands inside its
+  window and gets reverted.
+- **Watch out for self-matching `pgrep`.** `pgrep -f "bench init"` inside an ssh command matches the
+  ssh command's own string and kills your session.
+- **String-constant mutation is off by default** (`--mutate-strings`). In this codebase strings are
+  field and doctype names; mutating them is pure noise — over half of `permissions.py`'s mutable
+  sites are strings.
+
+---
+
+## 9. Check the target map before writing a test
+
+`config.py` maps each target module to the test modules the harness runs against its mutants. A
+stale map reports gaps that are not real — nine survivors existed only because the killing test
+already existed and was not mapped. That is worse than a low score, because it sends people to write
+tests that are already there.
+
+The map is deliberately narrow, and should stay narrow: stage 1 answers "does this module's own
+tests pin it?", and widening the map toward the full suite turns stage 1 into stage 2 and makes the
+campaign unaffordable. The rule now written into `config.py` is that a test module earns a place
+only if it is the *primary or sole* place some behaviour of the target is asserted. Several
+candidates were measured and rejected on cost.
+
+Cost is not per-mutant: `run_one_mutant` runs the list in order and returns on the first
+non-survivor, so a mapped module is only paid for on mutants that survived everything before it.
+
+## 10. What to do next
+
+1. **Let the nightly run for a week** and check it is actually rotating. The failure mode to watch
+   for is a cache that never invalidates, which looks identical to success from the outside.
+2. **Triage the remaining survivors**, re-derived from a fresh journal rather than from old counts.
+   The largest untouched pockets are `gp_user_profile.get_list` (23) and `get_last_post` (9) —
+   nothing calls either — `gp_draft.get_my_drafts` (26), and `email_digest.summarized_names` (18).
+3. **Two known clusters that are not test gaps.** ~21 survivors across the corpus are equivalent
+   mutants (`return False → None`, `as_dict=1 → 2`, `limit+1 → limit+2`); chasing them buys
+   `assertIs` noise and nothing else. And every remaining `gp_project` survivor is an
+   `ignore_permissions` flip that **cannot** be killed as written — see §3, "the prediction that
+   failed". Record them as equivalent rather than leaving them to look like debt.
+4. **Verify strategy.** Full-suite-per-survivor is ~27h and mostly wasted. The cheapest answer in
+   practice: when a survivor sits in code nothing else exercises, stage 1 *is* the answer, and
+   writing the assertion costs less than proving you needed to. Reach for `verify` only on survivors
+   you are about to act on. If a broad number is ever wanted, stratified sampling across modules
+   *and* mutator classes beats a full run by an order of magnitude.
+5. **Deferred, found along the way, not chased:** `GP Project Visit` has no unique constraint on
+   `(user, project)` and `track_visit` is a get-then-insert, so duplicate rows are reachable and
+   inflate unread counts (`COUNT DISTINCT` makes the read side robust, but the root cause stands).
+   `GPProjectVisit.get_list_query` is dead — its only dispatcher is commented out in `hooks.py`.
+   And `gameplan.extends.client.get_list` passes `ignore_permissions=True`, so for doctypes with no
+   `get_list_query` nothing scopes that endpoint; worth an audit.
+
+Useful queries against the journal:
+
+```bash
+# survivors by module
+python3 -c "
+import json,collections
+rows=[json.loads(l) for l in open('.mutation/journal.jsonl')]
+s=[r for r in rows if r['status']=='survived']
+print(collections.Counter(r['file'] for r in s).most_common())"
+
+# survivors in one function
+python3 -c "
+import json
+rows=[json.loads(l) for l in open('.mutation/journal.jsonl')]
+for r in rows:
+    if r['status']=='survived' and r.get('function')=='can_edit_content':
+        print(r['line'], r['mutator'], r['original_segment'], '->', r['mutated_segment'])"
+```

--- a/frontend/src/components/MergeSpaceDialog.vue
+++ b/frontend/src/components/MergeSpaceDialog.vue
@@ -8,12 +8,13 @@
     "
     v-model:open="show"
   >
-    <p class="text-p-base text-ink-gray-7 mb-4">
+    <p v-if="hasMergeTargets" class="text-p-base text-ink-gray-7 mb-4">
       This will move all discussions, tasks, and pages from the
       <span class="whitespace-nowrap font-semibold">{{ space?.title }}</span> space to the selected
       space. This change is irreversible!
     </p>
     <Combobox
+      v-if="hasMergeTargets"
       :options="groupedSpaceOptions"
       v-model="selectedSpace"
       placeholder="Select a space"
@@ -21,11 +22,13 @@
       open-on-click
       autofocus
     />
+    <p v-else class="text-p-base text-ink-gray-6">{{ noTargetsMessage }}</p>
     <ErrorMessage class="mt-2" :message="spaces.runDocMethod.error" />
     <template #actions>
       <Button
         class="w-full"
         variant="solid"
+        :disabled="!hasMergeTargets"
         :loading="spaces.runDocMethod.isLoading(spaceId, 'merge_with_project')"
         @click="submit"
       >
@@ -42,6 +45,8 @@ import { useGroupedSpaceOptions } from '@/data/groupedSpaces'
 import { useDoctype } from 'frappe-ui'
 import { GPProject } from '@/types/doctypes'
 import { getSpace, useSpace } from '@/data/spaces'
+import { useSessionUser } from '@/data/users'
+import { canManageSpace, isGuest } from '@/utils/permissions'
 
 const props = defineProps<{
   spaceId: string
@@ -50,12 +55,40 @@ const props = defineProps<{
 const router = useRouter()
 const spaces = useDoctype<GPProject>('GP Project')
 const space = useSpace(() => props.spaceId)
+const sessionUser = useSessionUser()
 
 const selectedSpace = ref(null)
 const show = defineModel<boolean>()
 
+/**
+ * A merge empties this Space into the target, so the backend
+ * (`GP Project.require_can_manage_merge`) demands manage rights on BOTH and refuses guests
+ * outright. Mirroring that here keeps the picker from offering targets whose merge would
+ * come back as "Only space managers can merge spaces" — an error the user had no way to
+ * anticipate. `canManageSpace` reads the already-fetched space/community membership, so
+ * this costs no extra request.
+ */
+const isGuestUser = computed(() => isGuest(sessionUser))
+const canMergeThisSpace = computed(
+  () => !isGuestUser.value && canManageSpace(space.value, sessionUser),
+)
+
 const groupedSpaceOptions = useGroupedSpaceOptions({
-  filterFn: (s) => s.name.toString() !== props.spaceId.toString() && s.team === space.value?.team,
+  filterFn: (s) =>
+    canMergeThisSpace.value &&
+    s.name.toString() !== props.spaceId.toString() &&
+    s.team === space.value?.team &&
+    canManageSpace(s, sessionUser),
+})
+
+const hasMergeTargets = computed(() => groupedSpaceOptions.value.length > 0)
+
+const noTargetsMessage = computed(() => {
+  if (isGuestUser.value) return 'Guests cannot merge spaces.'
+  if (!canMergeThisSpace.value) {
+    return 'Only space managers can merge spaces, and you do not manage this one.'
+  }
+  return 'There are no other spaces in this community that you manage, so there is nothing to merge into.'
 })
 
 function submit() {

--- a/gameplan/gameplan/doctype/gp_discussion/api.py
+++ b/gameplan/gameplan/doctype/gp_discussion/api.py
@@ -209,6 +209,16 @@ def include_ongoing_polls(discussions):
 
 
 def include_last_post_content(discussions):
+	"""Attach a one-line preview of each discussion's newest post.
+
+	The two sides of the lookup are keyed differently by the schema, so the `cint` below
+	is load-bearing rather than defensive. `GP Comment` and `GP Poll` are `autoincrement`
+	doctypes, so their `name` comes back from the database as an integer, while
+	`GP Discussion.last_post` is a Dynamic Link — a varchar — and comes back as `"41"`.
+	Keying the maps on the raw name and coercing the discussion side is what makes the
+	two meet; normalising the other direction instead would work equally well, but doing
+	neither silently drops every preview.
+	"""
 	Comment = frappe.qb.DocType("GP Comment")
 
 	last_comments_name = [d.last_post for d in discussions if d.last_post_type == "GP Comment"]

--- a/gameplan/gameplan/doctype/gp_discussion/api.py
+++ b/gameplan/gameplan/doctype/gp_discussion/api.py
@@ -3,12 +3,80 @@
 
 
 import frappe
+from frappe import _
 from frappe.query_builder.functions import Count
-from frappe.utils import cint
+from frappe.utils import cint, cstr
 from pypika.terms import ExistsCriterion
 
+from gameplan.gameplan.doctype.gp_poll.gp_poll import ongoing_polls_clause
 from gameplan.permissions import apply_accessible_project_filter
 from gameplan.utils import html_to_text_preview
+
+# `order_by` arrives from the client and both halves of it end up in the SQL — the field
+# as a column and the direction as a bare keyword — so only these get through. The list
+# is exactly what the app sorts feeds by: the three choices in the "Sort by" select
+# (Discussions.vue), the pinned strip's `pinned_at desc` (DiscussionList.vue), and `name`
+# as the stable order a pager needs when two rows share a timestamp.
+SORTABLE_FIELDS = frozenset({"last_post_at", "creation", "pinned_at", "name"})
+SORT_DIRECTIONS = frozenset({"asc", "desc"})
+
+DEFAULT_ORDER_BY = "last_post_at desc"
+
+
+def parse_order_by(order_by) -> tuple[str, str]:
+	"""Split a client-supplied `<field> [asc|desc]` into a pair that is safe to splice in.
+
+	Anything else is a rejected request, not a traceback. The old `order_by.split(" ", 1)`
+	failed in two different ways: a bare field (`last_post_at`) had nothing to unpack and
+	raised a 500, while a third token never burst the unpack at all — maxsplit kept it in
+	the direction half, so `last_post_at desc, name asc` quietly reached the database as
+	trailing ORDER BY SQL. Both halves are now checked against a fixed list, and a bare
+	field means descending, which is how Frappe's own query engine reads a directionless
+	`order_by` (`frappe.database.query.Engine._validate_order_by`). The query string can
+	also hand us a list rather than a string, so the value is stringified first.
+	"""
+	tokens = cstr(order_by).split()
+	if len(tokens) == 1:
+		tokens.append("desc")
+
+	if len(tokens) == 2 and tokens[0] in SORTABLE_FIELDS and tokens[1].lower() in SORT_DIRECTIONS:
+		return tokens[0], tokens[1].lower()
+
+	frappe.throw(
+		_("Discussions can only be sorted by {0}, ascending or descending.").format(
+			", ".join(sorted(SORTABLE_FIELDS))
+		)
+	)
+
+
+def parse_offset(start) -> int:
+	"""Turn the client's `start` into a number that is safe to splice into OFFSET.
+
+	It used to go in as whatever the client sent, so `start="1); DROP TABLE ..."` was
+	spliced into the statement verbatim and the database refused the query. A negative
+	offset is a syntax error on MariaDB — invisible to a SQLite test run — so it is
+	clamped here rather than sent.
+	"""
+	return max(cint(start), 0)
+
+
+def parse_filters(filters) -> dict:
+	"""Decode the client's `filters` into the mapping the rest of this endpoint assumes.
+
+	`feed_type` and `participator` are lifted out by key before the remainder is handed
+	to the query builder, so a JSON list — a shape the query builder itself accepts —
+	used to reach `.pop()` and raise a 500. Field names, operators and values inside the
+	mapping are the query builder's own business: it rejects fieldnames outside
+	`[A-Za-z0-9_]`, looks operators up in a fixed map, and escapes values.
+	"""
+	filters = frappe.parse_json(filters) if filters else None
+	if filters is None:
+		return {}
+
+	if not isinstance(filters, dict):
+		frappe.throw(_("Discussion filters must be an object of field names and values."))
+
+	return filters
 
 
 @frappe.whitelist()
@@ -16,12 +84,12 @@ def get_discussions(filters=None, order_by=None, start=None, limit=None):
 	if not frappe.has_permission("GP Discussion", "read"):
 		frappe.throw("Insufficient Permission for GP Discussion", frappe.PermissionError)
 
-	filters = frappe.parse_json(filters) if filters else None
+	filters = parse_filters(filters)
 	feed_type = filters.pop("feed_type", None) if filters else None
 	participator = filters.pop("participator", None) if filters else None
 	limit = cint(limit)
-	order_by = order_by or "last_post_at desc"
-	order_field, order_direction = order_by.split(" ", 1)
+	start = parse_offset(start)
+	order_field, order_direction = parse_order_by(order_by or DEFAULT_ORDER_BY)
 
 	Discussion = frappe.qb.DocType("GP Discussion")
 	Project = frappe.qb.DocType("GP Project")
@@ -45,7 +113,7 @@ def get_discussions(filters=None, order_by=None, start=None, limit=None):
 		.on(Discussion.project == Project.name)
 		.where(Project.archived_at.isnull())
 		.limit(limit + 1)
-		.offset(start or 0)
+		.offset(start)
 	)
 	query = apply_accessible_project_filter(query, Discussion.project)
 
@@ -76,7 +144,6 @@ def get_discussions(filters=None, order_by=None, start=None, limit=None):
 			| clause_discussions_commented_by_user(frappe.session.user)
 		)
 
-	# default order by last_post_at desc
 	query = query.orderby(Discussion[order_field], order=frappe._dict(value=order_direction))
 
 	discussions = query.run(as_dict=1)
@@ -128,7 +195,7 @@ def include_ongoing_polls(discussions):
 		(
 			frappe.qb.from_(Poll)
 			.select(Poll.name, Poll.owner, Poll.discussion)
-			.where(Poll.stopped_at.isnull() | (Poll.stopped_at > frappe.utils.now()))
+			.where(ongoing_polls_clause(Poll))
 			.where(Poll.discussion.isin(discussion_names))
 			.orderby(Poll.creation, order=frappe._dict(value="asc"))
 			.run(as_dict=1)

--- a/gameplan/gameplan/doctype/gp_notification/gp_notification.json
+++ b/gameplan/gameplan/doctype/gp_notification/gp_notification.json
@@ -93,7 +93,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-02-01 13:07:33.079297",
+ "modified": "2026-07-31 10:15:00.000000",
  "modified_by": "Administrator",
  "module": "Gameplan",
  "name": "GP Notification",
@@ -125,7 +125,6 @@
    "write": 1
   },
   {
-   "create": 1,
    "email": 1,
    "export": 1,
    "print": 1,
@@ -136,7 +135,6 @@
    "write": 1
   },
   {
-   "create": 1,
    "email": 1,
    "export": 1,
    "print": 1,

--- a/gameplan/gameplan/doctype/gp_poll/gp_poll.py
+++ b/gameplan/gameplan/doctype/gp_poll/gp_poll.py
@@ -4,7 +4,7 @@
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import flt
+from frappe.utils import DATETIME_FORMAT, flt, get_datetime
 
 from gameplan.mixins.archivable import check_if_space_is_archived
 from gameplan.mixins.reactions import HasReactions
@@ -16,6 +16,36 @@ from gameplan.permissions import (
 )
 
 from .gp_poll_attributes import GPPollAttributes
+
+
+def poll_has_stopped(stopped_at, now=None) -> bool:
+	"""Whether a poll with this `stopped_at` is closed at `now`.
+
+	`stopped_at` is the instant the poll stops, not the last instant it runs: `stop_poll`
+	stamps it with the current time, so if that exact microsecond still counted as open a
+	vote could land after the stop was recorded. The boundary is therefore inclusive — at
+	`stopped_at` the ballot is shut.
+
+	This is the one place that rule is written down. `ongoing_polls_clause` is its query
+	mirror for callers that must ask the database instead (the discussion feed), and
+	TestFeedOngoingPolls.test_the_feed_and_the_ballot_close_at_the_same_instant pins the
+	two together so they cannot drift apart again.
+	"""
+	if not stopped_at:
+		return False
+	return get_datetime(stopped_at) <= (now or frappe.utils.now_datetime())
+
+
+def ongoing_polls_clause(Poll, now=None):
+	"""Query-builder mirror of `poll_has_stopped`: the polls still open at `now`.
+
+	A poll with no `stopped_at` runs until someone stops it, so it is always ongoing.
+	SQLite compares datetimes as text, so `now` is rendered in the same format Frappe
+	stored the column in — otherwise the two mirrors would part company on the
+	microseconds, which is the exact boundary they exist to keep in step.
+	"""
+	now = now or frappe.utils.now_datetime()
+	return Poll.stopped_at.isnull() | (Poll.stopped_at > now.strftime(DATETIME_FORMAT))
 
 
 class GPPoll(HasReactions, Document, GPPollAttributes):
@@ -206,10 +236,7 @@ class GPPoll(HasReactions, Document, GPPollAttributes):
 		return len({d.user for d in self.votes})
 
 	def check_if_stopped(self):
-		# Every caller reloads first, so Frappe has normalised the stored Datetime to a
-		# datetime object. `stop_poll` assigns a string, but no comparison is made until
-		# the next vote/retract call reloads the document.
-		if self.stopped_at and self.stopped_at < frappe.utils.now_datetime():
+		if poll_has_stopped(self.stopped_at):
 			frappe.throw(_("Poll has ended"))
 
 

--- a/gameplan/gameplan/doctype/gp_project/gp_project.py
+++ b/gameplan/gameplan/doctype/gp_project/gp_project.py
@@ -1,13 +1,12 @@
 # Copyright (c) 2022, Frappe Technologies Pvt Ltd and contributors
 # For license information, please see license.txt
 
-from urllib.parse import urljoin
-
 import frappe
-import requests
-from bs4 import BeautifulSoup
+from frappe import _
 from frappe.model.document import Document
+from frappe.utils import cint
 
+import gameplan
 from gameplan.api import _invite_by_email
 from gameplan.gameplan.doctype.gp_unread_record.gp_unread_record import GPUnreadRecord
 from gameplan.mixins.archivable import Archivable
@@ -15,6 +14,7 @@ from gameplan.mixins.manage_members import ManageMembersMixin
 from gameplan.permissions import (
 	apply_accessible_project_filter,
 	apply_project_query_filter,
+	can_manage_space,
 	can_view_space,
 	require_can_invite_guest,
 	require_can_manage_space_members,
@@ -49,10 +49,6 @@ class GPProject(ManageMembersMixin, Archivable, Document):
 	def get_list_query(query):
 		return apply_project_query_filter(query)
 
-	def as_dict(self, *args, **kwargs) -> dict:
-		d = super().as_dict(*args, **kwargs)
-		return d
-
 	def before_validate(self):
 		if not self.icon or not self.icon.startswith("lucide-"):
 			self.icon = DEFAULT_SPACE_ICON
@@ -85,13 +81,48 @@ class GPProject(ManageMembersMixin, Archivable, Document):
 
 	@frappe.whitelist(methods=["POST"])
 	def merge_with_project(self, project=None):
-		if not project or self.name == project:
+		if not project:
 			return
-		if isinstance(project, str):
-			project = int(project)
-		if not frappe.db.exists("GP Project", project):
+		# Coerce BEFORE comparing. GP Project autoincrements, so self.name is an int, while
+		# MergeSpaceDialog sends the target as a string: comparing first sees "7" != 7, the
+		# self-merge guard falls through, and the rename below deletes this Space and leaves
+		# every discussion in it pointing at nothing.
+		target = cint(project)
+		if target == cint(self.name):
+			return
+		self.require_can_manage_merge(target)
+		if not frappe.db.exists("GP Project", target):
 			frappe.throw(f'Invalid Project "{project}"')
-		return self.rename(project, merge=True, validate_rename=False, force=True)
+		# validate_rename stays off: this doctype autoincrements, and validate_rename runs
+		# the new name through validate_name, which for an autoincrement doctype rewinds the
+		# table's sequence to the merge target's id — every subsequent insert would then
+		# collide with an existing row. Turning it off drops FIVE guards, not just that one,
+		# so each is re-established above: source-exists (this is a loaded doc), old != new,
+		# target-exists, and write permission on both source and target. The only one not
+		# reproduced is validate_rename's `SELECT ... FOR UPDATE` lock on the target row,
+		# which frappe does not expose separately.
+		return self.rename(target, merge=True, validate_rename=False, force=True)
+
+	def require_can_manage_merge(self, target):
+		"""A merge empties this Space into `target`, so it needs manage rights on both.
+
+		The v2 method route only checks write on the document the method is called on,
+		and the rename it guards skips frappe's own "write permission on the merge target"
+		check along with the rest of validate_rename — leaving the target ungated.
+
+		Runs BEFORE the target-exists check: `frappe.db.exists` answers for every Space on
+		the site, so rejecting an unknown id with a different error than a forbidden one
+		would let any Space manager enumerate GP Project ids, private Spaces included.
+		"""
+		user = frappe.session.user
+		# Guests hold GP Member rows on the private Spaces they're granted, which is enough
+		# for can_manage_space — same reason can_invite_guest rules them out up front. Guest
+		# access is read-and-participate; a merge destroys a Space.
+		if gameplan.is_guest(user):
+			frappe.throw(_("Only space managers can merge spaces"), frappe.PermissionError)
+		for space in (self, target):
+			if not can_manage_space(user, space):
+				frappe.throw(_("Only space managers can merge spaces"), frappe.PermissionError)
 
 	@frappe.whitelist(methods=["POST"])
 	def invite_guest(self, email):
@@ -198,35 +229,34 @@ class GPProject(ManageMembersMixin, Archivable, Document):
 			project_visit_doc.insert(ignore_permissions=True)
 
 
-def get_meta_tags(url):
-	response = requests.get(url, timeout=2, allow_redirects=True)
-	soup = BeautifulSoup(response.text, "html.parser")
-	title = soup.find("title").text.strip()
-
-	image = None
-	favicon = soup.find("link", rel="icon")
-	if favicon:
-		image = favicon["href"]
-
-	if image and image.startswith("/"):
-		image = urljoin(url, image)
-
-	return {"title": title, "image": image}
-
-
 @frappe.whitelist()
 def get_joined_spaces():
-	user = frappe.session.user
-	projects = frappe.qb.get_query(
-		"GP Project",
-		filters={"members.user": user},
-		fields=["name"],
-	).run(as_dict=True, pluck="name")
-	guest_access_projects = frappe.qb.get_query(
-		"GP Guest Access", filters={"user": user}, fields=["project"]
-	).run(as_dict=True, pluck="project")
+	"""Every Space the user is in, whether as a member or as an invited guest.
 
-	return list(map(str, set(projects + guest_access_projects)))
+	Both sources are normalised to `str` as they are read: GP Project autoincrements,
+	so a membership row yields the name as an int while the guest grant stores the
+	same name in a link column as a str. Left mixed, they dedupe against nothing and
+	a Space held both ways is reported twice.
+	"""
+	user = frappe.session.user
+	member_spaces = [
+		str(name)
+		for name in frappe.qb.get_query(
+			"GP Project",
+			filters={"members.user": user},
+			fields=["name"],
+		).run(pluck="name")
+	]
+	guest_spaces = [
+		str(project)
+		for project in frappe.qb.get_query("GP Guest Access", filters={"user": user}, fields=["project"]).run(
+			pluck="project"
+		)
+	]
+
+	# dict.fromkeys, not set: the order has to be stable so callers (and the sidebar)
+	# see the same list twice in a row.
+	return list(dict.fromkeys(member_spaces + guest_spaces))
 
 
 @frappe.whitelist()
@@ -305,9 +335,12 @@ def mark_all_as_read(spaces: list[str | int] = None):
 
 @frappe.whitelist()
 def get_unread_count():
-	from frappe.query_builder.functions import Count, Sum
+	from frappe.query_builder.functions import Count
 
 	user = frappe.session.user
+	# Scopes the count below — without it the query answered for every Space on the site,
+	# so anyone in at least one Space was handed unread counts for private Spaces they
+	# cannot open. The empty case has to short-circuit: `IN ()` is not valid SQL.
 	joined_projects = get_joined_spaces()
 
 	if not joined_projects:
@@ -317,46 +350,34 @@ def get_unread_count():
 	gdv = frappe.qb.DocType("GP Discussion Visit").as_("gdv")
 	gpv = frappe.qb.DocType("GP Project Visit").as_("gpv")
 
-	# Case 1: Projects with mark_all_read_at timestamp
-	# Check if discussion's last_post_at is after the project's mark_all_read_at
-	query1 = (
-		frappe.qb.from_(gd)
-		.select(gd.project, Count(gd.name).as_("unread_count"))
-		.inner_join(gpv)
-		.on((gd.project == gpv.project) & (gpv.user == user) & gpv.mark_all_read_at.isnotnull())
-		.where(gd.last_post_at > gpv.mark_all_read_at)
-		.groupby(gd.project)
+	# A Space is read-tracked one of two ways: by its own "mark all read" timestamp once
+	# it has one, and by per-discussion visits until then.
+	marked_read = gpv.mark_all_read_at.isnotnull() & (gd.last_post_at > gpv.mark_all_read_at)
+	never_marked_read = (gpv.name.isnull() | gpv.mark_all_read_at.isnull()) & (
+		gdv.name.isnull() | (gd.last_post_at > gdv.last_visit)
 	)
 
-	# Case 2: Projects without mark_all_read_at (or NULL)
-	# Fall back to individual discussion visit tracking
-	query2 = (
+	# One OR'd predicate over a single pair of joins rather than a UNION of the two cases:
+	# frappe's SQLite query builder (frappe/query_builder/builder.py::SQLite) leaves
+	# pypika's wrap_set_operation_queries at its default True, so a set operation renders
+	# with each term in parentheses and SQLite rejects the compound SELECT outright
+	# ("near UNION: syntax error").
+	#
+	# COUNT is DISTINCT because the two predicates are exclusive per JOINED ROW, not per
+	# discussion: GP Project Visit has no unique constraint on (user, project) and
+	# track_visit is a get-then-insert, so a Space can carry two visit rows for one user —
+	# one with mark_all_read_at, one without — and each discussion then satisfies both
+	# branches on different rows. The UNION this replaced deduped for the same reason.
+	query = (
 		frappe.qb.from_(gd)
-		.select(gd.project, Count(gd.name).as_("unread_count"))
+		.select(gd.project, Count(gd.name).distinct().as_("unread_count"))
 		.left_join(gpv)
 		.on((gd.project == gpv.project) & (gpv.user == user))
 		.left_join(gdv)
 		.on((gd.name == gdv.discussion) & (gdv.user == user))
-		.where(
-			(gpv.name.isnull() | gpv.mark_all_read_at.isnull())
-			& (gdv.name.isnull() | (gd.last_post_at > gdv.last_visit))
-		)
+		.where(gd.project.isin(joined_projects))
+		.where(marked_read | never_marked_read)
 		.groupby(gd.project)
 	)
 
-	# Combine both queries using pypika's UNION operator
-	union_query = query1 + query2
-
-	# Create outer query to sum the unread counts per project
-	combined = union_query.as_("combined")
-
-	final_query = (
-		frappe.qb.from_(combined)
-		.select(combined.project, Sum(combined.unread_count).as_("unread_count"))
-		.groupby(combined.project)
-	)
-
-	result = final_query.run(as_dict=True)
-	unread_counts_dict = {row["project"]: row["unread_count"] for row in result}
-
-	return unread_counts_dict
+	return {row["project"]: row["unread_count"] for row in query.run(as_dict=True)}

--- a/gameplan/gameplan/doctype/gp_project/gp_project.py
+++ b/gameplan/gameplan/doctype/gp_project/gp_project.py
@@ -101,7 +101,11 @@ class GPProject(ManageMembersMixin, Archivable, Document):
 		# target-exists, and write permission on both source and target. The only one not
 		# reproduced is validate_rename's `SELECT ... FOR UPDATE` lock on the target row,
 		# which frappe does not expose separately.
-		return self.rename(target, merge=True, validate_rename=False, force=True)
+		#
+		# `force` is deliberately not passed with it: rename_doc reads force only inside
+		# the `if validate:` block it hands to validate_rename, so with validate off the
+		# argument reaches nothing.
+		return self.rename(target, merge=True, validate_rename=False)
 
 	def require_can_manage_merge(self, target):
 		"""A merge empties this Space into `target`, so it needs manage rights on both.
@@ -197,10 +201,19 @@ class GPProject(ManageMembersMixin, Archivable, Document):
 	@frappe.whitelist(methods=["POST"])
 	def archive(self):
 		super().archive()
-		# delete pinned projects
-		for pin in frappe.db.get_all(
-			"GP Pinned Project", filters={"project": self.name, "user": frappe.session.user}, pluck="name"
-		):
+		# Everyone's pin, not just the archiver's. Archiving retires the Space for the
+		# whole site, so a pin left on another user's sidebar points at something they
+		# cannot open. The patch
+		# gp_pinned_project/patches/delete_pinned_projects_for_archived_spaces.py exists
+		# only to clear that state out, and a session-scoped delete regenerates its
+		# precondition on every archive.
+		pins = frappe.qb.get_query(
+			"GP Pinned Project",
+			filters={"project": self.name},
+			fields=["name"],
+			ignore_permissions=True,
+		).run(pluck="name")
+		for pin in pins:
 			frappe.delete_doc("GP Pinned Project", pin, ignore_permissions=True)
 
 	@frappe.whitelist(methods=["POST"])

--- a/gameplan/hooks.py
+++ b/gameplan/hooks.py
@@ -124,6 +124,11 @@ permission_query_conditions = {
 	"GP Page": "gameplan.gameplan.doctype.gp_page.gp_page.get_permission_query_conditions",
 	"GP Draft": "gameplan.permissions.draft_query_conditions",
 	"GP Bookmark": "gameplan.permissions.bookmark_query_conditions",
+	# Per-user state — see gameplan/per_user_state.py for why if_owner cannot express this.
+	"GP Notification": "gameplan.per_user_state.notification_query_conditions",
+	"GP Project Visit": "gameplan.per_user_state.project_visit_query_conditions",
+	"GP Discussion Visit": "gameplan.per_user_state.discussion_visit_query_conditions",
+	"GP Pinned Project": "gameplan.per_user_state.pinned_project_query_conditions",
 }
 
 has_permission = {
@@ -136,6 +141,10 @@ has_permission = {
 	"GP Page": "gameplan.gameplan.doctype.gp_page.gp_page.has_permission",
 	"GP User Profile": "gameplan.gameplan.doctype.gp_user_profile.gp_user_profile.has_permission",
 	"GP Bookmark": "gameplan.permissions.bookmark_has_permission",
+	"GP Notification": "gameplan.per_user_state.notification_has_permission",
+	"GP Project Visit": "gameplan.per_user_state.project_visit_has_permission",
+	"GP Discussion Visit": "gameplan.per_user_state.discussion_visit_has_permission",
+	"GP Pinned Project": "gameplan.per_user_state.pinned_project_has_permission",
 }
 
 # DocType Class

--- a/gameplan/mixins/reactions.py
+++ b/gameplan/mixins/reactions.py
@@ -55,20 +55,30 @@ class HasReactions:
 		self.save()
 		return self.get("reactions")
 
+	def reaction_keys(self):
+		"""A reaction is identified by (user, emoji) — the same identity `react` uses."""
+		return {(reaction.user, reaction.emoji) for reaction in (self.get("reactions") or [])}
+
 	def notify_reactions(self):
 		from gameplan.permissions import can_view_content
 
+		# Only a reaction that was ADDED is news. Sizes are the wrong test in both
+		# directions: a withdrawal changes the count too (and would re-raise a bell the
+		# owner already cleared, about a reaction that no longer exists), while swapping
+		# one emoji for another in a single save leaves the count equal even though the
+		# new emoji is a reaction the owner has never been told about.
 		previous = self.get_doc_before_save()
-		if previous and len(previous.get("reactions")) == len(self.get("reactions")):
-			return
-		if len(self.get("reactions")) == 0:
-			return
-
+		previous_keys = previous.reaction_keys() if previous else set()
 		# Your own reaction never notifies you and is never counted: the row would
 		# otherwise read "1 person reacted to your post" about yourself.
-		people = list({r.user for r in self.get("reactions") if r.user != self.owner})
-		if not people:
+		added = {key for key in self.reaction_keys() - previous_keys if key[0] != self.owner}
+		if not added:
 			return
+
+		# Several changes can land in one save (the frontend debounces a quick tap-tap
+		# into one batch). The message describes the post as it now stands, not the
+		# delta, so it stays true however many rows moved.
+		people = list({r.user for r in self.get("reactions") if r.user != self.owner})
 		if not can_view_content(self.owner, self):
 			return
 

--- a/gameplan/per_user_state.py
+++ b/gameplan/per_user_state.py
@@ -1,0 +1,110 @@
+# Copyright (c) 2026, Frappe Technologies Pvt Ltd and Contributors
+# See license.txt
+
+"""Row-level access control for the doctypes that hold per-user state.
+
+GP Notification, GP Project Visit, GP Discussion Visit and GP Pinned Project each
+store one row per user, and each grants Gameplan Member and Gameplan Guest read and
+write with `if_owner` unset (GP Pinned Project also grants `delete`). Role permissions
+alone therefore let any signed-in user read, enumerate, overwrite and — for pins —
+delete anyone else's bell feed, visit history, read-state and sidebar through the
+generic `/api/v2/document/<doctype>` API.
+
+`if_owner` cannot express this rule. For GP Notification the row's `owner` is the
+person who *triggered* it (the mentioner), while the row belongs to `to_user` — so
+`if_owner` would hand the notification to the sender and hide it from the recipient.
+The visit doctypes and GP Pinned Project have the mirror problem:
+`GPUnreadRecord.create_project_visits`, the Discourse importer and the demo seeder
+legitimately create rows *for* another user, whose `owner` is then the importing
+session. The row's own user column is the only honest source of truth, so the rule is
+expressed as a `permission_query_conditions` hook (list/report) plus a `has_permission`
+hook (single-document read/write/create/delete), the same pair GP Bookmark uses.
+
+`GPPinnedProject.get_list_query` scopes only one endpoint —
+`gameplan.extends.client.get_list`, the SPA's default list URL. `frappe.get_list`,
+`frappe.client.get_list` and `/api/v2/document/GP Pinned Project` never call it, and
+none of them scoped anything before these hooks existed.
+
+Server-side writers are unaffected: every one of them (`GPProject.track_visit`,
+`GPProject.mark_all_as_read`, `GPProject.archive`, `GPDiscussion.track_visit`, the
+mention and reaction mixins, `GPUnreadRecord`) writes with `ignore_permissions` or raw
+query-builder statements, both of which skip these hooks.
+"""
+
+import frappe
+
+from gameplan.permissions import criterion_sql, get_doc_value, is_delete_cascade
+
+# The column naming the user a row belongs to, per doctype.
+NOTIFICATION_USER_FIELD = "to_user"
+VISIT_USER_FIELD = "user"
+PIN_USER_FIELD = "user"
+
+
+def _own_rows_only(doctype, fieldname, user):
+	user = user or frappe.session.user
+	table = frappe.qb.DocType(doctype)
+	return criterion_sql(table[fieldname] == user)
+
+
+def _belongs_to_user(doc, fieldname, user):
+	user = user or frappe.session.user
+	# Doctype-level checks arrive without a document (e.g. "may this user open the list
+	# at all?"); those stay open and the query conditions above do the scoping.
+	if not hasattr(doc, "doctype"):
+		return True
+	if is_delete_cascade(doc):
+		# Deleting a discussion or a Space takes *everyone's* visit rows with it (see
+		# GPDiscussion/GPProject.on_delete_cascade). The parent delete was already
+		# authorised and the flag is unreachable over HTTP, so this row goes with it.
+		return True
+	return get_doc_value(doc, fieldname) == user
+
+
+def notification_query_conditions(user=None, **kwargs):
+	return _own_rows_only("GP Notification", NOTIFICATION_USER_FIELD, user)
+
+
+def notification_has_permission(doc, ptype="read", user=None, **kwargs):
+	"""A notification is addressed to exactly one person: only they may see or clear it.
+
+	Deliberately no admin exception — nothing in Gameplan reads someone else's bell feed.
+	"""
+	return _belongs_to_user(doc, NOTIFICATION_USER_FIELD, user)
+
+
+def project_visit_query_conditions(user=None, **kwargs):
+	return _own_rows_only("GP Project Visit", VISIT_USER_FIELD, user)
+
+
+def project_visit_has_permission(doc, ptype="read", user=None, **kwargs):
+	"""A Space visit row is one user's own last-visit / mark-all-read watermark."""
+	return _belongs_to_user(doc, VISIT_USER_FIELD, user)
+
+
+def discussion_visit_query_conditions(user=None, **kwargs):
+	return _own_rows_only("GP Discussion Visit", VISIT_USER_FIELD, user)
+
+
+def discussion_visit_has_permission(doc, ptype="read", user=None, **kwargs):
+	"""A discussion visit row is one user's own read-state for that discussion."""
+	return _belongs_to_user(doc, VISIT_USER_FIELD, user)
+
+
+def pinned_project_query_conditions(user=None, **kwargs):
+	return _own_rows_only("GP Pinned Project", PIN_USER_FIELD, user)
+
+
+def pinned_project_has_permission(doc, ptype="read", user=None, **kwargs):
+	"""A pin is one user's own sidebar shortcut, so only they may see or drop it.
+
+	`delete` matters most here: unpinning *is* deleting the row (there is no unpin
+	endpoint), which is why the role grant has to stay and this hook has to scope it.
+	"""
+	if ptype == "create":
+		# `Document.insert` runs the create check *before* `before_insert`, and
+		# `before_insert` is where `user` gets stamped with the session user. Judging the
+		# still-empty field here would deny every legitimate pin; the stamping is what
+		# makes creating a pin for someone else impossible in the first place.
+		return True
+	return _belongs_to_user(doc, PIN_USER_FIELD, user)

--- a/gameplan/permissions.py
+++ b/gameplan/permissions.py
@@ -53,6 +53,14 @@ def content_has_permission(doc, ptype="read", user=None, **kwargs):
 		return can_write_content(user, doc)
 	if ptype == "delete":
 		return can_delete_content(user, doc)
+	# Defer, don't decide. A has_permission hook can only ever DENY — frappe's
+	# has_controller_permissions treats a falsy answer as "blocked" and never grants
+	# anything the role layer withheld — so True is the correct answer for a permission
+	# type Gameplan does not model (submit/cancel/amend/import, or a site's custom
+	# Permission Type). It also carries a live caller: frappe.permissions.get_doc_permissions
+	# invokes the hook with ptype=None to evaluate the whole permission dict, and a False
+	# here collapses that dict to {None: 0}, i.e. the document reads as having no
+	# permissions at all. See tests/permissions/test_permission_defaults.py.
 	return True
 
 
@@ -248,6 +256,14 @@ def can_interact_with_content(user, doc):
 	alike) and, for personal/space-less content, its owner. This is the floor for the
 	`write` permission; whether a specific *edit* is allowed on top of it is decided
 	by can_edit_content / _protected_fields_changed.
+
+	Two of the branches below never fire from its only caller: can_write_content reaches
+	here only once can_edit_content has said False, and an admin or the owner of
+	space-less content is always an editor. They stay because this is a named predicate
+	about who may reach content at all, not a private tail of can_write_content: dropping
+	the admin line makes it answer False for a global admin on another user's personal
+	page, and dropping the owner line at the end turns the space-less case into an
+	unconditional True the moment can_view_content's own space-less rule loosens.
 	"""
 	if is_global_admin(user):
 		return True
@@ -255,6 +271,8 @@ def can_interact_with_content(user, doc):
 		return False
 	if get_content_project(doc):
 		return True
+	# Today can_view_content has already established owner == user for space-less content,
+	# so this only ever returns True — it is the deny-by-default that keeps that true.
 	return get_doc_value(doc, "owner") == user
 
 
@@ -419,6 +437,12 @@ def can_delete_content(user, doc):
 		return False
 	project = get_content_project(doc)
 	if not project:
+		# Space-less content has no community to moderate it: only its owner and the
+		# global admin, both handled above. Unreachable today (a non-owner who is not a
+		# global admin fails the can_view_content check above for space-less content) and
+		# the line below would deny too — get_project_info(None) is None. Kept as the
+		# explicit statement of the rule: that "would deny too" rests on an implicit
+		# falsy chain, and this is the one function where the rule should be readable.
 		return False
 	project_info = get_project_info(project)
 	return bool(project_info and is_community_admin(user, project_info.team))

--- a/gameplan/tests/features/test_discussions.py
+++ b/gameplan/tests/features/test_discussions.py
@@ -9,6 +9,7 @@ from gameplan.gameplan.doctype.gp_discussion.api import (
 	get_discussions,
 )
 from gameplan.gameplan.doctype.gp_discussion.gp_discussion import has_permission
+from gameplan.gameplan.doctype.gp_unread_record.gp_unread_record import GPUnreadRecord
 from gameplan.tests.base import GameplanTestCase
 from gameplan.tests.fixtures import (
 	create_community,
@@ -481,3 +482,247 @@ class TestParticipants(DiscussionLifecycleTestCase):
 		self.delete_as(first, self.second_member)
 
 		self.assertEqual(self.stored().participants_count, 2)
+
+
+class DiscussionFeedTestCase(GameplanTestCase):
+	"""World for `get_discussions`, the query behind every discussion feed.
+
+	One community with two public spaces. `member` joined the first, `second_member`
+	joined the second — so every space has a member, and exactly one of them is the
+	reader. That asymmetry is deliberate: a feed scoped "by membership" and a feed
+	scoped "by *anyone's* membership" only differ when someone else has joined
+	somewhere the reader has not.
+	"""
+
+	def setUp(self):
+		super().setUp()
+		self.community = create_community("Feed Co", members=[self.member, self.second_member])
+		self.space = create_space("Joined", self.community, members=[self.member])
+		self.other_space = create_space("Not joined", self.community, members=[self.second_member])
+
+	def feed(self, user, limit=20, **kwargs):
+		"""`get_discussions` as `user`, scoped to this community unless told otherwise."""
+		filters = dict(kwargs.pop("filters", None) or {})
+		filters.setdefault("team", self.community.name)
+		with self.as_user(user):
+			return get_discussions(filters=filters, limit=limit, **kwargs)
+
+	def feed_names(self, user, **kwargs):
+		return [str(d.name) for d in self.feed(user, **kwargs)]
+
+	def post(self, user, title, space=None, content="<p>Body</p>"):
+		"""Start a discussion as `user`.
+
+		Inserted through the session rather than `create_discussion(owner=...)`: both the
+		owner and the unread records that get built on insert key off the acting user, and
+		rewriting the owner afterwards happens too late for the unread fan-out.
+		"""
+		return self._insert_as(
+			user,
+			doctype="GP Discussion",
+			title=title,
+			project=(space or self.space).name,
+			content=content,
+		)
+
+	def comment(self, discussion, user, content="<p>A reply</p>"):
+		return self._insert_as(
+			user,
+			doctype="GP Comment",
+			reference_doctype="GP Discussion",
+			reference_name=discussion.name,
+			content=content,
+		)
+
+	def _insert_as(self, user, **fields):
+		with self.as_user(user):
+			return frappe.get_doc(**fields).insert()
+
+	def rows_by_name(self, user):
+		return {str(row.name): row for row in self.feed(user)}
+
+
+class TestFeedPaging(DiscussionFeedTestCase):
+	"""`limit` and `start` page the feed; `has_next_page` tells the client whether to
+	ask for another page. All three come out of one deliberately over-fetched row."""
+
+	def setUp(self):
+		super().setUp()
+		self.threads = [self.post(self.member, f"Thread {index}") for index in range(3)]
+
+	def test_a_full_page_reports_that_more_are_waiting(self):
+		rows = self.feed(self.member, limit=2)
+
+		self.assertEqual(len(rows), 2)
+		self.assertIs(frappe.response["has_next_page"], True)
+
+	def test_the_last_page_reports_that_nothing_is_waiting(self):
+		"""Exactly `limit` rows left is the case that decides the over-fetch: the extra
+		row is what separates "a full page" from "a full page and then some"."""
+		rows = self.feed(self.member, limit=3)
+
+		self.assertEqual(len(rows), 3)
+		self.assertIs(frappe.response["has_next_page"], False)
+
+	def test_start_skips_the_rows_already_shown(self):
+		names = [str(thread.name) for thread in self.threads]
+
+		first_page = self.feed_names(self.member, limit=2, order_by="name asc")
+		second_page = self.feed_names(self.member, limit=2, start=2, order_by="name asc")
+
+		self.assertEqual(first_page, names[:2])
+		self.assertEqual(second_page, names[2:])
+
+
+class TestEmptyFeed(DiscussionFeedTestCase):
+	def test_a_feed_with_nothing_in_it_is_an_empty_list(self):
+		"""The enrichment steps run in sequence and hand their result to the next one, so
+		an empty feed is the case where a dropped return value blows up the whole endpoint."""
+		self.assertEqual(self.feed(self.member), [])
+
+
+class TestFeedUnreadCounts(DiscussionFeedTestCase):
+	"""Every row carries `unread`: how many posts in that thread this reader has not
+	seen. It is per-reader, so it must never be assembled from anyone else's records."""
+
+	def test_the_author_has_nothing_to_catch_up_on_but_everyone_else_does(self):
+		self.post(self.second_member, "Fresh thread")
+
+		[author_row] = self.feed(self.second_member)
+		[reader_row] = self.feed(self.member)
+
+		self.assertEqual(author_row.unread, 0)
+		self.assertEqual(reader_row.unread, 1)
+
+	def test_each_new_post_adds_to_the_count(self):
+		discussion = self.post(self.second_member, "Fresh thread")
+		self.comment(discussion, self.second_member)
+
+		[row] = self.feed(self.member)
+
+		self.assertEqual(row.unread, 2)
+
+	def test_reading_a_thread_returns_its_count_to_zero(self):
+		discussion = self.post(self.second_member, "Fresh thread")
+
+		GPUnreadRecord.mark_discussion_as_read_for_user(str(discussion.name), self.member.name)
+
+		[row] = self.feed(self.member)
+		self.assertEqual(row.unread, 0)
+
+
+class TestFollowingFeed(DiscussionFeedTestCase):
+	""" "Following" is scoped by space membership — the spaces *this* reader joined."""
+
+	def test_it_shows_only_threads_in_spaces_the_reader_joined(self):
+		joined = self.post(self.member, "In the space I joined", self.space)
+		elsewhere = self.post(self.member, "In a space someone else joined", self.other_space)
+
+		names = self.feed_names(self.member, filters={"feed_type": "following"})
+
+		self.assertIn(str(joined.name), names)
+		self.assertNotIn(str(elsewhere.name), names)
+
+
+class TestUnreadFeed(DiscussionFeedTestCase):
+	""" "Unread" is scoped by this reader's own outstanding unread records."""
+
+	def setUp(self):
+		super().setUp()
+		self.theirs = self.post(self.second_member, "New to me")
+		self.mine = self.post(self.member, "Written by me")
+
+	def unread_feed(self):
+		return self.feed_names(self.member, filters={"feed_type": "unread"})
+
+	def test_it_shows_a_thread_the_reader_has_not_seen(self):
+		self.assertIn(str(self.theirs.name), self.unread_feed())
+
+	def test_it_hides_a_thread_the_reader_has_nothing_outstanding_in(self):
+		"""The reader wrote this one, so only *other* people have unread records for it."""
+		self.assertNotIn(str(self.mine.name), self.unread_feed())
+
+	def test_reading_a_thread_drops_it_from_the_feed(self):
+		GPUnreadRecord.mark_discussion_as_read_for_user(str(self.theirs.name), self.member.name)
+
+		self.assertNotIn(str(self.theirs.name), self.unread_feed())
+
+
+class TestParticipatingFeed(DiscussionFeedTestCase):
+	""" "Participating" is the threads the reader started or replied to."""
+
+	def setUp(self):
+		super().setUp()
+		self.started = self.post(self.member, "I started this")
+		self.replied_to = self.post(self.second_member, "Someone else started this")
+		self.comment(self.replied_to, self.member)
+		self.untouched = self.post(self.second_member, "Nothing to do with me")
+		self.comment(self.untouched, self.second_member)
+
+	def participating(self):
+		return self.feed_names(self.member, filters={"feed_type": "participating"})
+
+	def test_it_shows_threads_the_reader_started(self):
+		self.assertIn(str(self.started.name), self.participating())
+
+	def test_it_shows_threads_the_reader_replied_to(self):
+		self.assertIn(str(self.replied_to.name), self.participating())
+
+	def test_it_hides_threads_only_other_people_touched(self):
+		self.assertNotIn(str(self.untouched.name), self.participating())
+
+	def test_the_default_feed_is_not_filtered_by_participation(self):
+		self.assertIn(str(self.untouched.name), self.feed_names(self.member))
+
+
+class TestFeedOngoingPolls(DiscussionFeedTestCase):
+	"""Each row carries the polls still open in that thread, so the feed can render a
+	vote prompt without a second request."""
+
+	def test_a_thread_carries_its_own_polls_and_nobody_elses(self):
+		with_poll = self.post(self.member, "Has a poll")
+		without_poll = self.post(self.member, "Has no poll")
+		poll = create_poll("Ship on Friday?", with_poll)
+
+		rows = self.rows_by_name(self.member)
+
+		self.assertEqual([str(p.name) for p in rows[str(with_poll.name)].ongoing_polls], [str(poll.name)])
+		self.assertEqual(rows[str(without_poll.name)].ongoing_polls, [])
+
+	def test_a_poll_that_has_stopped_is_no_longer_ongoing(self):
+		discussion = self.post(self.member, "Has a stopped poll")
+		poll = create_poll("Ship on Friday?", discussion)
+		frappe.db.set_value("GP Poll", poll.name, "stopped_at", "2020-01-01 00:00:00", update_modified=False)
+
+		[row] = self.feed(self.member)
+
+		self.assertEqual(row.ongoing_polls, [])
+
+
+class TestFeedLastPostPreview(DiscussionFeedTestCase):
+	"""Each row carries a one-line preview of the newest post: a comment's text, a
+	poll's title, or the discussion's own body while nobody has replied."""
+
+	def test_it_previews_the_last_comment(self):
+		discussion = self.post(self.member, "Thread")
+		self.comment(discussion, self.second_member, "<p>The latest reply</p>")
+
+		[row] = self.feed(self.member)
+
+		self.assertEqual(row.last_comment_content, "The latest reply")
+
+	def test_it_names_the_last_poll(self):
+		discussion = self.post(self.member, "Thread")
+		with self.as_user(self.second_member):
+			create_poll("Ship on Friday?", discussion)
+
+		[row] = self.feed(self.member)
+
+		self.assertEqual(row.last_poll_title, "Ship on Friday?")
+
+	def test_a_thread_with_no_replies_previews_its_own_body(self):
+		self.post(self.member, "Thread", content="<p>The opening post</p>")
+
+		[row] = self.feed(self.member)
+
+		self.assertEqual(row.last_comment_content, "The opening post")

--- a/gameplan/tests/features/test_discussions.py
+++ b/gameplan/tests/features/test_discussions.py
@@ -1,16 +1,24 @@
 # Copyright (c) 2023, Frappe Technologies Pvt Ltd and Contributors
 # See license.txt
 
+import unittest
+from datetime import timedelta
+
 import frappe
 from frappe.utils import get_datetime
 
 from gameplan.gameplan.doctype.gp_discussion.api import (
 	clause_discussions_commented_by_user,
 	get_discussions,
+	parse_offset,
 )
 from gameplan.gameplan.doctype.gp_discussion.gp_discussion import has_permission
 from gameplan.gameplan.doctype.gp_unread_record.gp_unread_record import GPUnreadRecord
 from gameplan.tests.base import GameplanTestCase
+
+# The poll boundary belongs to the poll suite; the feed is its second reader, so it
+# borrows the same frozen instant rather than inventing one that could drift.
+from gameplan.tests.features.test_polls import STOP_INSTANT, frozen_clock
 from gameplan.tests.fixtures import (
 	create_community,
 	create_discussion,
@@ -573,6 +581,69 @@ class TestFeedPaging(DiscussionFeedTestCase):
 		self.assertEqual(first_page, names[:2])
 		self.assertEqual(second_page, names[2:])
 
+	def test_a_start_that_is_not_a_number_pages_from_the_beginning(self):
+		"""`start` is spliced into OFFSET. It used to go there as whatever string the
+		client sent — `start="1); DROP TABLE ..."` landed in the statement verbatim and
+		the database refused the whole query — so anything that is not a number now
+		means "no offset" rather than a 500.
+		"""
+		names = [str(thread.name) for thread in self.threads]
+
+		page = self.feed_names(
+			self.member, limit=2, order_by="name asc", start="1); DROP TABLE `tabGP Discussion`; --"
+		)
+
+		self.assertEqual(page, names[:2])
+
+	def test_a_negative_start_pages_from_the_beginning(self):
+		names = [str(thread.name) for thread in self.threads]
+
+		page = self.feed_names(self.member, limit=2, order_by="name asc", start=-5)
+
+		self.assertEqual(page, names[:2])
+
+
+class TestOffsetParsing(unittest.TestCase):
+	"""`parse_offset` is tested apart from the feed because the case that matters most —
+	a negative offset — is a syntax error on MariaDB but silently equals zero on the
+	SQLite bench, so a query-level test cannot tell the clamp from its absence.
+	"""
+
+	def test_a_number_is_kept(self):
+		self.assertEqual(parse_offset("2"), 2)
+
+	def test_sql_dressed_up_as_a_number_becomes_no_offset(self):
+		self.assertEqual(parse_offset("1); DROP TABLE `tabGP Discussion`; --"), 0)
+		self.assertEqual(parse_offset("0 UNION SELECT 1"), 0)
+
+	def test_a_negative_offset_is_clamped(self):
+		self.assertEqual(parse_offset(-5), 0)
+
+	def test_no_offset_at_all_is_the_first_page(self):
+		self.assertEqual(parse_offset(None), 0)
+
+
+class TestFeedFilterInput(DiscussionFeedTestCase):
+	"""`filters` reaches the query builder as the client sent it, so the endpoint has to
+	answer for the shapes a client can send."""
+
+	def test_a_filter_value_carrying_sql_is_matched_as_text(self):
+		"""Filter values are escaped by the query builder, so a value with a quote and a
+		tautology in it is a title nobody has, not a clause that widens the feed.
+		"""
+		self.post(self.member, "Ordinary thread")
+
+		self.assertEqual(self.feed_names(self.member, filters={"title": "x' OR 1=1 -- "}), [])
+
+	def test_a_filters_argument_that_is_not_a_mapping_is_refused(self):
+		"""`feed_type` and `participator` are lifted out of `filters` by key, so a JSON
+		list used to blow up on `.pop()` — an unhandled 500 on a whitelisted endpoint.
+		"""
+		with self.as_user(self.member), self.assertRaises(frappe.ValidationError):
+			# Straight to the endpoint: `feed()` normalises filters into a dict, which is
+			# exactly the shape this test needs to get past.
+			get_discussions(filters='["name", "asc"]', limit=20)
+
 
 class TestEmptyFeed(DiscussionFeedTestCase):
 	def test_a_feed_with_nothing_in_it_is_an_empty_list(self):
@@ -697,6 +768,97 @@ class TestFeedOngoingPolls(DiscussionFeedTestCase):
 		[row] = self.feed(self.member)
 
 		self.assertEqual(row.ongoing_polls, [])
+
+	def test_the_feed_and_the_ballot_close_at_the_same_instant(self):
+		"""The feed and the poll doctype are two readers of one rule, so they have to
+		agree microsecond for microsecond: while the feed still offers a poll the ballot
+		must still take a vote, and the instant it stops offering it the ballot must
+		refuse. They used to disagree at exactly `stopped_at` — the feed hid a poll the
+		doctype would happily have recorded a vote on.
+		"""
+		discussion = self.post(self.member, "Has a poll about to stop")
+		poll = create_poll("Ship on Friday?", discussion)
+		frappe.db.set_value("GP Poll", poll.name, "stopped_at", STOP_INSTANT, update_modified=False)
+		poll.reload()
+
+		with frozen_clock(STOP_INSTANT - timedelta(microseconds=1)):
+			[still_open] = self.feed(self.member)
+			with self.as_user(self.member):
+				poll.submit_vote("Yes")
+
+		with frozen_clock(STOP_INSTANT):
+			[now_closed] = self.feed(self.member)
+			with self.as_user(self.member), self.assertRaises(frappe.ValidationError):
+				poll.submit_vote("No")
+
+		self.assertEqual([str(p.name) for p in still_open.ongoing_polls], [str(poll.name)])
+		self.assertEqual(now_closed.ongoing_polls, [])
+
+
+class TestFeedSorting(DiscussionFeedTestCase):
+	"""`order_by` comes straight off the query string and is spliced into the query, so
+	it is checked against the sorts the feed actually offers before it gets there."""
+
+	def setUp(self):
+		super().setUp()
+		self.older = self.post(self.member, "Older")
+		self.newer = self.post(self.member, "Newer")
+		# Two posts a few microseconds apart would sort correctly by luck; fixed stamps
+		# make "newest first" mean something.
+		self.stamp(self.older, "2024-01-01 00:00:00")
+		self.stamp(self.newer, "2024-06-01 00:00:00")
+
+	def stamp(self, discussion, last_post_at):
+		frappe.db.set_value(
+			"GP Discussion", discussion.name, "last_post_at", last_post_at, update_modified=False
+		)
+
+	def test_newest_first_is_the_default(self):
+		self.assertEqual(self.feed_names(self.member), [str(self.newer.name), str(self.older.name)])
+
+	def test_oldest_first_reverses_the_feed(self):
+		names = self.feed_names(self.member, order_by="last_post_at asc")
+
+		self.assertEqual(names, [str(self.older.name), str(self.newer.name)])
+
+	def test_every_sort_the_app_asks_for_is_accepted(self):
+		"""The three sorts the feed's Select offers, the pinned strip's own sort, and the
+		upper-case spelling frappe-ui's OrderBy type also allows."""
+		for order_by in (
+			"last_post_at desc",
+			"last_post_at asc",
+			"creation desc",
+			"pinned_at desc",
+			"last_post_at DESC",
+		):
+			with self.subTest(order_by=order_by):
+				self.assertEqual(len(self.feed(self.member, order_by=order_by)), 2)
+
+	def test_a_bare_field_sorts_newest_first(self):
+		"""A directionless `order_by` is what raised the original 500. It is a shape
+		Frappe's own query engine accepts and reads as descending
+		(`frappe.database.query.Engine._validate_order_by`), so it keeps that meaning
+		here instead of being rejected.
+		"""
+		names = self.feed_names(self.member, order_by="last_post_at")
+
+		self.assertEqual(names, [str(self.newer.name), str(self.older.name)])
+
+	def test_a_field_the_feed_does_not_sort_by_is_refused(self):
+		with self.assertRaises(frappe.ValidationError):
+			self.feed(self.member, order_by="content desc")
+
+	def test_a_direction_that_is_not_asc_or_desc_is_refused(self):
+		with self.assertRaises(frappe.ValidationError):
+			self.feed(self.member, order_by="last_post_at sideways")
+
+	def test_a_multi_token_sort_is_refused_rather_than_being_spliced_in(self):
+		"""Three tokens never burst the old `split(" ", 1)` — maxsplit swept everything
+		after the field into the direction half, so this reached the database as
+		`ORDER BY "last_post_at" desc, name asc`: arbitrary trailing SQL, quietly executed.
+		"""
+		with self.assertRaises(frappe.ValidationError):
+			self.feed(self.member, order_by="last_post_at desc, name asc")
 
 
 class TestFeedLastPostPreview(DiscussionFeedTestCase):

--- a/gameplan/tests/features/test_drafts.py
+++ b/gameplan/tests/features/test_drafts.py
@@ -5,8 +5,22 @@
 
 import frappe
 
+from gameplan.gameplan.doctype.gp_draft.gp_draft import (
+	GPDraft,
+	commit_draft,
+	find_my_draft,
+	get_my_drafts,
+	publish_draft,
+)
 from gameplan.tests.base import GameplanTestCase
-from gameplan.tests.fixtures import create_member
+from gameplan.tests.fixtures import (
+	create_comment,
+	create_community,
+	create_discussion,
+	create_member,
+	create_space,
+	set_owner,
+)
 
 
 class TestDrafts(GameplanTestCase):
@@ -60,9 +74,6 @@ class TestDrafts(GameplanTestCase):
 		"""Singleton draft creation is a find-then-insert, so a rare race can leave two rows for
 		one reply. Reads collapse them: find_my_draft keeps the newest and deletes the rest, so the
 		composer resumes a single draft and the duplicate can't linger."""
-		from gameplan.gameplan.doctype.gp_draft.gp_draft import find_my_draft
-		from gameplan.tests.fixtures import create_community, create_discussion, create_space
-
 		# reference_name is a Dynamic Link, validated on insert — point at a real discussion.
 		team = create_community("Draft Heal Team")
 		project = create_space("Draft Heal Space", team.name)
@@ -90,15 +101,13 @@ class TestDrafts(GameplanTestCase):
 		remaining = frappe.get_all("GP Draft", filters={"owner": alice.name, **ref}, pluck="name")
 		self.assertEqual(remaining, [newer.name])
 		self.assertFalse(frappe.db.exists("GP Draft", older.name))
-
-	def test_deleting_a_comment_removes_its_edit_draft(self):
-		from gameplan.tests.fixtures import (
-			create_comment,
-			create_community,
-			create_discussion,
-			create_space,
+		# Permanently, not archived: a discarded autosave still holds the user's typing, and
+		# a Deleted Document copy would keep it readable long after the draft is gone.
+		self.assertFalse(
+			frappe.db.exists("Deleted Document", {"deleted_doctype": "GP Draft", "deleted_name": older.name})
 		)
 
+	def test_deleting_a_comment_removes_its_edit_draft(self):
 		alice = create_member("draft_comment_owner@example.com", "Draft Comment Owner")
 		community = create_community("Draft Comment Community", members=[alice])
 		space = create_space("Draft Comment Space", community)
@@ -119,3 +128,277 @@ class TestDrafts(GameplanTestCase):
 
 		self.assertFalse(frappe.db.exists("GP Comment", comment.name))
 		self.assertFalse(frappe.db.exists("GP Draft", draft.name))
+
+
+def _insert_draft(**fields):
+	"""Insert a draft as the current session user."""
+	return frappe.get_doc(doctype="GP Draft", **fields).insert()
+
+
+class TestDraftListScoping(GameplanTestCase):
+	"""The v2 list hook is one of the two independent layers that keep drafts private."""
+
+	def test_controller_list_query_scopes_drafts_to_the_session_user(self):
+		"""`GPDraft.get_list` is the hook `/api/v2/document/GP Draft` hands its query to, and
+		v2 keeps the *unnarrowed* query when the hook returns None. So the hook has to narrow
+		on its own merits: this exercises it against a query built with permissions off, which
+		is the only way to see the hook rather than the permission_query_conditions layer
+		underneath it (gameplan.permissions.draft_query_conditions, which mirrors this rule)."""
+		with self.as_user(self.member):
+			mine = _insert_draft(type="Discussion", mode="New", content="my draft")
+		with self.as_user(self.second_member):
+			theirs = _insert_draft(type="Discussion", mode="New", content="their draft")
+
+			query = frappe.qb.get_query(
+				"GP Draft",
+				fields=["name"],
+				filters={"name": ["in", [mine.name, theirs.name]]},
+				ignore_permissions=True,
+			)
+			narrowed = GPDraft.get_list(query)
+			self.assertIsNotNone(narrowed, "get_list must return the narrowed query; v2 discards None")
+			names = [row.name for row in narrowed.run(as_dict=True)]
+
+		self.assertEqual(names, [theirs.name])
+
+
+class TestDraftPublish(GameplanTestCase):
+	"""Publishing turns a draft into a discussion and destroys the draft — a one-way step."""
+
+	def setUp(self):
+		super().setUp()
+		self.community = create_community("Draft Publish Community", members=[self.member])
+		self.space = create_space("Draft Publish Space", self.community)
+
+	def _draft(self, content="<p>draft body</p>"):
+		with self.as_user(self.member):
+			return _insert_draft(
+				type="Discussion",
+				mode="New",
+				title="Draft title",
+				content=content,
+				project=self.space.name,
+			)
+
+	def test_publishing_creates_the_discussion_and_removes_the_draft(self):
+		draft = self._draft()
+
+		with self.as_user(self.member):
+			discussion_name = publish_draft(draft.name)
+
+		# The client routes to the new discussion using this name, so returning nothing
+		# strands the author on a draft that no longer exists.
+		self.assertIsNotNone(discussion_name)
+		discussion = frappe.get_doc("GP Discussion", discussion_name)
+		self.assertEqual(discussion.title, "Draft title")
+		self.assertIn("draft body", discussion.content)
+		self.assertEqual(str(discussion.project), str(self.space.name))
+		self.assertFalse(frappe.db.exists("GP Draft", draft.name))
+
+	def test_publishing_strips_image_query_params_from_the_content(self):
+		"""Draft images carry a ?fid= pointer to the file attached to the draft. The draft is
+		deleted on publish, so a surviving ?fid= renders as a broken image in the discussion."""
+		draft = self._draft(content='<p><img src="/files/pic.png?fid=abc123"></p>')
+
+		with self.as_user(self.member):
+			discussion_name = publish_draft(draft.name)
+
+		content = frappe.db.get_value("GP Discussion", discussion_name, "content")
+		self.assertIn('src="/files/pic.png"', content)
+		self.assertNotIn("fid=", content)
+
+	def test_only_the_owner_can_publish_a_draft(self):
+		"""Drafts are readable by name (share-by-link), so the publish gate is the only thing
+		stopping another member turning someone's half-written draft into a public post."""
+		draft = self._draft()
+
+		with self.as_user(self.second_member):
+			with self.assertRaises(frappe.ValidationError):
+				publish_draft(draft.name)
+
+		self.assertTrue(frappe.db.exists("GP Draft", draft.name))
+		self.assertEqual(frappe.db.count("GP Discussion", {"project": self.space.name}), 0)
+
+
+class TestDraftCommit(GameplanTestCase):
+	"""Committing finalises an edit whose content is already on the target document."""
+
+	def setUp(self):
+		super().setUp()
+		self.community = create_community("Draft Commit Community", members=[self.member])
+		self.space = create_space("Draft Commit Space", self.community)
+		self.discussion = create_discussion("Draft Commit Discussion", self.space, owner=self.member)
+
+	def _target_and_draft(self, content):
+		comment = create_comment(self.discussion, content=content, owner=self.member)
+		with self.as_user(self.member):
+			draft = _insert_draft(
+				type="Comment",
+				mode="Edit",
+				reference_doctype="GP Comment",
+				reference_name=str(comment.name),
+				content=content,
+			)
+		return comment, draft
+
+	def test_committing_leaves_already_clean_target_content_untouched(self):
+		"""The target holds the finished text; commit only migrates attachments and deletes the
+		draft. Rewriting the target here would silently blank an edit the user just saved."""
+		comment, draft = self._target_and_draft("<p>the final wording</p>")
+		saved = frappe.db.get_value("GP Comment", comment.name, "content")
+
+		with self.as_user(self.member):
+			commit_draft(draft.name, "GP Comment", str(comment.name))
+
+		self.assertEqual(frappe.db.get_value("GP Comment", comment.name, "content"), saved)
+		self.assertFalse(frappe.db.exists("GP Draft", draft.name))
+
+	def test_committing_strips_image_query_params_from_the_target(self):
+		"""Images pasted while editing point at the draft's copy of the file (?fid=). Commit
+		reparents the file and must clear the pointer, or the edited comment shows a broken image."""
+		comment, draft = self._target_and_draft('<p><img src="/files/pic.png?fid=abc123"></p>')
+
+		with self.as_user(self.member):
+			commit_draft(draft.name, "GP Comment", str(comment.name))
+
+		content = frappe.db.get_value("GP Comment", comment.name, "content")
+		self.assertIn('src="/files/pic.png"', content)
+		self.assertNotIn("fid=", content)
+
+	def test_only_the_owner_can_commit_a_draft(self):
+		comment, draft = self._target_and_draft("<p>the final wording</p>")
+
+		with self.as_user(self.second_member):
+			with self.assertRaises(frappe.ValidationError):
+				commit_draft(draft.name, "GP Comment", str(comment.name))
+
+		self.assertTrue(frappe.db.exists("GP Draft", draft.name))
+
+
+class TestFindMyDraft(GameplanTestCase):
+	def test_find_my_draft_resolves_a_draft_that_has_no_reference(self):
+		"""Not every singleton draft points at a target: an in-flight new post is keyed by
+		(owner, type, mode) alone. That branch still has to hand the row back, or the composer
+		reopens empty and the user's typing looks lost."""
+		with self.as_user(self.member):
+			draft = _insert_draft(type="Discussion", mode="New", content="resume this")
+
+			result = find_my_draft(type="Discussion", mode="New")
+
+		self.assertIsNotNone(result)
+		self.assertEqual(result["name"], draft.name)
+		self.assertIn("resume this", result["content"])
+
+
+class TestMyDrafts(GameplanTestCase):
+	"""The Drafts list: what it shows, what metadata it resolves, and what it must hide."""
+
+	def setUp(self):
+		super().setUp()
+		self.community = create_community("My Drafts Community", members=[self.member])
+		self.space = create_space("My Drafts Space", self.community)
+
+	def test_lists_discussion_drafts_with_their_space(self):
+		"""The row carries the space's title, community and privacy so the list can render and
+		route without an N+1 round trip per draft."""
+		with self.as_user(self.member):
+			draft = _insert_draft(
+				type="Discussion",
+				mode="New",
+				title="Half-written post",
+				content="body",
+				project=self.space.name,
+			)
+
+			drafts = get_my_drafts()
+
+		self.assertEqual([row["name"] for row in drafts], [draft.name])
+		row = drafts[0]
+		self.assertEqual(row["kind"], "discussion")
+		self.assertEqual(row["title"], "Half-written post")
+		self.assertEqual(str(row["space"]), str(self.space.name))
+		self.assertEqual(row["space_title"], "My Drafts Space")
+		self.assertEqual(str(row["community"]), str(self.community.name))
+		self.assertEqual(row["is_private"], 0)
+		self.assertIsNone(row["discussion"])
+
+	def test_lists_comment_drafts_with_their_parent_discussion(self):
+		"""A reply draft stores only its text and a reference, so the list resolves the parent
+		discussion's title and space here — without them the row is unrenderable and unroutable."""
+		discussion = create_discussion("Reply Target", self.space)
+		with self.as_user(self.member):
+			draft = _insert_draft(
+				type="Comment",
+				mode="New",
+				reference_doctype="GP Discussion",
+				reference_name=str(discussion.name),
+				content="half-written reply",
+			)
+
+			drafts = get_my_drafts()
+
+		self.assertEqual([row["name"] for row in drafts], [draft.name])
+		row = drafts[0]
+		self.assertEqual(row["kind"], "comment")
+		self.assertEqual(row["title"], "Reply Target")
+		self.assertEqual(str(row["discussion"]), str(discussion.name))
+		self.assertEqual(str(row["space"]), str(self.space.name))
+		self.assertEqual(row["space_title"], "My Drafts Space")
+		self.assertEqual(str(row["community"]), str(self.community.name))
+
+	def test_hides_a_draft_in_a_space_the_user_can_no_longer_reach(self):
+		"""Membership can be revoked after the draft was written. The space lookup is the gate:
+		if it stops checking permissions the list leaks the private space's title and hands back
+		a route the user cannot open."""
+		private_space = create_space("Locked Space", self.community, is_private=1)
+		draft = frappe.get_doc(
+			doctype="GP Draft",
+			type="Discussion",
+			mode="New",
+			title="Written before I lost access",
+			content="body",
+			project=private_space.name,
+		).insert(ignore_permissions=True)
+		set_owner(draft, self.member)
+
+		with self.as_user(self.member):
+			drafts = get_my_drafts()
+
+		self.assertEqual(drafts, [])
+
+	def test_marks_a_draft_with_no_space_as_public(self):
+		"""A new post drafted before a space is chosen has no space at all. Defaulting it to
+		private would put a lock badge on a draft nobody has restricted."""
+		with self.as_user(self.member):
+			_insert_draft(type="Discussion", mode="New", title="No space yet", content="body")
+
+			drafts = get_my_drafts()
+
+		row = drafts[0]
+		self.assertIsNone(row["space"])
+		self.assertIsNone(row["space_title"])
+		self.assertIsNone(row["community"])
+		self.assertEqual(row["is_private"], 0)
+
+	def test_collapses_duplicate_reply_drafts_and_deletes_them_permanently(self):
+		"""Same self-healing as find_my_draft, on the list path: the newest reply survives and
+		the stale sibling is destroyed outright rather than archived into Deleted Document,
+		where the abandoned text would stay readable."""
+		discussion = create_discussion("Duplicate Reply Target", self.space)
+		reference = dict(
+			type="Comment",
+			mode="New",
+			reference_doctype="GP Discussion",
+			reference_name=str(discussion.name),
+		)
+		with self.as_user(self.member):
+			older = _insert_draft(content="older", **reference)
+			newer = _insert_draft(content="newer", **reference)
+
+			drafts = get_my_drafts()
+
+		self.assertEqual([row["name"] for row in drafts], [newer.name])
+		self.assertFalse(frappe.db.exists("GP Draft", older.name))
+		self.assertFalse(
+			frappe.db.exists("Deleted Document", {"deleted_doctype": "GP Draft", "deleted_name": older.name})
+		)

--- a/gameplan/tests/features/test_email_digest.py
+++ b/gameplan/tests/features/test_email_digest.py
@@ -1,19 +1,24 @@
 # Copyright (c) 2026, Frappe Technologies Pvt Ltd and contributors
 # See license.txt
 
+from contextlib import contextmanager
 from datetime import date
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 from urllib.parse import parse_qs, urlparse
 
 import frappe
 from frappe.email.email_body import get_formatted_html
-from frappe.utils import get_url
+from frappe.utils import add_to_date, get_url, now_datetime
 from frappe.utils.jinja import get_email_from_template
 
 from gameplan.email_digest import (
+	DIGEST_PREFERENCES_REDIRECT,
 	get_due_profiles,
+	get_safe_digest_redirect,
 	get_unread_discussions,
 	is_digest_due,
+	is_valid_digest_login_link,
+	open_digest_preferences,
 	send_digest_for_profile,
 )
 from gameplan.tests.base import GameplanTestCase
@@ -419,3 +424,141 @@ class TestEmailDigest(GameplanTestCase):
 		self.assertEqual(query["redirect"], [redirect])
 		self.assertIn("expires", query)
 		self.assertIn("_signature", query)
+
+
+def as_expires(moment):
+	return moment.strftime("%Y-%m-%d %H:%M:%S")
+
+
+class TestDigestLoginLink(GameplanTestCase):
+	"""Pins the gates behind `open_digest_preferences`, which is `allow_guest` and logs a user in.
+
+	`verify_request`'s HMAC is the primary defense — nobody forges a link without the site
+	secret. These cover the layer behind it, so a refactor cannot silently drop the expiry
+	check, the `enabled` check or the redirect allowlist. The two regressions they exist to
+	catch: an expired digest link working forever, and an offboarded user logging in from an
+	old digest email.
+	"""
+
+	def setUp(self):
+		super().setUp()
+		self.link_user = create_member(
+			f"digest-link-{frappe.generate_hash(length=8)}@example.com", "Link User"
+		)
+		self.future = as_expires(add_to_date(now_datetime(), days=1))
+		self.past = as_expires(add_to_date(now_datetime(), days=-1))
+
+	@contextmanager
+	def isolated_response(self):
+		"""Swap in a throwaway `frappe.local.response`.
+
+		Both branches under test write to the shared response — `respond_as_web_page` on
+		rejection, the redirect keys on success — and that dict outlives the test.
+		"""
+		previous = frappe.local.response
+		frappe.local.response = frappe._dict()
+		try:
+			yield frappe.local.response
+		finally:
+			frappe.local.response = previous
+
+	def test_link_for_an_enabled_user_before_expiry_is_valid(self):
+		with self.isolated_response():
+			self.assertIs(is_valid_digest_login_link(self.link_user.name, self.future), True)
+
+	def test_link_is_rejected_when_either_user_or_expiry_is_missing(self):
+		"""A missing field is rejected outright, before the clock is ever consulted.
+
+		Asserting the clock goes untouched is the point, not incidental strictness. A
+		missing `expires` would otherwise reach `get_datetime(None) < now_datetime()`,
+		which compares "now" against a "now" sampled microseconds later — it rejects by
+		accident, and only because evaluating the left side takes non-zero time.
+		"""
+		for user, expires in ((None, self.future), (self.link_user.name, None), (None, None)):
+			with (
+				self.subTest(user=user, expires=expires),
+				self.isolated_response(),
+				patch("gameplan.email_digest.now_datetime") as clock,
+			):
+				self.assertIs(is_valid_digest_login_link(user, expires), False)
+				clock.assert_not_called()
+
+	def test_expired_link_is_rejected(self):
+		with self.isolated_response():
+			self.assertIs(is_valid_digest_login_link(self.link_user.name, self.past), False)
+
+	def test_link_is_valid_up_to_and_including_its_expiry_moment(self):
+		# Truncated to the second because that is the resolution `get_signed_digest_url`
+		# writes; a microsecond of drift would make this an expired-link test by accident.
+		frozen = now_datetime().replace(microsecond=0)
+
+		with self.isolated_response(), patch("gameplan.email_digest.now_datetime", return_value=frozen):
+			self.assertIs(is_valid_digest_login_link(self.link_user.name, as_expires(frozen)), True)
+
+	def test_link_for_a_disabled_user_is_rejected(self):
+		frappe.db.set_value("User", self.link_user.name, "enabled", 0, update_modified=False)
+
+		with self.isolated_response():
+			self.assertIs(is_valid_digest_login_link(self.link_user.name, self.future), False)
+
+	def test_link_for_a_deleted_user_is_rejected(self):
+		with self.isolated_response():
+			self.assertIs(is_valid_digest_login_link("digest-ghost@example.com", self.future), False)
+
+	def test_in_app_redirect_is_preserved(self):
+		self.assertEqual(get_safe_digest_redirect("/g/spaces"), "/g/spaces")
+
+	def test_offsite_redirects_fall_back_to_the_preferences_page(self):
+		hostile = (
+			"//evil.example.com",
+			"https://evil.example.com",
+			"/g\\evil.example.com",
+			"\\\\evil.example.com",
+			"/other",
+		)
+
+		for redirect in hostile:
+			with self.subTest(redirect=redirect):
+				self.assertEqual(get_safe_digest_redirect(redirect), DIGEST_PREFERENCES_REDIRECT)
+
+	def test_endpoint_stays_reachable_without_a_session(self):
+		# The link is opened from an email client, so losing allow_guest would break every
+		# digest link for logged-out readers.
+		with self.as_user("Guest"):
+			frappe.is_whitelisted(open_digest_preferences)
+
+	def test_signed_valid_link_logs_the_user_in_and_redirects(self):
+		response, login_manager = self.open_preferences(
+			verified=True, expires=self.future, redirect="/g/spaces"
+		)
+
+		login_manager.login_as.assert_called_once_with(self.link_user.name)
+		self.assertEqual(response["type"], "redirect")
+		self.assertEqual(response["location"], "/g/spaces")
+
+	def test_unsigned_request_does_not_log_the_user_in(self):
+		response, login_manager = self.open_preferences(verified=False, expires=self.future)
+
+		login_manager.login_as.assert_not_called()
+		self.assertNotIn("location", response)
+
+	def test_invalid_link_does_not_log_the_user_in(self):
+		response, login_manager = self.open_preferences(verified=True, expires=self.past)
+
+		login_manager.login_as.assert_not_called()
+		self.assertNotIn("location", response)
+
+	def open_preferences(self, verified, expires, redirect=DIGEST_PREFERENCES_REDIRECT):
+		"""Call the endpoint with the signature check stubbed and the login manager faked.
+
+		Returns `(response, login_manager)` to assert on.
+		"""
+		login_manager = MagicMock()
+		with (
+			self.isolated_response() as response,
+			patch("gameplan.email_digest.verify_request", return_value=verified),
+			patch.object(frappe.local, "login_manager", login_manager, create=True),
+		):
+			open_digest_preferences(user=self.link_user.name, redirect=redirect, expires=expires)
+
+		return response, login_manager

--- a/gameplan/tests/features/test_members.py
+++ b/gameplan/tests/features/test_members.py
@@ -9,6 +9,8 @@ authenticated Gameplan user (incl. a Guest) could change roles, disable
 accounts, or send invites. The contract: only admins may call them.
 """
 
+from unittest.mock import patch
+
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
@@ -108,10 +110,23 @@ class TestMemberManagement(FrappeTestCase):
 		project.save(ignore_permissions=True)
 
 		frappe.set_user(member.name)
-		project.invite_guest("invited_guest@example.com")
+		# GP Invitation.after_insert emails the invitee, so without this the assertion
+		# under test would hinge on the site having an outgoing Email Account (CI mutes
+		# mail via site config; a plain dev site raises OutgoingEmailError). Same mute as
+		# InvitationTestCase in test_invitations.py.
+		with patch("frappe.sendmail"):
+			project.invite_guest("invited_guest@example.com")
 
 		frappe.set_user("Administrator")
-		self.assertTrue(frappe.db.exists("GP Invitation", {"email": "invited_guest@example.com"}))
+		invitation = frappe.db.get_value(
+			"GP Invitation",
+			{"email": "invited_guest@example.com"},
+			["role", "projects"],
+			as_dict=True,
+		)
+		self.assertIsNotNone(invitation)
+		self.assertEqual(invitation.role, "Gameplan Guest")
+		self.assertEqual(frappe.parse_json(invitation.projects), [project.name])
 
 	def test_get_user_info_hides_email_from_guest(self):
 		"""A Guest caller must not receive other members' email addresses."""

--- a/gameplan/tests/features/test_per_user_state.py
+++ b/gameplan/tests/features/test_per_user_state.py
@@ -1,0 +1,417 @@
+# Copyright (c) 2026, Frappe Technologies Pvt Ltd and Contributors
+# See license.txt
+
+"""Per-user state is private to its user.
+
+Four doctypes hold state that belongs to exactly one person:
+
+- **GP Notification** — the bell feed. `to_user` owns the row; `owner` is whoever
+  *triggered* it (the mentioner), so ownership and readership differ here.
+- **GP Project Visit** — per-user last-visit / "mark all read" watermark for a Space.
+- **GP Discussion Visit** — per-user last-visit for a discussion.
+- **GP Pinned Project** — the Spaces one user has pinned to their own sidebar, and
+  the order they sit in.
+
+All four grant Gameplan Member and Gameplan Guest read, write and (for pins) delete
+with `if_owner` unset, so role permissions alone let any signed-in user reach any other
+user's row through the generic `/api/v2/document/<doctype>` API. The invariant pinned
+here is: you can read, list, write and delete **your own** rows and nobody else's —
+while every server-side writer (a mention creating a notification *for* someone,
+`track_visit`, `mark_all_as_read`, the unread-record backfill, `GPProject.archive`
+clearing the whole site's pins) keeps working, because those run with
+`ignore_permissions` and must not be caught by the fix.
+
+The list assertions go through `frappe.qb.get_query(..., ignore_permissions=False)`
+because that is literally what `frappe/api/v2.py::document_list` runs. `if_owner` on
+the role row would not cover this doctype set at all: for GP Notification the owner is
+the sender, not the recipient, and the demo seeder inserts visit and pin rows *for*
+another user while running as Administrator.
+"""
+
+import frappe
+
+from gameplan import per_user_state
+from gameplan.api import mark_all_notifications_as_read
+from gameplan.gameplan.doctype.gp_notification.gp_notification import GPNotification
+from gameplan.gameplan.doctype.gp_unread_record.gp_unread_record import GPUnreadRecord
+from gameplan.tests.base import GameplanTestCase
+from gameplan.tests.fixtures import create_community, create_discussion, create_space
+
+
+def list_as_client(doctype, **filters):
+	"""Enumerate `doctype` exactly the way `/api/v2/document/<doctype>` does."""
+	return frappe.qb.get_query(
+		doctype,
+		fields=["name"],
+		filters=filters,
+		ignore_permissions=False,
+	).run(pluck="name")
+
+
+class PerUserStateTestCase(GameplanTestCase):
+	def setUp(self):
+		super().setUp()
+		self.community = create_community("Acme", members=[self.member, self.second_member])
+		self.space = create_space("Engineering", self.community)
+		self.discussion = create_discussion("Roadmap", self.space, owner=self.member)
+
+
+class TestNotificationPrivacy(PerUserStateTestCase):
+	def setUp(self):
+		super().setUp()
+		# Inserted as the second member so `owner` is deliberately NOT `to_user`: this is
+		# the real shape of a mention notification, and the reason `if_owner` cannot work.
+		with self.as_user(self.second_member):
+			self.notification = frappe.get_doc(
+				doctype="GP Notification",
+				to_user=self.member.name,
+				type="Mention",
+				message="Second Member mentioned you",
+				discussion=self.discussion.name,
+			).insert(ignore_permissions=True)
+
+	def test_recipient_can_read_own_notification(self):
+		self.assert_allowed(self.notification, "read", self.member)
+
+	def test_recipient_can_list_own_notification(self):
+		with self.as_user(self.member):
+			self.assertIn(self.notification.name, list_as_client("GP Notification"))
+
+	def test_recipient_can_mark_own_notification_read(self):
+		with self.as_user(self.member):
+			doc = frappe.get_doc("GP Notification", self.notification.name)
+			doc.read = 1
+			doc.save()
+		self.assertEqual(frappe.db.get_value("GP Notification", self.notification.name, "read"), 1)
+
+	def test_sender_cannot_read_notification_they_triggered(self):
+		# The mentioner created the row, so `owner` is theirs — but the notification is
+		# addressed to someone else and must stay out of their bell feed.
+		self.assert_not_allowed(self.notification, "read", self.second_member)
+
+	def test_other_user_cannot_read_notification(self):
+		self.assert_not_allowed(self.notification, "read", self.outsider)
+
+	def test_other_user_cannot_list_notification(self):
+		with self.as_user(self.outsider):
+			self.assertNotIn(self.notification.name, list_as_client("GP Notification"))
+
+	def test_other_user_cannot_mark_notification_read(self):
+		with self.as_user(self.outsider):
+			doc = frappe.get_doc("GP Notification", self.notification.name)
+			doc.read = 1
+			with self.assertRaises(frappe.PermissionError):
+				doc.save()
+		self.assertEqual(frappe.db.get_value("GP Notification", self.notification.name, "read"), 0)
+
+	def test_user_cannot_create_notification_addressed_to_someone_else(self):
+		with self.as_user(self.outsider), self.assertRaises(frappe.PermissionError):
+			frappe.get_doc(
+				doctype="GP Notification",
+				to_user=self.member.name,
+				type="Mention",
+				message="Forged",
+			).insert()
+
+	def test_mention_still_creates_notification_for_the_mentioned_user(self):
+		mention = (
+			f'<p>Hi <span data-type="mention" data-id="{self.second_member.name}" '
+			'data-label="Second Member">@Second Member</span></p>'
+		)
+		with self.as_user(self.member):
+			create_discussion("Mentioning", self.space, content=mention)
+		self.assertTrue(
+			frappe.db.exists("GP Notification", {"to_user": self.second_member.name, "type": "Mention"})
+		)
+
+	def test_clear_notifications_still_marks_own_rows_read(self):
+		with self.as_user(self.member):
+			GPNotification.clear_notifications(discussion=self.discussion.name)
+		self.assertEqual(frappe.db.get_value("GP Notification", self.notification.name, "read"), 1)
+
+	def test_mark_all_notifications_as_read_still_works(self):
+		with self.as_user(self.member):
+			mark_all_notifications_as_read()
+		self.assertEqual(frappe.db.get_value("GP Notification", self.notification.name, "read"), 1)
+
+
+class TestProjectVisitPrivacy(PerUserStateTestCase):
+	def setUp(self):
+		super().setUp()
+		self.visit = frappe.get_doc(
+			doctype="GP Project Visit",
+			user=self.member.name,
+			project=self.space.name,
+			last_visit=frappe.utils.now(),
+		).insert(ignore_permissions=True)
+
+	def test_owner_can_read_own_visit(self):
+		self.assert_allowed(self.visit, "read", self.member)
+
+	def test_owner_can_list_own_visit(self):
+		with self.as_user(self.member):
+			self.assertIn(self.visit.name, list_as_client("GP Project Visit"))
+
+	def test_other_member_cannot_read_visit(self):
+		self.assert_not_allowed(self.visit, "read", self.second_member)
+
+	def test_other_member_cannot_list_visit(self):
+		with self.as_user(self.second_member):
+			self.assertNotIn(self.visit.name, list_as_client("GP Project Visit"))
+
+	def test_other_member_cannot_rewrite_visit(self):
+		with self.as_user(self.second_member):
+			doc = frappe.get_doc("GP Project Visit", self.visit.name)
+			doc.mark_all_read_at = frappe.utils.now()
+			with self.assertRaises(frappe.PermissionError):
+				doc.save()
+		self.assertIsNone(
+			frappe.db.get_value("GP Project Visit", self.visit.name, "mark_all_read_at"),
+		)
+
+	def test_user_cannot_create_visit_for_someone_else(self):
+		with self.as_user(self.second_member), self.assertRaises(frappe.PermissionError):
+			frappe.get_doc(
+				doctype="GP Project Visit",
+				user=self.outsider.name,
+				project=self.space.name,
+				last_visit=frappe.utils.now(),
+			).insert()
+
+	def test_track_visit_still_records_the_session_user(self):
+		with self.as_user(self.second_member):
+			frappe.get_doc("GP Project", self.space.name).track_visit()
+		self.assertTrue(
+			frappe.db.exists(
+				"GP Project Visit", {"user": self.second_member.name, "project": self.space.name}
+			)
+		)
+
+	def test_mark_all_as_read_still_writes_the_watermark(self):
+		with self.as_user(self.second_member):
+			frappe.get_doc("GP Project", self.space.name).mark_all_as_read()
+		self.assertIsNotNone(
+			frappe.db.get_value(
+				"GP Project Visit",
+				{"user": self.second_member.name, "project": self.space.name},
+				"mark_all_read_at",
+			)
+		)
+
+	def test_deleting_a_space_still_takes_every_users_visit_row(self):
+		# A cascade delete legitimately removes other people's rows: the parent delete is
+		# authorised once and its children go with it.
+		with self.as_user(self.admin):
+			frappe.delete_doc("GP Project", self.space.name)
+		self.assertFalse(frappe.db.exists("GP Project Visit", self.visit.name))
+
+	def test_unread_record_backfill_still_creates_visits_for_a_user(self):
+		# Runs as Administrator on behalf of another user — a legitimate cross-user writer.
+		now = frappe.utils.now()
+		GPUnreadRecord.create_project_visits([self.space.name], self.outsider.name, now, now)
+		self.assertTrue(
+			frappe.db.exists("GP Project Visit", {"user": self.outsider.name, "project": self.space.name})
+		)
+
+
+class TestDiscussionVisitPrivacy(PerUserStateTestCase):
+	def setUp(self):
+		super().setUp()
+		self.visit = frappe.get_doc(
+			doctype="GP Discussion Visit",
+			user=self.member.name,
+			discussion=self.discussion.name,
+			last_visit=frappe.utils.now(),
+		).insert(ignore_permissions=True)
+
+	def test_owner_can_read_own_visit(self):
+		self.assert_allowed(self.visit, "read", self.member)
+
+	def test_owner_can_list_own_visit(self):
+		with self.as_user(self.member):
+			self.assertIn(self.visit.name, list_as_client("GP Discussion Visit"))
+
+	def test_other_member_cannot_read_visit(self):
+		self.assert_not_allowed(self.visit, "read", self.second_member)
+
+	def test_other_member_cannot_list_visit(self):
+		with self.as_user(self.second_member):
+			self.assertNotIn(self.visit.name, list_as_client("GP Discussion Visit"))
+
+	def test_other_member_cannot_rewrite_visit(self):
+		original = frappe.db.get_value("GP Discussion Visit", self.visit.name, "last_visit")
+		with self.as_user(self.second_member):
+			doc = frappe.get_doc("GP Discussion Visit", self.visit.name)
+			doc.last_visit = "2000-01-01 00:00:00"
+			with self.assertRaises(frappe.PermissionError):
+				doc.save()
+		self.assertEqual(frappe.db.get_value("GP Discussion Visit", self.visit.name, "last_visit"), original)
+
+	def test_user_cannot_create_visit_for_someone_else(self):
+		with self.as_user(self.second_member), self.assertRaises(frappe.PermissionError):
+			frappe.get_doc(
+				doctype="GP Discussion Visit",
+				user=self.outsider.name,
+				discussion=self.discussion.name,
+				last_visit=frappe.utils.now(),
+			).insert()
+
+	def test_deleting_a_discussion_still_takes_every_readers_visit_row(self):
+		# The discussion owner deletes their thread; this visit row belongs to someone
+		# else, and the cascade must still be allowed to remove it.
+		other = frappe.get_doc(
+			doctype="GP Discussion Visit",
+			user=self.second_member.name,
+			discussion=self.discussion.name,
+			last_visit=frappe.utils.now(),
+		).insert(ignore_permissions=True)
+
+		with self.as_user(self.member):
+			frappe.delete_doc("GP Discussion", self.discussion.name)
+
+		self.assertFalse(frappe.db.exists("GP Discussion Visit", other.name))
+
+	def test_track_visit_still_records_the_session_user(self):
+		with self.as_user(self.second_member):
+			frappe.get_doc("GP Discussion", self.discussion.name).track_visit()
+		self.assertTrue(
+			frappe.db.exists(
+				"GP Discussion Visit",
+				{"user": self.second_member.name, "discussion": self.discussion.name},
+			)
+		)
+
+
+class TestPinnedProjectPrivacy(PerUserStateTestCase):
+	"""A pin is one person's own sidebar shortcut to a Space.
+
+	Unlike the visit doctypes this one also grants `delete` to Gameplan Member and
+	Gameplan Guest, and delete is how unpinning works — there is no unpin endpoint, the
+	SPA removes the row through the generic document API. So the delete grant has to
+	stay, and the hook is the only thing standing between it and someone else's sidebar.
+	"""
+
+	def setUp(self):
+		super().setUp()
+		self.pin = self.pin_as(self.member)
+
+	def pin_as(self, user):
+		"""Pin `self.space` as `user`.
+
+		`GPPinnedProject.before_insert` stamps `user` with the session user, so who is
+		logged in decides whose pin this is — there is no field to pass.
+		"""
+		with self.as_user(user):
+			return frappe.get_doc(doctype="GP Pinned Project", project=self.space.name).insert(
+				ignore_permissions=True
+			)
+
+	def test_owner_can_read_own_pin(self):
+		self.assert_allowed(self.pin, "read", self.member)
+
+	def test_owner_can_list_own_pin(self):
+		with self.as_user(self.member):
+			self.assertIn(self.pin.name, list_as_client("GP Pinned Project"))
+
+	def test_owner_can_reorder_own_pin(self):
+		with self.as_user(self.member):
+			doc = frappe.get_doc("GP Pinned Project", self.pin.name)
+			doc.order = 5
+			doc.save()
+		self.assertEqual(frappe.db.get_value("GP Pinned Project", self.pin.name, "order"), 5)
+
+	def test_owner_can_unpin_by_deleting_own_pin(self):
+		with self.as_user(self.member):
+			frappe.delete_doc("GP Pinned Project", self.pin.name)
+		self.assertFalse(frappe.db.exists("GP Pinned Project", self.pin.name))
+
+	def test_other_member_cannot_read_pin(self):
+		self.assert_not_allowed(self.pin, "read", self.second_member)
+
+	def test_other_member_cannot_list_pin(self):
+		with self.as_user(self.second_member):
+			self.assertNotIn(self.pin.name, list_as_client("GP Pinned Project"))
+
+	def test_other_member_cannot_reorder_pin(self):
+		with self.as_user(self.second_member):
+			doc = frappe.get_doc("GP Pinned Project", self.pin.name)
+			doc.order = 99
+			with self.assertRaises(frappe.PermissionError):
+				doc.save()
+		self.assertEqual(frappe.db.get_value("GP Pinned Project", self.pin.name, "order"), 1)
+
+	def test_other_member_cannot_unpin_someone_elses_pin(self):
+		with self.as_user(self.second_member), self.assertRaises(frappe.PermissionError):
+			frappe.delete_doc("GP Pinned Project", self.pin.name)
+		self.assertTrue(frappe.db.exists("GP Pinned Project", self.pin.name))
+
+	def test_guest_cannot_read_pin(self):
+		self.assert_not_allowed(self.pin, "read", self.guest)
+
+	def test_guest_cannot_list_pin(self):
+		with self.as_user(self.guest):
+			self.assertNotIn(self.pin.name, list_as_client("GP Pinned Project"))
+
+	def test_guest_cannot_unpin_someone_elses_pin(self):
+		with self.as_user(self.guest), self.assertRaises(frappe.PermissionError):
+			frappe.delete_doc("GP Pinned Project", self.pin.name)
+		self.assertTrue(frappe.db.exists("GP Pinned Project", self.pin.name))
+
+	def test_pinning_a_space_still_works_without_ignore_permissions(self):
+		"""The create check runs *before* `before_insert`, i.e. before `user` is stamped.
+
+		A create rule that judged the unstamped row would deny every legitimate pin, so
+		this is the regression guard on the carve-out in `pinned_project_has_permission`.
+		"""
+		with self.as_user(self.second_member):
+			pin = frappe.get_doc(doctype="GP Pinned Project", project=self.space.name).insert()
+		self.assertEqual(pin.user, self.second_member.name)
+
+	def test_archiving_a_space_still_clears_every_users_pin(self):
+		other_pin = self.pin_as(self.second_member)
+
+		with self.as_user(self.admin):
+			frappe.get_doc("GP Project", self.space.name).archive()
+
+		self.assertFalse(frappe.db.exists("GP Pinned Project", self.pin.name))
+		self.assertFalse(frappe.db.exists("GP Pinned Project", other_pin.name))
+
+	def test_deleting_a_space_still_takes_every_users_pin(self):
+		other_pin = self.pin_as(self.second_member)
+
+		with self.as_user(self.admin):
+			frappe.delete_doc("GP Project", self.space.name)
+
+		self.assertFalse(frappe.db.exists("GP Pinned Project", self.pin.name))
+		self.assertFalse(frappe.db.exists("GP Pinned Project", other_pin.name))
+
+
+class TestPerUserStateHooksAreRegistered(PerUserStateTestCase):
+	"""The doctypes' role rows are open by design; the hooks are what closes them."""
+
+	DOCTYPES = ["GP Notification", "GP Project Visit", "GP Discussion Visit", "GP Pinned Project"]
+
+	def test_every_per_user_doctype_has_a_query_conditions_hook(self):
+		hooks = frappe.get_hooks("permission_query_conditions")
+		for doctype in self.DOCTYPES:
+			self.assertTrue(hooks.get(doctype), f"{doctype} has no permission_query_conditions hook")
+
+	def test_every_per_user_doctype_has_a_has_permission_hook(self):
+		hooks = frappe.get_hooks("has_permission")
+		for doctype in self.DOCTYPES:
+			self.assertTrue(hooks.get(doctype), f"{doctype} has no has_permission hook")
+
+	def test_has_permission_hooks_return_a_hard_false_for_another_users_row(self):
+		"""`assertIs` on purpose: a hook that returned `None` would read as "no opinion"
+		to some callers and as a denial to `assertFalse`, hiding a return-none regression."""
+		visit = frappe.get_doc(
+			doctype="GP Project Visit",
+			user=self.member.name,
+			project=self.space.name,
+			last_visit=frappe.utils.now(),
+		).insert(ignore_permissions=True)
+
+		self.assertIs(
+			per_user_state.project_visit_has_permission(visit, "read", self.second_member.name), False
+		)
+		self.assertIs(per_user_state.project_visit_has_permission(visit, "read", self.member.name), True)

--- a/gameplan/tests/features/test_polls.py
+++ b/gameplan/tests/features/test_polls.py
@@ -672,6 +672,96 @@ class TestPollFieldProtection(PollTestCase):
 		self.assertEqual([(row.user, row.emoji) for row in poll.reactions], [(self.second_member.name, "👍")])
 
 
+class TestPollInAClosedDiscussion(PollTestCase):
+	"""A closed discussion refuses a poll, exactly as it refuses a comment.
+
+	The composer disappears client-side once a thread is closed, so nothing in the UI ever
+	exercises the server guard — which is precisely why it needs a test of its own.
+	"""
+
+	def close(self):
+		with self.as_user(self.member):
+			frappe.get_doc("GP Discussion", self.discussion.name).close_discussion()
+
+	def reopen(self):
+		with self.as_user(self.member):
+			frappe.get_doc("GP Discussion", self.discussion.name).reopen_discussion()
+
+	def test_a_poll_cannot_be_added_to_a_closed_discussion(self):
+		self.close()
+
+		with self.assertRaisesRegex(frappe.ValidationError, "Cannot add a poll to a closed discussion"):
+			create_poll("Too late?", self.discussion)
+
+		self.assertEqual(frappe.db.count("GP Poll", {"discussion": self.discussion.name}), 0)
+
+	def test_the_guard_only_bites_while_the_discussion_is_closed(self):
+		"""The other side of the same rule: an open thread — and a reopened one — still
+		takes polls, so the guard cannot simply refuse everything."""
+		poll = self.poll()
+		self.close()
+		self.reopen()
+
+		reopened_poll = create_poll("Back on?", self.discussion)
+
+		self.assertTrue(frappe.db.exists("GP Poll", poll.name))
+		self.assertTrue(frappe.db.exists("GP Poll", reopened_poll.name))
+
+
+class TestPollUpdatesItsDiscussion(PollTestCase):
+	"""Posting a poll is posting in the thread, so the thread's counters have to move.
+
+	The feed sorts and attributes a thread by `last_post_at` / `last_post_by` and shows
+	`comments_count` and `participants_count` on the row, so a poll that left them alone
+	would make an active thread look untouched since its last comment. Deleting the poll
+	has to walk all of that back — `GPPoll.after_delete` refreshes the same fields.
+	"""
+
+	def meta(self):
+		return frappe.db.get_value(
+			"GP Discussion",
+			self.discussion.name,
+			["comments_count", "participants_count", "last_post_type", "last_post", "last_post_by"],
+			as_dict=True,
+		)
+
+	def last_post_at(self):
+		return frappe.db.get_value("GP Discussion", self.discussion.name, "last_post_at")
+
+	def test_posting_a_poll_moves_the_threads_counters(self):
+		self.assertEqual(self.meta().comments_count, 0)
+
+		with self.as_user(self.second_member):
+			poll = create_poll("Ship on Friday?", self.discussion)
+
+		meta = self.meta()
+		self.assertEqual(meta.comments_count, 1)
+		# The thread's owner plus the poll's author — a poll's author is a participant in
+		# the thread just as a commenter is.
+		self.assertEqual(meta.participants_count, 2)
+		self.assertEqual(meta.last_post_type, "GP Poll")
+		self.assertEqual(str(meta.last_post), str(poll.name))
+		self.assertEqual(meta.last_post_by, self.second_member.name)
+		self.assertEqual(self.last_post_at(), get_datetime(poll.creation))
+
+	def test_deleting_the_poll_moves_them_back(self):
+		with self.as_user(self.second_member):
+			poll = create_poll("Ship on Friday?", self.discussion)
+		self.assertEqual(self.meta().comments_count, 1)
+
+		with self.as_user(self.second_member):
+			frappe.delete_doc("GP Poll", poll.name)
+
+		meta = self.meta()
+		self.assertEqual(meta.comments_count, 0)
+		self.assertEqual(meta.participants_count, 1)
+		self.assertIsNone(meta.last_post_type)
+		self.assertFalse(meta.last_post)
+		self.assertEqual(meta.last_post_by, self.member.name)
+		# Nothing left in the thread, so the discussion is its own last post again.
+		self.assertEqual(self.last_post_at(), get_datetime(self.discussion.creation))
+
+
 class TestDeletingAPoll(PollTestCase):
 	"""Deleting a discussion takes the polls inside it, whoever posted them.
 

--- a/gameplan/tests/features/test_polls.py
+++ b/gameplan/tests/features/test_polls.py
@@ -15,8 +15,13 @@ The other half of that rule is that a poll's ballot and lifecycle belong to its 
 go through `stop_poll` or straight at the document — TestPollFieldProtection locks that.
 """
 
+from contextlib import contextmanager
+from datetime import timedelta
+from unittest.mock import patch
+
 import frappe
-from frappe.utils import add_days, now_datetime
+import frappe.utils.data
+from frappe.utils import add_days, get_datetime, now_datetime
 
 from gameplan.gameplan.doctype.gp_poll.gp_poll import GPPoll
 from gameplan.tests.base import GameplanTestCase
@@ -28,6 +33,27 @@ from gameplan.tests.fixtures import (
 	declared_http_methods,
 	grant_guest_access,
 )
+
+# A fixed instant to stop a poll at. Far enough ahead that the real clock never reaches
+# it, so a test that forgets to freeze the clock fails instead of passing by accident.
+STOP_INSTANT = get_datetime("2099-01-01 09:00:00.500000")
+
+
+@contextmanager
+def frozen_clock(instant):
+	"""Hold the whole request at `instant`.
+
+	A poll closes on a microsecond boundary, and a test that waited for real time to
+	pass could only ever observe one side of it. `frappe.utils` re-exports
+	`now_datetime` under its own name, so both that binding and the definition in
+	`frappe.utils.data` (which `frappe.utils.now` calls) have to be replaced before
+	every reader of the clock agrees on where the boundary is.
+	"""
+	with (
+		patch.object(frappe.utils, "now_datetime", return_value=instant),
+		patch.object(frappe.utils.data, "now_datetime", return_value=instant),
+	):
+		yield
 
 
 class PollTestCase(GameplanTestCase):
@@ -355,6 +381,54 @@ class TestStoppingAPoll(PollTestCase):
 
 		self.vote(poll, self.second_member, "Yes")
 
+		self.assertEqual(poll.total_votes, 1)
+
+
+class TestTheStopInstant(PollTestCase):
+	"""`stopped_at` names the moment the poll stops, not the last moment it runs.
+
+	`stop_poll` stamps it with the current time, so if that exact microsecond still
+	counted as open a vote could land after the stop was recorded. The boundary is
+	therefore inclusive, and the discussion feed reads the same rule — see
+	TestFeedOngoingPolls.test_the_feed_and_the_ballot_close_at_the_same_instant.
+	"""
+
+	def stopping_poll(self):
+		poll = self.poll()
+		frappe.db.set_value("GP Poll", poll.name, "stopped_at", STOP_INSTANT, update_modified=False)
+		poll.reload()
+		return poll
+
+	def test_a_vote_at_the_stop_instant_is_refused(self):
+		poll = self.stopping_poll()
+
+		with frozen_clock(STOP_INSTANT), self.as_user(self.second_member):
+			with self.assertRaises(frappe.ValidationError):
+				poll.submit_vote("Yes")
+
+		poll.reload()
+		self.assertEqual(poll.total_votes, 0)
+
+	def test_a_vote_a_microsecond_earlier_is_accepted(self):
+		"""The other side of the same boundary: closing it one tick early would end
+		every poll before the instant it advertises."""
+		poll = self.stopping_poll()
+
+		with frozen_clock(STOP_INSTANT - timedelta(microseconds=1)), self.as_user(self.second_member):
+			poll.submit_vote("Yes")
+
+		poll.reload()
+		self.assertEqual(poll.total_votes, 1)
+
+	def test_a_retraction_at_the_stop_instant_is_refused(self):
+		poll = self.stopping_poll()
+		self.vote(poll, self.second_member, "Yes")
+
+		with frozen_clock(STOP_INSTANT), self.as_user(self.second_member):
+			with self.assertRaises(frappe.ValidationError):
+				poll.retract_vote()
+
+		poll.reload()
 		self.assertEqual(poll.total_votes, 1)
 
 

--- a/gameplan/tests/features/test_reactions.py
+++ b/gameplan/tests/features/test_reactions.py
@@ -14,10 +14,16 @@ file owns — is the operation contract of `react`:
   a quick toggle),
 - garbage in a batch is ignored, not stored,
 - reacting never touches the post itself.
+
+One notification property lives here rather than in the notifications spec: the unread
+flag `notify_reactions` resets on every reaction (`TestReactionNotificationUnreadState`).
+That spec covers what a reaction notification says and which post it points at; whether
+the row arrives unread is a property of this mixin's write path and nothing asserted it.
 """
 
 import frappe
 
+from gameplan.api import mark_all_notifications_as_read, unread_notifications
 from gameplan.mixins.reactions import HasReactions
 from gameplan.tests.base import GameplanTestCase
 from gameplan.tests.fixtures import (
@@ -272,6 +278,51 @@ class TestPollReactions(ReactionTestCase):
 		self.assertEqual([(v.user, v.option) for v in poll.votes], [(self.member.name, "Yes")])
 		self.assertEqual(poll.total_votes, 1)
 		self.assertEqual([o.title for o in poll.options], ["Yes", "No"])
+
+
+class TestReactionNotificationUnreadState(ReactionTestCase):
+	"""A reaction has to leave the post owner's bell unread, every time.
+
+	`notify_reactions` reuses one notification row per post, so `read = 0` is not a
+	default that happens to hold — it is the only thing that raises the badge again for
+	the second, third and tenth reactor after the owner has cleared it once. Drop it and
+	reactions become a channel that lights up exactly once and then goes silent.
+	"""
+
+	def bell_count(self, user):
+		"""What the bell badge shows for `user` (gameplan.api.unread_notifications)."""
+		with self.as_user(user):
+			return unread_notifications()
+
+	def clear_bell(self, user):
+		with self.as_user(user):
+			mark_all_notifications_as_read()
+
+	def reaction_notifications(self, user, discussion):
+		return frappe.get_all(
+			"GP Notification",
+			filters={"to_user": user.name, "type": "Reaction", "discussion": discussion.name},
+			pluck="name",
+		)
+
+	def test_a_reaction_lights_the_post_owners_bell(self):
+		self.clear_bell(self.member)
+
+		self.react(self.discussion, self.second_member, [add(THUMBS_UP)])
+
+		self.assertEqual(self.bell_count(self.member), 1)
+
+	def test_a_later_reaction_re_lights_a_bell_the_owner_already_cleared(self):
+		self.react(self.discussion, self.second_member, [add(THUMBS_UP)])
+		self.clear_bell(self.member)
+		self.assertEqual(self.bell_count(self.member), 0)
+
+		self.react(self.discussion, self.admin, [add(HEART)])
+
+		# One row, re-flagged rather than a second row appearing: on this path the reset
+		# is the only thing that can raise the badge.
+		self.assertEqual(len(self.reaction_notifications(self.member, self.discussion)), 1)
+		self.assertEqual(self.bell_count(self.member), 1)
 
 
 class TestReactionsSurviveAnEdit(ReactionTestCase):

--- a/gameplan/tests/features/test_reactions.py
+++ b/gameplan/tests/features/test_reactions.py
@@ -15,10 +15,11 @@ file owns — is the operation contract of `react`:
 - garbage in a batch is ignored, not stored,
 - reacting never touches the post itself.
 
-One notification property lives here rather than in the notifications spec: the unread
-flag `notify_reactions` resets on every reaction (`TestReactionNotificationUnreadState`).
-That spec covers what a reaction notification says and which post it points at; whether
-the row arrives unread is a property of this mixin's write path and nothing asserted it.
+Two notification properties live here rather than in the notifications spec, because both
+are properties of this mixin's write path rather than of the notification itself: the
+unread flag resets on every reaction (`TestReactionNotificationUnreadState`), and only an
+ADDED reaction notifies at all (`TestWhichReactionChangesNotify`). That spec covers what a
+reaction notification says and which post it points at.
 """
 
 import frappe
@@ -323,6 +324,83 @@ class TestReactionNotificationUnreadState(ReactionTestCase):
 		# is the only thing that can raise the badge.
 		self.assertEqual(len(self.reaction_notifications(self.member, self.discussion)), 1)
 		self.assertEqual(self.bell_count(self.member), 1)
+
+
+class TestWhichReactionChangesNotify(ReactionTestCase):
+	"""Only a reaction someone *added* is news to the post owner.
+
+	`notify_reactions` runs on every save of the post, so it has to work out what
+	actually changed in the reactions table. A withdrawal is not news — the owner
+	already saw that reaction and cleared the bell, and re-raising it says "1 person
+	reacted to your post" about a reaction that no longer exists. Swapping one emoji
+	for another in a single batch (the debounced tap-tap the frontend sends) leaves
+	the table the same size but *is* a new reaction, and has to notify.
+	"""
+
+	def bell_count(self, user):
+		with self.as_user(user):
+			return unread_notifications()
+
+	def clear_bell(self, user):
+		with self.as_user(user):
+			mark_all_notifications_as_read()
+
+	def notification(self, user, discussion):
+		return frappe.db.get_value(
+			"GP Notification",
+			{"to_user": user.name, "type": "Reaction", "discussion": discussion.name},
+			["read", "message"],
+			as_dict=True,
+		)
+
+	def test_withdrawing_a_reaction_does_not_re_light_a_cleared_bell(self):
+		self.react(self.discussion, self.second_member, [add(THUMBS_UP)])
+		self.react(self.discussion, self.admin, [add(HEART)])
+		self.clear_bell(self.member)
+
+		self.react(self.discussion, self.admin, [remove(HEART)])
+
+		self.assertEqual(self.bell_count(self.member), 0)
+		self.assertEqual(self.notification(self.member, self.discussion).read, 1)
+
+	def test_swapping_one_emoji_for_another_notifies(self):
+		"""Remove + add in one batch keeps the table the same size, but the heart is a
+		reaction the owner has never been told about."""
+		self.react(self.discussion, self.second_member, [add(THUMBS_UP)])
+		self.clear_bell(self.member)
+
+		self.react(self.discussion, self.second_member, [remove(THUMBS_UP), add(HEART)])
+
+		self.assertEqual(self.bell_count(self.member), 1)
+
+	def test_a_save_that_leaves_the_reactions_alone_does_not_notify(self):
+		self.react(self.discussion, self.second_member, [add(THUMBS_UP)])
+		self.clear_bell(self.member)
+
+		with self.as_user(self.member):
+			discussion = frappe.get_doc("GP Discussion", self.discussion.name)
+			discussion.title = "Welcome thread (edited)"
+			discussion.save()
+
+		self.assertEqual(self.bell_count(self.member), 0)
+
+	def test_the_owner_reacting_to_their_own_post_never_lights_their_own_bell(self):
+		"""Own reactions are excluded from the count, so adding one is not news either —
+		even once someone else's reaction has put a notification row on the post."""
+		self.react(self.discussion, self.second_member, [add(THUMBS_UP)])
+		self.clear_bell(self.member)
+
+		self.react(self.discussion, self.member, [add(HEART)])
+
+		self.assertEqual(self.bell_count(self.member), 0)
+
+	def test_the_message_counts_everyone_holding_a_reaction_after_the_change(self):
+		self.react(self.discussion, self.second_member, [add(THUMBS_UP)])
+		self.react(self.discussion, self.admin, [add(THUMBS_UP)])
+
+		self.assertEqual(
+			self.notification(self.member, self.discussion).message, "2 people reacted to your post"
+		)
 
 
 class TestReactionsSurviveAnEdit(ReactionTestCase):

--- a/gameplan/tests/features/test_reactions.py
+++ b/gameplan/tests/features/test_reactions.py
@@ -15,11 +15,12 @@ file owns — is the operation contract of `react`:
 - garbage in a batch is ignored, not stored,
 - reacting never touches the post itself.
 
-Two notification properties live here rather than in the notifications spec, because both
-are properties of this mixin's write path rather than of the notification itself: the
-unread flag resets on every reaction (`TestReactionNotificationUnreadState`), and only an
-ADDED reaction notifies at all (`TestWhichReactionChangesNotify`). That spec covers what a
-reaction notification says and which post it points at.
+Some notification behaviour lives here rather than in the notifications spec, because it
+belongs to this mixin's write path rather than to the notification itself: the unread flag
+resets on every reaction (`TestReactionNotificationUnreadState`), only an ADDED reaction
+notifies at all (`TestWhichReactionChangesNotify`), and one row is reused per post, which
+makes the row's link fields both its routing and its identity
+(`TestReactionNotificationRouting`). The notifications spec covers what the message says.
 """
 
 import frappe
@@ -401,6 +402,110 @@ class TestWhichReactionChangesNotify(ReactionTestCase):
 		self.assertEqual(
 			self.notification(self.member, self.discussion).message, "2 people reacted to your post"
 		)
+
+
+class TestReactionNotificationRouting(ReactionTestCase):
+	"""A reaction notification has to name the post that was reacted to.
+
+	The bell renders each row as a link, so the row carries the post in its own link field
+	— `comment`, `poll` or `discussion` — and a reply additionally carries the thread it
+	lives in, which is what lets the client open the thread and scroll to the reply.
+
+	`notify_reactions` reuses one row per post rather than inserting one per reaction, so
+	the same fields double as the lookup key. That makes them load-bearing twice over: a
+	key that is not specific enough makes a reaction on a thread and a reaction on a reply
+	inside it land on one row, and the second one silently overwrites the first.
+	"""
+
+	def notifications(self, user):
+		rows = frappe.get_all(
+			"GP Notification",
+			filters={"to_user": user.name, "type": "Reaction"},
+			fields=["name", "discussion", "comment", "poll"],
+			order_by="creation asc",
+		)
+		# Link fields come back as "" or None depending on the backend; normalise so the
+		# assertions below read as "points nowhere" rather than at one storage detail.
+		return [
+			frappe._dict(
+				name=row.name,
+				discussion=str(row.discussion) if row.discussion else None,
+				comment=str(row.comment) if row.comment else None,
+				poll=str(row.poll) if row.poll else None,
+			)
+			for row in rows
+		]
+
+	def test_a_comment_reaction_points_at_the_comment_and_its_thread(self):
+		self.react(self.comment, self.second_member, [add(THUMBS_UP)])
+
+		rows = self.notifications(self.member)
+		self.assertEqual(len(rows), 1)
+		self.assertEqual(rows[0].comment, str(self.comment.name))
+		self.assertEqual(rows[0].discussion, str(self.discussion.name))
+		self.assertIsNone(rows[0].poll)
+
+	def test_a_poll_reaction_points_at_the_poll_and_its_thread(self):
+		self.react(self.poll, self.second_member, [add(THUMBS_UP)])
+
+		rows = self.notifications(self.member)
+		self.assertEqual(len(rows), 1)
+		self.assertEqual(rows[0].poll, str(self.poll.name))
+		self.assertEqual(rows[0].discussion, str(self.discussion.name))
+		self.assertIsNone(rows[0].comment)
+
+	def test_a_discussion_reaction_points_at_the_discussion_alone(self):
+		self.react(self.discussion, self.second_member, [add(THUMBS_UP)])
+
+		rows = self.notifications(self.member)
+		self.assertEqual(len(rows), 1)
+		self.assertEqual(rows[0].discussion, str(self.discussion.name))
+		self.assertIsNone(rows[0].comment)
+		self.assertIsNone(rows[0].poll)
+
+	def test_a_thread_and_a_reply_inside_it_get_their_own_notifications(self):
+		"""Both rows carry the same discussion, so only the emptiness of `comment` tells
+		the thread's row apart from the reply's — the lookup has to say so."""
+		self.react(self.comment, self.second_member, [add(THUMBS_UP)])
+		self.react(self.discussion, self.second_member, [add(THUMBS_UP)])
+
+		rows = self.notifications(self.member)
+		self.assertEqual(len(rows), 2)
+		self.assertEqual(len({row.name for row in rows}), 2)
+		self.assertEqual({row.comment for row in rows}, {str(self.comment.name), None})
+
+	def test_a_thread_and_a_poll_inside_it_get_their_own_notifications(self):
+		self.react(self.poll, self.second_member, [add(THUMBS_UP)])
+		self.react(self.discussion, self.second_member, [add(THUMBS_UP)])
+
+		rows = self.notifications(self.member)
+		self.assertEqual(len(rows), 2)
+		self.assertEqual(len({row.name for row in rows}), 2)
+		self.assertEqual({row.poll for row in rows}, {str(self.poll.name), None})
+
+	def test_the_order_the_reactions_arrive_in_does_not_merge_them(self):
+		"""The reverse of the two tests above: the thread's row exists first, and the
+		reply's reaction must still get a row of its own rather than claiming that one."""
+		self.react(self.discussion, self.second_member, [add(THUMBS_UP)])
+		self.react(self.comment, self.second_member, [add(THUMBS_UP)])
+		self.react(self.poll, self.second_member, [add(THUMBS_UP)])
+
+		rows = self.notifications(self.member)
+		self.assertEqual(len(rows), 3)
+		self.assertEqual(
+			{(row.comment, row.poll) for row in rows},
+			{(None, None), (str(self.comment.name), None), (None, str(self.poll.name))},
+		)
+
+	def test_two_replies_in_one_thread_get_their_own_notifications(self):
+		other_comment = create_comment(self.discussion, content="Second reply", owner=self.member)
+
+		self.react(self.comment, self.second_member, [add(THUMBS_UP)])
+		self.react(other_comment, self.second_member, [add(THUMBS_UP)])
+
+		rows = self.notifications(self.member)
+		self.assertEqual(len(rows), 2)
+		self.assertEqual({row.comment for row in rows}, {str(self.comment.name), str(other_comment.name)})
 
 
 class TestReactionsSurviveAnEdit(ReactionTestCase):

--- a/gameplan/tests/features/test_spaces.py
+++ b/gameplan/tests/features/test_spaces.py
@@ -4,13 +4,18 @@
 """Space (GP Project) behaviour: archiving, activity, search scoping, and who may
 join, leave, manage members or invite guests."""
 
+from unittest.mock import patch
+
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
 from gameplan.gameplan.doctype.gp_project import gp_project as gp_project_module
 from gameplan.gameplan.doctype.gp_project.gp_project import (
+	DEFAULT_SPACE_ICON,
 	GPProject,
 	get_activity,
+	get_joined_spaces,
+	get_unread_count,
 	mark_all_as_read,
 	track_visits,
 )
@@ -85,6 +90,24 @@ class TestSpaces(FrappeTestCase):
 
 		self.assertEqual(str(activity[str(public_project.name)]), "2026-01-02 10:00:00")
 		self.assertNotIn(str(private_project.name), activity)
+
+	def test_get_activity_omits_a_space_whose_latest_post_time_is_unknown(self):
+		"""A NULL max timestamp is "no activity", not activity at an unknown time.
+
+		The falsy guard has to reject it before the string comparison runs: `str(None)`
+		is `"None"`, which sorts above the `""` seed, so a comparison-first version would
+		publish `None` as the space's last activity and the sidebar would sort on it.
+		"""
+		member = create_member("test_null_activity_member@example.com")
+		team = create_community("Null Activity Team")
+		project = create_space("Null Activity Space", team.name)
+		discussion = create_discussion("Null Activity Discussion", project.name)
+		frappe.db.set_value("GP Discussion", discussion.name, "last_post_at", None)
+
+		frappe.set_user(member.name)
+		activity = get_activity()
+
+		self.assertNotIn(str(project.name), activity)
 
 
 class TestSpaceMembership(GameplanTestCase):
@@ -178,10 +201,22 @@ class TestSpaceMembership(GameplanTestCase):
 		community = create_community("Guest Invite Community", members=[self.member])
 		space = create_space("Guest Invite Space", community, is_private=1, members=[self.member])
 
-		with self.as_user(self.member):
+		# GP Invitation.after_insert emails the invitee, so without this the assertion
+		# under test would hinge on the site having an outgoing Email Account (CI mutes
+		# mail via site config; a plain dev site raises OutgoingEmailError). Same mute as
+		# InvitationTestCase in test_invitations.py.
+		with self.as_user(self.member), patch("frappe.sendmail"):
 			space.invite_guest("new_perm_guest@example.com")
 
-		self.assertTrue(frappe.db.exists("GP Invitation", {"email": "new_perm_guest@example.com"}))
+		invitation = frappe.db.get_value(
+			"GP Invitation",
+			{"email": "new_perm_guest@example.com"},
+			["role", "projects"],
+			as_dict=True,
+		)
+		self.assertIsNotNone(invitation)
+		self.assertEqual(invitation.role, "Gameplan Guest")
+		self.assertEqual(frappe.parse_json(invitation.projects), [space.name])
 
 	def test_regular_member_cannot_invite_guest_to_public_space(self):
 		community = create_community("Blocked Public Guest Invite Community", members=[self.member])
@@ -335,6 +370,42 @@ class TestSpaceReadState(GameplanTestCase):
 			)
 		)
 
+	def test_guest_can_record_a_repeat_visit_to_a_granted_space(self):
+		"""The second visit updates the row instead of inserting one.
+
+		Worth its own test because the two branches need different permissions: the
+		Gameplan Guest role has `create` on GP Project Visit but not `write`, so only
+		the update branch depends on the ignore_permissions save.
+		"""
+		grant_guest_access(self.guest, self.space)
+
+		with self.as_user(self.guest):
+			frappe.get_doc("GP Project", self.space.name).track_visit()
+			frappe.get_doc("GP Project", self.space.name).track_visit()
+
+		self.assertEqual(
+			frappe.db.count("GP Project Visit", {"user": self.guest.name, "project": self.space.name}),
+			1,
+		)
+
+	def test_guest_can_mark_a_granted_space_read_after_visiting_it(self):
+		"""Same split as the repeat visit: marking read after a visit takes the update
+		branch, which the Gameplan Guest role has no write permission for."""
+		grant_guest_access(self.guest, self.space)
+
+		with self.as_user(self.guest):
+			space = frappe.get_doc("GP Project", self.space.name)
+			space.track_visit()
+			space.mark_all_as_read()
+
+		self.assertTrue(
+			frappe.db.get_value(
+				"GP Project Visit",
+				{"user": self.guest.name, "project": self.space.name},
+				"mark_all_read_at",
+			)
+		)
+
 	def test_guest_without_space_access_cannot_record_a_visit(self):
 		with self.as_user(self.guest), self.assertRaises(frappe.PermissionError):
 			frappe.get_doc("GP Project", self.space.name).track_visit()
@@ -363,6 +434,162 @@ class TestSpaceReadState(GameplanTestCase):
 				{"user": self.outsider.name, "project": private_space.name},
 			)
 		)
+
+
+class TestSpaceIcon(GameplanTestCase):
+	def test_space_keeps_an_icon_that_names_a_lucide_glyph(self):
+		community = create_community("Icon Community", members=[self.member])
+		space = frappe.get_doc(
+			doctype="GP Project", title="Lucide Icon Space", team=community.name, icon="lucide-rocket"
+		).insert(ignore_permissions=True)
+
+		self.assertEqual(space.icon, "lucide-rocket")
+
+	def test_space_icon_outside_the_lucide_set_falls_back_to_the_default(self):
+		community = create_community("Fallback Icon Community", members=[self.member])
+		space = frappe.get_doc(
+			doctype="GP Project", title="Bad Icon Space", team=community.name, icon="rocket"
+		).insert(ignore_permissions=True)
+
+		self.assertEqual(space.icon, DEFAULT_SPACE_ICON)
+
+
+class TestJoinedSpaces(GameplanTestCase):
+	"""`get_joined_spaces` is the sidebar's source of truth for "my spaces".
+
+	It unions two disjoint sources — member rows and guest grants — so it has to
+	return both and must not report a space the user has neither on.
+	"""
+
+	def test_joined_spaces_are_the_users_own_memberships(self):
+		community = create_community("Joined Spaces Community", members=[self.member, self.second_member])
+		joined = create_space("Joined Space", community, members=[self.member])
+		others = create_space("Someone Elses Space", community, members=[self.second_member])
+
+		with self.as_user(self.member):
+			spaces = get_joined_spaces()
+
+		self.assertIn(str(joined.name), spaces)
+		self.assertNotIn(str(others.name), spaces)
+
+	def test_joined_spaces_include_guest_grants_and_never_repeat_a_space(self):
+		community = create_community("Guest Joined Community", members=[self.member])
+		granted = create_space("Guest Granted Space", community)
+		both = create_space("Guest And Member Space", community, members=[self.guest])
+		grant_guest_access(self.guest, granted)
+		grant_guest_access(self.guest, both)
+
+		with self.as_user(self.guest):
+			spaces = get_joined_spaces()
+
+		# Asserted as a set, not a list: the two source queries pluck the same space as
+		# an int (GP Project.name) and as a str (GP Guest Access.project), so the set()
+		# that is meant to dedupe them does not, and a space held both ways is returned
+		# twice. Pinning the list here would freeze that bug in place.
+		self.assertEqual(set(spaces), {str(granted.name), str(both.name)})
+
+
+class TestSpaceMemberRemoval(GameplanTestCase):
+	def test_removing_a_member_leaves_every_other_member_in_place(self):
+		community = create_community(
+			"Removal Community", members=[self.member, self.second_member, self.outsider]
+		)
+		space = create_space(
+			"Removal Space",
+			community,
+			is_private=1,
+			members=[self.member, self.second_member, self.outsider],
+		)
+
+		with self.as_user(self.member):
+			space.remove_member(self.second_member.name)
+
+		space.reload()
+		remaining = [row.user for row in space.members]
+		self.assertNotIn(self.second_member.name, remaining)
+		self.assertIn(self.member.name, remaining)
+		self.assertIn(self.outsider.name, remaining)
+
+
+class TestBulkSpaceVisits(GameplanTestCase):
+	def test_bulk_track_visits_records_a_visit_for_every_space_passed(self):
+		community = create_community("Bulk Visit Community", members=[self.member])
+		first = create_space("Bulk Visit Space One", community, members=[self.member])
+		second = create_space("Bulk Visit Space Two", community, members=[self.member])
+
+		with self.as_user(self.member):
+			track_visits(spaces=[int(first.name), int(second.name)])
+
+		for space in (first, second):
+			self.assertTrue(
+				frappe.db.exists("GP Project Visit", {"user": self.member.name, "project": space.name}),
+				f"no visit recorded for space {space.name}",
+			)
+
+
+class TestSpaceMerge(GameplanTestCase):
+	"""Merging a space renames it onto another and deletes the original.
+
+	It is destructive and irreversible, so the two no-op guards (no target, self)
+	and the unknown-target rejection carry as much weight as the merge itself.
+	"""
+
+	def setUp(self):
+		super().setUp()
+		self.community = create_community("Merge Community", members=[self.member])
+		self.source = create_space("Merge Source Space", self.community)
+		self.target = create_space("Merge Target Space", self.community)
+		self.source_name = self.source.name
+		self.discussion = create_discussion("Merged Discussion", self.source)
+
+	def test_merging_moves_content_to_the_target_and_removes_the_source(self):
+		self.source.merge_with_project(self.target.name)
+
+		self.assertFalse(frappe.db.exists("GP Project", self.source_name))
+		self.assertEqual(
+			str(frappe.db.get_value("GP Discussion", self.discussion.name, "project")),
+			str(self.target.name),
+		)
+
+	def test_merging_without_a_target_does_nothing(self):
+		self.source.merge_with_project(None)
+
+		self.assertTrue(frappe.db.exists("GP Project", self.source_name))
+		self.assertEqual(
+			str(frappe.db.get_value("GP Discussion", self.discussion.name, "project")),
+			str(self.source_name),
+		)
+
+	def test_merging_a_space_into_itself_does_nothing(self):
+		self.source.merge_with_project(self.source_name)
+
+		self.assertTrue(frappe.db.exists("GP Project", self.source_name))
+		self.assertEqual(
+			str(frappe.db.get_value("GP Discussion", self.discussion.name, "project")),
+			str(self.source_name),
+		)
+
+	def test_merging_into_an_unknown_space_is_rejected_before_anything_moves(self):
+		with self.assertRaisesRegex(frappe.ValidationError, "Invalid Project"):
+			self.source.merge_with_project(9999999)
+
+		self.assertTrue(frappe.db.exists("GP Project", self.source_name))
+
+
+class TestSpaceUnreadCounts(GameplanTestCase):
+	"""`get_unread_count` drives the unread badge next to every space.
+
+	Only the short-circuit is covered here. The counting query itself unions two
+	SELECTs, and pypika parenthesises each term — which SQLite rejects outright
+	("near UNION: syntax error"), so on a SQLite site the endpoint raises before it
+	can return anything. Until that is fixed there is no way to assert a count.
+	"""
+
+	def test_unread_counts_are_an_empty_mapping_for_a_user_in_no_space(self):
+		with self.as_user(self.outsider):
+			counts = get_unread_count()
+
+		self.assertEqual(counts, {})
 
 
 class TestSpaceMutationHTTPMethods(GameplanTestCase):

--- a/gameplan/tests/features/test_spaces.py
+++ b/gameplan/tests/features/test_spaces.py
@@ -482,11 +482,24 @@ class TestJoinedSpaces(GameplanTestCase):
 		with self.as_user(self.guest):
 			spaces = get_joined_spaces()
 
-		# Asserted as a set, not a list: the two source queries pluck the same space as
-		# an int (GP Project.name) and as a str (GP Guest Access.project), so the set()
-		# that is meant to dedupe them does not, and a space held both ways is returned
-		# twice. Pinning the list here would freeze that bug in place.
-		self.assertEqual(set(spaces), {str(granted.name), str(both.name)})
+		# Asserted as an exact list, not a set: the two source queries pluck the same
+		# space from differently typed columns (GP Project.name is an integer,
+		# GP Guest Access.project a string), and a set of mixed types cannot dedupe
+		# them. A set assertion would pass while the sidebar showed the space twice.
+		self.assertEqual(spaces, [str(both.name), str(granted.name)])
+
+	def test_joined_spaces_are_strings_so_the_sidebar_can_match_them(self):
+		"""The endpoint is typed `string[]` in the SPA and compared with `includes()`,
+		so an integer space name would silently never match."""
+		community = create_community("String Joined Community", members=[self.member])
+		space = create_space("String Joined Space", community, members=[self.member])
+
+		with self.as_user(self.member):
+			spaces = get_joined_spaces()
+
+		self.assertEqual(spaces, [str(space.name)])
+		for name in spaces:
+			self.assertIsInstance(name, str)
 
 
 class TestSpaceMemberRemoval(GameplanTestCase):
@@ -561,13 +574,22 @@ class TestSpaceMerge(GameplanTestCase):
 		)
 
 	def test_merging_a_space_into_itself_does_nothing(self):
-		self.source.merge_with_project(self.source_name)
+		"""Covers the string form because that is the only one that ever arrives.
 
-		self.assertTrue(frappe.db.exists("GP Project", self.source_name))
-		self.assertEqual(
-			str(frappe.db.get_value("GP Discussion", self.discussion.name, "project")),
-			str(self.source_name),
-		)
+		GP Project autoincrements, so `self.name` is an int, while MergeSpaceDialog sends
+		the combobox value as a string. A guard that compares before coercing sees
+		`"7" != 7`, falls through, and the rename below deletes the space and leaves every
+		discussion in it pointing at nothing.
+		"""
+		for target in (str(self.source_name), int(self.source_name)):
+			with self.subTest(target=target):
+				frappe.get_doc("GP Project", self.source_name).merge_with_project(target)
+
+				self.assertTrue(frappe.db.exists("GP Project", self.source_name))
+				self.assertEqual(
+					str(frappe.db.get_value("GP Discussion", self.discussion.name, "project")),
+					str(self.source_name),
+				)
 
 	def test_merging_into_an_unknown_space_is_rejected_before_anything_moves(self):
 		with self.assertRaisesRegex(frappe.ValidationError, "Invalid Project"):
@@ -575,21 +597,234 @@ class TestSpaceMerge(GameplanTestCase):
 
 		self.assertTrue(frappe.db.exists("GP Project", self.source_name))
 
+	def test_space_manager_can_merge_two_spaces_they_manage(self):
+		private_community = create_community("Merge Manager Community", members=[self.member])
+		source = create_space("Managed Merge Source", private_community, is_private=1, members=[self.member])
+		target = create_space("Managed Merge Target", private_community, is_private=1, members=[self.member])
+		source_name = source.name
+		discussion = create_discussion("Managed Merge Discussion", source)
+
+		with self.as_user(self.member):
+			frappe.get_doc("GP Project", source_name).merge_with_project(target.name)
+
+		self.assertFalse(frappe.db.exists("GP Project", source_name))
+		self.assertEqual(
+			str(frappe.db.get_value("GP Discussion", discussion.name, "project")),
+			str(target.name),
+		)
+
+	def test_manager_of_only_the_source_cannot_merge_into_a_space_they_dont_manage(self):
+		"""The merge moves every discussion, task and page into the target, so managing
+		the source alone is not enough — without a gate on the target it is a way to
+		push content into a space the user has no rights over."""
+		community = create_community("Merge Target Gate Community", members=[self.member, self.second_member])
+		source = create_space("Gated Merge Source", community, is_private=1, members=[self.member])
+		target = create_space("Gated Merge Target", community, is_private=1, members=[self.second_member])
+		source_name = source.name
+		discussion = create_discussion("Gated Merge Discussion", source)
+
+		with self.as_user(self.member), self.assertRaises(frappe.PermissionError):
+			frappe.get_doc("GP Project", source_name).merge_with_project(target.name)
+
+		self.assertTrue(frappe.db.exists("GP Project", source_name))
+		self.assertEqual(
+			str(frappe.db.get_value("GP Discussion", discussion.name, "project")),
+			str(source_name),
+		)
+
+	def test_an_unknown_merge_target_is_rejected_the_same_way_a_forbidden_one_is(self):
+		"""Otherwise the endpoint is an id oracle for the whole site.
+
+		The unknown-target check runs `frappe.db.exists`, so if it is reached before the
+		permission gate, any space manager can tell "Invalid Project 999" (no such space)
+		from "Only space managers can merge spaces" (it exists, you just can't have it) and
+		enumerate every GP Project on the site, private ones included.
+		"""
+		community = create_community("Merge Oracle Community", members=[self.member, self.second_member])
+		source = create_space("Oracle Merge Source", community, is_private=1, members=[self.member])
+		forbidden = create_space("Oracle Merge Target", community, is_private=1, members=[self.second_member])
+
+		with self.as_user(self.member):
+			with self.assertRaises(frappe.PermissionError):
+				frappe.get_doc("GP Project", source.name).merge_with_project(9999999)
+			with self.assertRaises(frappe.PermissionError):
+				frappe.get_doc("GP Project", source.name).merge_with_project(forbidden.name)
+
+	def test_guest_cannot_merge_a_space_they_hold_a_member_row_on(self):
+		"""A guest with a GP Member row on a private space passes can_manage_space.
+
+		Guest access is read-and-participate; merging destroys a space. Only the doctype
+		role table stands between a guest and this method today, and that is the wrong
+		place for a business rule — `can_invite_guest` sets the precedent of ruling guests
+		out before the manage check.
+		"""
+		community = create_community("Guest Merge Community", members=[self.member])
+		source = create_space("Guest Merge Source", community, is_private=1, members=[self.guest])
+		target = create_space("Guest Merge Target", community, is_private=1, members=[self.guest])
+		source_name = source.name
+		discussion = create_discussion("Guest Merge Discussion", source)
+
+		with self.as_user(self.guest), self.assertRaises(frappe.PermissionError):
+			frappe.get_doc("GP Project", source_name).merge_with_project(target.name)
+
+		self.assertTrue(frappe.db.exists("GP Project", source_name))
+		self.assertEqual(
+			str(frappe.db.get_value("GP Discussion", discussion.name, "project")),
+			str(source_name),
+		)
+
+	def test_manager_of_only_the_target_cannot_merge_a_space_they_dont_manage(self):
+		community = create_community("Merge Source Gate Community", members=[self.member, self.second_member])
+		source = create_space("Ungated Merge Source", community, is_private=1, members=[self.second_member])
+		target = create_space("Ungated Merge Target", community, is_private=1, members=[self.member])
+		source_name = source.name
+
+		with self.as_user(self.member), self.assertRaises(frappe.PermissionError):
+			frappe.get_doc("GP Project", source_name).merge_with_project(target.name)
+
+		self.assertTrue(frappe.db.exists("GP Project", source_name))
+
 
 class TestSpaceUnreadCounts(GameplanTestCase):
 	"""`get_unread_count` drives the unread badge next to every space.
 
-	Only the short-circuit is covered here. The counting query itself unions two
-	SELECTs, and pypika parenthesises each term — which SQLite rejects outright
-	("near UNION: syntax error"), so on a SQLite site the endpoint raises before it
-	can return anything. Until that is fixed there is no way to assert a count.
+	Two read-tracking regimes feed one number. A space the user has marked read
+	counts every discussion posted after that space-level timestamp; a space that
+	has never been marked read falls back to per-discussion visits. A space is
+	counted under exactly one regime, and both must ignore other users' rows.
 	"""
+
+	MARKED_READ_AT = "2026-01-02 00:00:00"
+
+	def setUp(self):
+		super().setUp()
+		self.community = create_community("Unread Count Community", members=[self.member, self.second_member])
+
+	def _space(self, title):
+		return create_space(title, self.community, members=[self.member, self.second_member])
+
+	def _discussion(self, title, space, last_post_at):
+		discussion = create_discussion(title, space)
+		frappe.db.set_value(
+			"GP Discussion", discussion.name, "last_post_at", last_post_at, update_modified=False
+		)
+		return discussion
+
+	def _visit_space(self, space, user, last_visit, mark_all_read_at=None):
+		return frappe.get_doc(
+			doctype="GP Project Visit",
+			user=user.name,
+			project=space.name,
+			last_visit=last_visit,
+			mark_all_read_at=mark_all_read_at,
+		).insert(ignore_permissions=True)
+
+	def _visit_discussion(self, discussion, user, last_visit):
+		return frappe.get_doc(
+			doctype="GP Discussion Visit",
+			user=user.name,
+			discussion=discussion.name,
+			last_visit=last_visit,
+		).insert(ignore_permissions=True)
 
 	def test_unread_counts_are_an_empty_mapping_for_a_user_in_no_space(self):
 		with self.as_user(self.outsider):
 			counts = get_unread_count()
 
 		self.assertEqual(counts, {})
+
+	def test_unread_counts_cover_every_read_tracking_regime_at_once(self):
+		"""One assertion over five spaces, because the interesting failures are spaces
+		that should be absent (fully read) or counted under the wrong regime — neither
+		of which a per-space assertion would notice."""
+		marked_read = self._space("Marked Read Space")
+		self._discussion("Read Before Mark", marked_read, "2026-01-01 09:00:00")
+		self._discussion("Posted After Mark", marked_read, "2026-01-03 09:00:00")
+		self._discussion("Posted Later Still", marked_read, "2026-01-04 09:00:00")
+		self._visit_space(marked_read, self.member, "2026-01-02 00:00:00", self.MARKED_READ_AT)
+
+		fully_read = self._space("Fully Read Space")
+		self._discussion("Everything Read", fully_read, "2026-01-01 09:00:00")
+		self._visit_space(fully_read, self.member, "2026-01-02 00:00:00", self.MARKED_READ_AT)
+
+		never_visited = self._space("Never Visited Space")
+		self._discussion("Unseen One", never_visited, "2026-01-01 09:00:00")
+		self._discussion("Unseen Two", never_visited, "2026-01-05 09:00:00")
+
+		visited_not_marked = self._space("Visited Not Marked Space")
+		seen = self._discussion("Seen Discussion", visited_not_marked, "2026-01-01 09:00:00")
+		unseen = self._discussion("Unseen Since Visit", visited_not_marked, "2026-01-06 09:00:00")
+		self._visit_space(visited_not_marked, self.member, "2026-01-02 00:00:00")
+		self._visit_discussion(seen, self.member, "2026-01-02 00:00:00")
+		self._visit_discussion(unseen, self.member, "2026-01-02 00:00:00")
+
+		self._space("Empty Space")
+
+		# Another member has read everything everywhere. None of it may leak into the
+		# counts below — every join in the query is scoped to the session user.
+		for space in (marked_read, fully_read, never_visited, visited_not_marked):
+			self._visit_space(space, self.second_member, "2026-01-09 00:00:00", "2026-01-09 00:00:00")
+		for discussion in (seen, unseen):
+			self._visit_discussion(discussion, self.second_member, "2026-01-09 00:00:00")
+
+		with self.as_user(self.member):
+			counts = get_unread_count()
+
+		self.assertEqual(
+			self._normalized(counts),
+			{
+				str(marked_read.name): 2,
+				str(never_visited.name): 2,
+				str(visited_not_marked.name): 1,
+			},
+		)
+
+	def test_unread_counts_stay_correct_when_a_space_has_duplicate_visit_rows(self):
+		"""Two visit rows for one (user, space) must not count every discussion twice.
+
+		GP Project Visit indexes (user, project) without a uniqueness constraint and
+		`track_visit` is a get-then-insert with no lock, so duplicate rows are reachable.
+		The two read-tracking predicates are exclusive per JOINED ROW, not per discussion:
+		with one row carrying `mark_all_read_at` and one without, both fire for the same
+		discussion and the badge doubles.
+		"""
+		space = self._space("Duplicate Visit Space")
+		self._discussion("Unread One", space, "2026-01-03 09:00:00")
+		self._discussion("Unread Two", space, "2026-01-04 09:00:00")
+		self._discussion("Unread Three", space, "2026-01-05 09:00:00")
+		self._visit_space(space, self.member, "2026-01-02 00:00:00", self.MARKED_READ_AT)
+		self._visit_space(space, self.member, "2026-01-02 00:00:00")
+
+		with self.as_user(self.member):
+			counts = get_unread_count()
+
+		self.assertEqual(self._normalized(counts), {str(space.name): 3})
+
+	def test_unread_counts_are_limited_to_the_users_own_spaces(self):
+		"""The joined-space list gated only the early return, not the counting query, so
+		anyone in at least one space was handed unread counts for every space on the
+		site — including private ones they cannot open."""
+		mine = self._space("Own Unread Space")
+		self._discussion("Own Unread Discussion", mine, "2026-01-03 09:00:00")
+
+		foreign_community = create_community("Foreign Unread Community", members=[self.outsider])
+		theirs = create_space(
+			"Foreign Unread Space", foreign_community, is_private=1, members=[self.outsider]
+		)
+		self._discussion("Foreign Unread Discussion", theirs, "2026-01-03 09:00:00")
+
+		with self.as_user(self.member):
+			counts = get_unread_count()
+
+		self.assertEqual(self._normalized(counts), {str(mine.name): 1})
+
+	def _normalized(self, counts):
+		"""Counts keyed by space name as a string.
+
+		Keys arrive as whatever the Link column stores (int on MariaDB, str on SQLite);
+		what these tests assert is which spaces appear and with what count.
+		"""
+		return {str(space): int(count) for space, count in counts.items()}
 
 
 class TestSpaceMutationHTTPMethods(GameplanTestCase):
@@ -598,6 +833,16 @@ class TestSpaceMutationHTTPMethods(GameplanTestCase):
 			self.assertFalse(hasattr(GPProject, method))
 		for endpoint in ("follow_spaces", "unfollow_spaces"):
 			self.assertFalse(hasattr(gp_project_module, endpoint))
+
+	def test_link_previews_are_not_a_space_api(self):
+		"""No caller ever asked a Space for a URL's meta tags. Keeping the helper kept an
+		outbound HTTP fetch reachable from a doctype controller for no reason."""
+		self.assertFalse(hasattr(gp_project_module, "get_meta_tags"))
+
+	def test_space_does_not_override_document_serialisation(self):
+		"""`as_dict` was overridden only to call super() and return the result. A no-op
+		override shadows the framework method and is a place for behaviour to rot in."""
+		self.assertNotIn("as_dict", vars(GPProject))
 
 	def test_space_membership_mutations_are_post_only(self):
 		for method in (

--- a/gameplan/tests/features/test_spaces.py
+++ b/gameplan/tests/features/test_spaces.py
@@ -1,14 +1,15 @@
 # Copyright (c) 2022, Frappe Technologies Pvt Ltd and Contributors
 # See license.txt
 
-"""Space (GP Project) behaviour: archiving, activity, search scoping, and who may
-join, leave, manage members or invite guests."""
+"""Space (GP Project) behaviour: archiving, activity, moving between communities,
+list and search scoping, and who may join, leave, manage members or invite guests."""
 
 from unittest.mock import patch
 
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
+from gameplan.extends.client import get_list
 from gameplan.gameplan.doctype.gp_project import gp_project as gp_project_module
 from gameplan.gameplan.doctype.gp_project.gp_project import (
 	DEFAULT_SPACE_ICON,
@@ -16,6 +17,8 @@ from gameplan.gameplan.doctype.gp_project.gp_project import (
 	get_activity,
 	get_joined_spaces,
 	get_unread_count,
+	join_spaces,
+	leave_spaces,
 	mark_all_as_read,
 	track_visits,
 )
@@ -25,7 +28,9 @@ from gameplan.tests.fixtures import (
 	create_community,
 	create_discussion,
 	create_member,
+	create_page,
 	create_space,
+	create_task,
 	declared_http_methods,
 	grant_guest_access,
 )
@@ -35,19 +40,6 @@ class TestSpaces(FrappeTestCase):
 	def tearDown(self):
 		frappe.set_user("Administrator")
 		frappe.db.rollback()
-
-	def test_archive_deletes_current_users_pin(self):
-		frappe.set_user("Administrator")
-		team = create_community("Pinned Archive Team")
-		project = create_space("Pinned Archive Space", team.name)
-		pin = frappe.get_doc(doctype="GP Pinned Project", project=project.name).insert(
-			ignore_permissions=True
-		)
-
-		project.archive()
-
-		self.assertTrue(project.archived_at)
-		self.assertFalse(frappe.db.exists("GP Pinned Project", pin.name))
 
 	def test_search_private_space_requires_space_membership(self):
 		member = create_member("test_search_member@example.com")
@@ -108,6 +100,200 @@ class TestSpaces(FrappeTestCase):
 		activity = get_activity()
 
 		self.assertNotIn(str(project.name), activity)
+
+
+class TestSpaceArchive(GameplanTestCase):
+	"""Archiving retires a Space for everyone, so it has to retire everyone's pin.
+
+	A pin outliving its Space is a sidebar entry pointing at something the SPA will
+	not open. The patch
+	gp_pinned_project/patches/delete_pinned_projects_for_archived_spaces.py exists
+	only to clear that state out, so `archive` must not keep regenerating it.
+	"""
+
+	def setUp(self):
+		super().setUp()
+		self.community = create_community("Archive Community", members=[self.member, self.second_member])
+		self.space = create_space("Archive Space", self.community, members=[self.member, self.second_member])
+
+	def _pin(self, user):
+		"""Pin the space as `user`.
+
+		GPPinnedProject.before_insert stamps the session user over whatever the caller
+		passed, so the pin's owner is decided by who is logged in, not by a field.
+		"""
+		with self.as_user(user):
+			return frappe.get_doc(doctype="GP Pinned Project", project=self.space.name).insert(
+				ignore_permissions=True
+			)
+
+	def test_archiving_a_space_deletes_the_pins_of_everyone_who_pinned_it(self):
+		archiver_pin = self._pin(self.admin)
+		other_pin = self._pin(self.second_member)
+
+		with self.as_user(self.admin):
+			frappe.get_doc("GP Project", self.space.name).archive()
+
+		self.assertTrue(frappe.db.get_value("GP Project", self.space.name, "archived_at"))
+		self.assertFalse(frappe.db.exists("GP Pinned Project", archiver_pin.name))
+		self.assertFalse(frappe.db.exists("GP Pinned Project", other_pin.name))
+
+	def test_unarchiving_a_space_does_not_bring_back_the_pins_archiving_dropped(self):
+		"""Recorded, not a gap: archiving deletes the rows, so there is nothing to restore.
+
+		Re-creating them would have to invent a sidebar position for every affected user,
+		and re-pinning is one click.
+		"""
+		self._pin(self.second_member)
+
+		with self.as_user(self.admin):
+			space = frappe.get_doc("GP Project", self.space.name)
+			space.archive()
+			space.unarchive()
+
+		self.assertIsNone(frappe.db.get_value("GP Project", self.space.name, "archived_at"))
+		self.assertFalse(frappe.db.exists("GP Pinned Project", {"project": self.space.name}))
+
+
+class TestSpaceCommunityMove(GameplanTestCase):
+	"""Moving a Space rewrites the Community cached on everything inside it.
+
+	`team` is denormalised onto every doctype in PROJECT_TEAM_DOCTYPES, so the move
+	has to rewrite those rows — and only the ones belonging to the Space that moved.
+	"""
+
+	def setUp(self):
+		super().setUp()
+		self.origin = create_community("Move Origin Community", members=[self.member])
+		self.destination = create_community("Move Destination Community", members=[self.member])
+		self.space = create_space("Moving Space", self.origin)
+		self.sibling = create_space("Staying Space", self.origin)
+
+	def _content(self, space):
+		"""A discussion, a task and a page in `space`, each tagged with its Community.
+
+		Seeded directly because nothing writes `team` on insert — the column is only
+		ever filled by the move under test and by GP Discussion's own move — so without
+		this the "other Spaces are untouched" assertion would compare NULL with NULL and
+		hold however wide the update ran.
+		"""
+		rows = {
+			"GP Discussion": create_discussion(f"{space.title} Discussion", space).name,
+			"GP Task": create_task(f"{space.title} Task", space).name,
+			"GP Page": create_page(f"{space.title} Page", space).name,
+		}
+		for doctype, name in rows.items():
+			frappe.db.set_value(doctype, name, "team", space.team, update_modified=False)
+		return rows
+
+	def _teams(self, rows):
+		return {doctype: frappe.db.get_value(doctype, name, "team") for doctype, name in rows.items()}
+
+	def test_moving_a_space_retags_its_own_content_and_nothing_else(self):
+		moved = self._content(self.space)
+		untouched = self._content(self.sibling)
+
+		frappe.get_doc("GP Project", self.space.name).move_to_team(self.destination.name)
+
+		self.assertEqual(frappe.db.get_value("GP Project", self.space.name, "team"), self.destination.name)
+		self.assertEqual(self._teams(moved), dict.fromkeys(moved, self.destination.name))
+		self.assertEqual(self._teams(untouched), dict.fromkeys(untouched, self.origin.name))
+
+	def test_moving_a_space_into_the_community_it_is_already_in_writes_nothing(self):
+		rows = self._content(self.space)
+		before = frappe.db.get_value("GP Project", self.space.name, "modified")
+
+		frappe.get_doc("GP Project", self.space.name).move_to_team(self.origin.name)
+
+		# The Space's own `modified` is the only witness: re-running the move with the
+		# same Community would set every column to the value it already holds, so the
+		# save is all that separates the guarded path from the unguarded one.
+		self.assertEqual(frappe.db.get_value("GP Project", self.space.name, "modified"), before)
+		self.assertEqual(self._teams(rows), dict.fromkeys(rows, self.origin.name))
+
+
+class TestBulkSpaceMembership(GameplanTestCase):
+	"""`join_spaces` / `leave_spaces` back the sidebar's multi-select membership editor."""
+
+	def setUp(self):
+		super().setUp()
+		self.community = create_community("Bulk Membership Community", members=[self.member])
+		self.first = create_space("Bulk Membership Space One", self.community)
+		self.second = create_space("Bulk Membership Space Two", self.community)
+
+	def _is_member(self, space):
+		return bool(
+			frappe.db.exists(
+				"GP Member",
+				{"parenttype": "GP Project", "parent": space.name, "user": self.member.name},
+			)
+		)
+
+	def _add_member(self, space):
+		space.append("members", {"user": self.member.name})
+		space.save(ignore_permissions=True)
+
+	def test_joining_in_bulk_adds_the_user_to_every_space_passed(self):
+		with self.as_user(self.member):
+			join_spaces(spaces=[int(self.first.name), int(self.second.name)])
+
+		self.assertTrue(self._is_member(self.first))
+		self.assertTrue(self._is_member(self.second))
+
+	def test_joining_no_spaces_at_all_is_a_no_op(self):
+		"""The SPA sends the selection as-is, so an empty one has to be a no-op rather
+		than an iteration over None."""
+		with self.as_user(self.member):
+			self.assertIsNone(join_spaces())
+			self.assertIsNone(join_spaces(spaces=[]))
+
+		self.assertFalse(self._is_member(self.first))
+		self.assertFalse(self._is_member(self.second))
+
+	def test_leaving_in_bulk_removes_the_user_from_every_space_passed(self):
+		self._add_member(self.first)
+		self._add_member(self.second)
+
+		with self.as_user(self.member):
+			leave_spaces(spaces=[int(self.first.name), int(self.second.name)])
+
+		self.assertFalse(self._is_member(self.first))
+		self.assertFalse(self._is_member(self.second))
+
+	def test_leaving_no_spaces_at_all_is_a_no_op(self):
+		self._add_member(self.first)
+		self._add_member(self.second)
+
+		with self.as_user(self.member):
+			self.assertIsNone(leave_spaces())
+			self.assertIsNone(leave_spaces(spaces=[]))
+
+		self.assertTrue(self._is_member(self.first))
+		self.assertTrue(self._is_member(self.second))
+
+
+class TestSpaceListVisibility(GameplanTestCase):
+	def test_the_space_list_hides_a_private_space_the_user_is_not_in(self):
+		"""`GPProject.get_list_query` is the only thing scoping the Space list endpoint.
+
+		`apply_custom_filters` keeps the unfiltered query when the hook hands back None,
+		so losing the filter does not fail loudly — it returns every Space on the site,
+		private ones included.
+		"""
+		community = create_community("Listed Community", members=[self.member, self.second_member])
+		public = create_space("Listed Public Space", community)
+		private = create_space("Listed Private Space", community, is_private=1, members=[self.second_member])
+
+		def listed_for(user):
+			with self.as_user(user):
+				rows = get_list("GP Project", fields=["name"], filters={"team": community.name}, limit=100)
+			return {str(row["name"]) for row in rows}
+
+		self.assertIn(str(public.name), listed_for(self.member))
+		self.assertNotIn(str(private.name), listed_for(self.member))
+		# A global admin gets no criterion at all, so the filter has to hand the query
+		# back whole rather than narrow it to nothing.
+		self.assertIn(str(private.name), listed_for(self.admin))
 
 
 class TestSpaceMembership(GameplanTestCase):
@@ -357,6 +543,11 @@ class TestSpaceReadState(GameplanTestCase):
 		)
 
 	def test_guest_with_space_access_can_record_a_visit(self):
+		"""A guest reaches a Space through a GP Guest Access grant, never a member row.
+
+		That grant is the only thing `require_view_access` accepts from a guest, so this
+		is the whole guest path through `track_visit`'s insert branch.
+		"""
 		grant_guest_access(self.guest, self.space)
 
 		with self.as_user(self.guest):
@@ -371,11 +562,17 @@ class TestSpaceReadState(GameplanTestCase):
 		)
 
 	def test_guest_can_record_a_repeat_visit_to_a_granted_space(self):
-		"""The second visit updates the row instead of inserting one.
+		"""The second visit updates the existing row instead of inserting a second one.
 
-		Worth its own test because the two branches need different permissions: the
-		Gameplan Guest role has `create` on GP Project Visit but not `write`, so only
-		the update branch depends on the ignore_permissions save.
+		`track_visit` is a get-then-insert, so only a repeat call reaches the update
+		branch. One row per (user, Space) is what the unread badge rests on: with two, a
+		discussion satisfies both read-tracking predicates on different joined rows and
+		the count doubles — see TestSpaceUnreadCounts.
+
+		It says nothing about the GP Project Visit role table. Both branches save with
+		`ignore_permissions=True`, so what that table grants a guest never comes into it;
+		what stands between a guest and someone else's Space is `require_view_access`,
+		pinned by the two tests below.
 		"""
 		grant_guest_access(self.guest, self.space)
 
@@ -389,8 +586,13 @@ class TestSpaceReadState(GameplanTestCase):
 		)
 
 	def test_guest_can_mark_a_granted_space_read_after_visiting_it(self):
-		"""Same split as the repeat visit: marking read after a visit takes the update
-		branch, which the Gameplan Guest role has no write permission for."""
+		"""Marking read after a visit stamps the row `track_visit` already created.
+
+		Same get-then-insert split as the repeat visit above, and equally independent of
+		the role table — both branches save with `ignore_permissions=True`. The row count
+		is asserted because `mark_all_read_at` alone reads the same whether the stamp
+		landed on the existing visit or on a second one.
+		"""
 		grant_guest_access(self.guest, self.space)
 
 		with self.as_user(self.guest):
@@ -398,6 +600,10 @@ class TestSpaceReadState(GameplanTestCase):
 			space.track_visit()
 			space.mark_all_as_read()
 
+		self.assertEqual(
+			frappe.db.count("GP Project Visit", {"user": self.guest.name, "project": self.space.name}),
+			1,
+		)
 		self.assertTrue(
 			frappe.db.get_value(
 				"GP Project Visit",
@@ -799,6 +1005,36 @@ class TestSpaceUnreadCounts(GameplanTestCase):
 			counts = get_unread_count()
 
 		self.assertEqual(self._normalized(counts), {str(space.name): 3})
+
+	def test_a_discussion_posted_exactly_at_the_mark_read_timestamp_counts_as_read(self):
+		""" "Mark all read" means everything posted up to and including now.
+
+		`mark_all_as_read` stamps the visit with `frappe.utils.now()` and a post stamps
+		`last_post_at` off the same clock, so the two land on the same second whenever a
+		user marks a Space read as a post arrives. A `>=` boundary would leave the badge
+		showing a discussion the user just cleared, and it would never clear.
+		"""
+		space = self._space("Mark Read Boundary Space")
+		self._discussion("Posted At The Mark", space, self.MARKED_READ_AT)
+		self._visit_space(space, self.member, self.MARKED_READ_AT, self.MARKED_READ_AT)
+
+		with self.as_user(self.member):
+			counts = get_unread_count()
+
+		self.assertEqual(self._normalized(counts), {})
+
+	def test_a_discussion_last_visited_exactly_when_it_was_last_posted_counts_as_read(self):
+		"""The same boundary on the per-discussion regime: opening a discussion writes
+		the visit with `now()`, so a visit equal to `last_post_at` is the reader having
+		seen the newest post, not having missed it."""
+		space = self._space("Visit Boundary Space")
+		discussion = self._discussion("Read At The Post", space, "2026-01-03 09:00:00")
+		self._visit_discussion(discussion, self.member, "2026-01-03 09:00:00")
+
+		with self.as_user(self.member):
+			counts = get_unread_count()
+
+		self.assertEqual(self._normalized(counts), {})
 
 	def test_unread_counts_are_limited_to_the_users_own_spaces(self):
 		"""The joined-space list gated only the early return, not the counting query, so

--- a/gameplan/tests/mutation/__init__.py
+++ b/gameplan/tests/mutation/__init__.py
@@ -1,0 +1,14 @@
+"""Mutation testing harness for the Gameplan Frappe app.
+
+Mutants are applied by rewriting the source file in place, running the mapped test
+modules through ``bench run-tests``, then restoring the original bytes. In-place
+rewriting is required because the bench imports the app from its fixed path, so a
+copied mutants/ tree would never be the code the tests actually import.
+
+See ``cli.py`` for the command surface and ``safety.py`` for the crash-recovery
+guarantees around editing files in a live working tree.
+"""
+
+from .cli import main
+
+__all__ = ["main"]

--- a/gameplan/tests/mutation/__main__.py
+++ b/gameplan/tests/mutation/__main__.py
@@ -1,0 +1,10 @@
+"""Entry point: ``python -m gameplan.tests.mutation <command>``."""
+
+from __future__ import annotations
+
+import sys
+
+from .cli import main
+
+if __name__ == "__main__":
+	sys.exit(main())

--- a/gameplan/tests/mutation/campaign.py
+++ b/gameplan/tests/mutation/campaign.py
@@ -1,0 +1,527 @@
+"""Campaign orchestration: baseline gate, mutant loop, and the stage-2 verify pass.
+
+Execution is strictly serial. Every worker would mutate the same single source tree,
+so any parallelism would have workers overwriting each other's mutants and reporting
+verdicts for code that was never actually under test.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from pathlib import Path
+
+from . import journal as journal_mod
+from . import mutators, safety
+from .config import (
+	APP_ROOT,
+	BACKUP_DIR,
+	JOURNAL_PATH,
+	MAX_CONSECUTIVE_INFRA_ERRORS,
+	RETRYABLE_STATUSES,
+	STATUS_BASELINE_SKIP,
+	STATUS_ERROR,
+	STATUS_INFRA_ERROR,
+	STATUS_KILLED,
+	STATUS_KILLED_BY_OTHER_SUITE,
+	STATUS_KILLED_IMPORT_ERROR,
+	STATUS_KILLED_TIMEOUT,
+	STATUS_SURVIVED,
+	VERIFY_PATH,
+	target_map,
+)
+from .runner import RunResult, run_tests
+
+
+def _log(message: str) -> None:
+	print(f"[mutation] {message}", flush=True)
+
+
+def classify(result: RunResult) -> str:
+	"""Map a test-run outcome to a mutant status."""
+	if result.timed_out:
+		return STATUS_KILLED_TIMEOUT
+	if result.passed:
+		return STATUS_SURVIVED
+	# Non-zero, but a broken import is a much weaker signal than a caught assertion.
+	if result.looks_like_import_error:
+		return STATUS_KILLED_IMPORT_ERROR
+	# Non-zero with no tests run and nothing pointing at the mutant: the suite never
+	# happened. Not a verdict, so it is neither killed nor survived.
+	if result.looks_like_infra_error:
+		return STATUS_INFRA_ERROR
+	return STATUS_KILLED
+
+
+def _describe_orphan(manifest: dict) -> None:
+	state = safety.orphan_state(manifest)
+	_log(f"  {manifest['path']}  [{state}]")
+	if state in {"mutated", "unknown"}:
+		for line in safety.orphan_diff(manifest).splitlines():
+			print(f"      {line}", flush=True)
+	if state == "unknown":
+		_log("    ^ this file matches neither the pristine backup nor the mutant we wrote.")
+		_log("      It has been edited since the crash. Restoring would destroy those edits.")
+
+
+def check_orphans(assume_yes: bool = False) -> bool:
+	"""Handle backups left behind by a hard crash. Returns True if it is safe to proceed."""
+	orphans = safety.find_orphaned_backups()
+	if not orphans:
+		return True
+	_log(f"found {len(orphans)} orphaned backup(s) from a previous crashed run:")
+	for manifest in orphans:
+		_describe_orphan(manifest)
+	if any(safety.orphan_state(m) == "unknown" for m in orphans):
+		_log("refusing to auto-restore: at least one target has been edited since the crash.")
+		_log("resolve it by hand, then re-run.")
+		return False
+	if not assume_yes:
+		if not sys.stdin.isatty():
+			_log("refusing to run with orphaned backups present.")
+			_log("run 'python -m gameplan.tests.mutation restore' first.")
+			return False
+		answer = input("[mutation] restore these files now? [y/N] ").strip().lower()
+		if answer not in {"y", "yes"}:
+			_log("aborting; source files may still contain mutants.")
+			return False
+	for manifest in orphans:
+		try:
+			safety.restore_orphan(manifest)
+		except safety.RestoreError as exc:
+			_log(f"FAILED: {exc}")
+			return False
+		_log(f"restored {manifest['path']}")
+	return True
+
+
+def restore_command(assume_yes: bool = True) -> int:
+	owner = safety.lock_owner()
+	if owner is not None and owner != os.getpid():
+		_log(f"a mutation run (pid {owner}) is using this working tree right now.")
+		_log("its backups are not orphans; restoring them would strand its mutant. aborting.")
+		return 1
+	orphans = safety.find_orphaned_backups()
+	if not orphans:
+		_log("no orphaned backups; working tree is clean.")
+		return 0
+	failures = 0
+	for manifest in orphans:
+		_describe_orphan(manifest)
+		try:
+			safety.restore_orphan(manifest)
+		except safety.RestoreError as exc:
+			failures += 1
+			_log(f"FAILED: {exc}")
+		else:
+			_log(f"restored {manifest['path']}")
+	return 1 if failures else 0
+
+
+def _baseline_ok(site: str, test_modules: list[str], timeout: int) -> tuple[bool, str]:
+	"""Run the mapped tests unmutated. Mutation scores against a red baseline are noise."""
+	for module in test_modules:
+		result = run_tests(site, module, timeout)
+		if result.timed_out:
+			return False, f"{module} timed out after {timeout}s"
+		if not result.passed:
+			tail = result.output.strip().splitlines()[-5:]
+			return False, f"{module} failed (exit {result.returncode}): {' | '.join(tail)}"
+		if result.tests_ran in (0, None):
+			return False, f"{module} ran no tests"
+	return True, ""
+
+
+def run_campaign(
+	tier: str = "1",
+	only_module: str | None = None,
+	site: str = "",
+	timeout: int = 120,
+	limit: int | None = None,
+	mutate_strings: bool = False,
+	assume_yes: bool = False,
+	journal_path: Path | None = None,
+) -> int:
+	from .config import DEFAULT_SITE, DEFAULT_TIMEOUT
+
+	site = site or DEFAULT_SITE
+	timeout = timeout or DEFAULT_TIMEOUT
+	journal_path = journal_path or JOURNAL_PATH
+
+	targets = target_map(tier)
+	if only_module:
+		rel = only_module
+		if rel not in targets:
+			merged = target_map("all")
+			if rel not in merged:
+				_log(f"no test mapping for {rel!r}; add it to config.TIER1/TIER2 first.")
+				return 2
+			targets = {rel: merged[rel]}
+		else:
+			targets = {rel: targets[rel]}
+
+	try:
+		lock = safety.CampaignLock()
+		lock.acquire()
+	except safety.LockError as exc:
+		_log(f"refusing to run: {exc}")
+		return 1
+
+	try:
+		return _run_campaign_locked(
+			targets=targets,
+			site=site,
+			timeout=timeout,
+			limit=limit,
+			mutate_strings=mutate_strings,
+			assume_yes=assume_yes,
+			journal_path=journal_path,
+		)
+	finally:
+		lock.release()
+
+
+def _run_campaign_locked(
+	targets: dict[str, list[str]],
+	site: str,
+	timeout: int,
+	limit: int | None,
+	mutate_strings: bool,
+	assume_yes: bool,
+	journal_path: Path,
+) -> int:
+	if not check_orphans(assume_yes=assume_yes):
+		return 1
+
+	# Pre-flight: a dirty file means a hard crash could not be undone with git.
+	clean, dirty = safety.git_is_clean(list(targets))
+	if not clean:
+		_log("refusing to run: these target files have uncommitted changes:")
+		for rel in dirty:
+			_log(f"  {rel}")
+		_log("commit or stash them so a crash is always recoverable via 'git checkout --'.")
+		return 1
+
+	safety.install_handlers()
+	BACKUP_DIR.mkdir(parents=True, exist_ok=True)
+
+	done = journal_mod.completed_keys(journal_path, exclude_statuses=RETRYABLE_STATUSES)
+	evaluated = 0
+	consecutive_infra = 0
+	aborted = False
+
+	with journal_mod.Journal(journal_path) as journal:
+		for rel_path, test_modules in targets.items():
+			abs_path = APP_ROOT / rel_path
+			if not abs_path.exists():
+				_log(f"skipping missing file {rel_path}")
+				continue
+
+			_log(f"=== {rel_path} ===")
+			_log(f"baseline: {len(test_modules)} test module(s)...")
+			ok, reason = _baseline_ok(site, test_modules, timeout)
+			if not ok:
+				_log(f"baseline RED -> skipping module. {reason}")
+				journal.append(
+					{
+						"key": f"baseline:{rel_path}",
+						"module": rel_path,
+						"file": rel_path,
+						"line": 0,
+						"col": 0,
+						"function": "",
+						"mutator": "",
+						"original_segment": "",
+						"mutated_segment": "",
+						"status": STATUS_BASELINE_SKIP,
+						"duration_s": 0.0,
+						"killed_by_test_module": None,
+						"reason": reason,
+					}
+				)
+				continue
+			_log("baseline GREEN")
+
+			guard = safety.FileGuard(abs_path)
+			sites = mutators.collect_sites(guard.source, rel_path, mutate_strings=mutate_strings)
+			pending = [s for s in sites if s.key not in done]
+			_log(f"{len(sites)} mutant(s), {len(sites) - len(pending)} already journaled")
+
+			if not pending:
+				continue
+
+			guard.install_backup()
+			safety.register(guard)
+			try:
+				for site_obj in pending:
+					if limit is not None and evaluated >= limit:
+						_log(f"limit of {limit} mutants reached")
+						break
+					built = mutators.build_mutant(
+						guard.source, site_obj.node_index, site_obj.mutator, site_obj.param
+					)
+					if built is None:
+						continue
+					mutated_source, _ = built
+
+					status, killed_by, duration = _evaluate_mutant(
+						guard, mutated_source, site, test_modules, timeout
+					)
+					evaluated += 1
+					record = site_obj.to_dict()
+					record.update(
+						{
+							"module": rel_path,
+							"status": status,
+							"duration_s": duration,
+							"killed_by_test_module": killed_by,
+						}
+					)
+					journal.append(record)
+					_log(
+						f"  L{site_obj.line} {site_obj.mutator}: "
+						f"{site_obj.original_segment} -> {site_obj.mutated_segment} = {status} "
+						f"({duration}s)"
+					)
+
+					if status == STATUS_INFRA_ERROR:
+						consecutive_infra += 1
+						if consecutive_infra >= MAX_CONSECUTIVE_INFRA_ERRORS:
+							_log(
+								f"{consecutive_infra} consecutive runs never executed a test "
+								f"(locked site? bench broken?). Aborting instead of scoring noise."
+							)
+							aborted = True
+							break
+					else:
+						consecutive_infra = 0
+			finally:
+				# try/finally is the first line of defence; atexit and the signal
+				# handlers cover the paths this cannot reach.
+				guard.release()
+				safety.unregister(guard)
+
+			if aborted or (limit is not None and evaluated >= limit):
+				break
+
+	_log(f"done. evaluated {evaluated} mutant(s). journal: {journal_path}")
+	return 1 if aborted else 0
+
+
+def _evaluate_mutant(
+	guard: safety.FileGuard,
+	mutated_source: str,
+	site: str,
+	test_modules: list[str],
+	timeout: int,
+) -> tuple[str, str | None, float]:
+	"""Apply one mutant, run its mapped tests in sequence, restore, and classify."""
+	started = time.monotonic()
+	try:
+		# Inside the try so the restore in `finally` covers a failure during apply too.
+		guard.apply(mutated_source)
+		for module in test_modules:
+			result = run_tests(site, module, timeout)
+			status = classify(result)
+			if status != STATUS_SURVIVED:
+				return status, module, round(time.monotonic() - started, 2)
+		return STATUS_SURVIVED, None, round(time.monotonic() - started, 2)
+	except Exception as exc:  # noqa: BLE001 - one bad mutant must not end the campaign
+		_log(f"  error while evaluating mutant: {exc}")
+		return STATUS_ERROR, None, round(time.monotonic() - started, 2)
+	finally:
+		guard.restore()
+
+
+def verify(
+	journal_path: Path | None = None,
+	verify_path: Path | None = None,
+	site: str = "",
+	timeout: int = 0,
+	limit: int | None = None,
+	assume_yes: bool = False,
+) -> int:
+	"""Stage 2: re-run every survivor against the FULL suite.
+
+	Stage 1 only runs a module's own tests, so a "survivor" may in fact be caught by
+	some other module's tests. This separates genuinely untested behaviour from
+	merely mis-mapped coverage.
+	"""
+	from .config import DEFAULT_SITE, DEFAULT_TIMEOUT
+
+	journal_path = journal_path or JOURNAL_PATH
+	verify_path = verify_path or VERIFY_PATH
+	site = site or DEFAULT_SITE
+	explicit_timeout = timeout
+	# The whole suite is far slower than one module.
+	control_timeout = explicit_timeout or DEFAULT_TIMEOUT * 10
+
+	journalled = journal_mod.latest_by_key(journal_path).values()
+	records = [r for r in journalled if r.get("status") == STATUS_SURVIVED]
+	if not records:
+		_log("no survivors to verify.")
+		return 0
+
+	try:
+		lock = safety.CampaignLock()
+		lock.acquire()
+	except safety.LockError as exc:
+		_log(f"refusing to run: {exc}")
+		return 1
+
+	try:
+		if not check_orphans(assume_yes=assume_yes):
+			return 1
+
+		files = sorted({r["file"] for r in records})
+		clean, dirty = safety.git_is_clean(files)
+		if not clean:
+			_log(f"refusing to run: uncommitted changes in {', '.join(dirty)}")
+			return 1
+
+		safety.install_handlers()
+
+		# Control run. Without it, a full suite that is red or slow for reasons that have
+		# nothing to do with mutation marks every survivor as killed-by-other-suite (or
+		# killed-timeout), and those verdicts supersede stage 1 in the report - producing
+		# exactly the "100%, no survivors" result the campaign exists to disprove.
+		_log("control: running the FULL suite unmutated...")
+		control = run_tests(site, None, control_timeout)
+		if control.timed_out:
+			_log(f"control run timed out after {control_timeout}s. Raise --timeout. aborting.")
+			return 1
+		if not control.passed:
+			tail = " | ".join(control.output.strip().splitlines()[-5:])
+			_log(f"control run is RED (exit {control.returncode}): {tail}")
+			_log("fix the suite first; every survivor would be scored against a red baseline.")
+			return 1
+		if control.tests_ran in (0, None):
+			_log("control run reported no tests. aborting.")
+			return 1
+		# Derive the per-mutant budget from what the suite actually costs rather than a
+		# fixed multiple of the per-module default.
+		timeout = explicit_timeout or max(int(control.duration_s * 2) + 30, DEFAULT_TIMEOUT)
+		_log(
+			f"control GREEN: {control.tests_ran} tests in {control.duration_s}s; "
+			f"per-mutant timeout {timeout}s"
+		)
+
+		already = journal_mod.completed_keys(verify_path, exclude_statuses=RETRYABLE_STATUSES)
+		pending = [r for r in records if r["key"] not in already]
+		_log(f"{len(records)} survivor(s), {len(pending)} to verify against the full suite")
+
+		count = 0
+		sites_cache: dict[tuple[str, str], dict[str, mutators.MutationSite]] = {}
+		with journal_mod.Journal(verify_path) as out:
+			for record in pending:
+				if limit is not None and count >= limit:
+					break
+				# One bad survivor must not end the stage, exactly as in stage 1.
+				try:
+					done = _verify_one(record, site, timeout, sites_cache, out)
+				except Exception as exc:  # noqa: BLE001 - isolate per survivor
+					_log(f"  error while verifying {record['key'][:12]}: {exc}")
+					failed = dict(record)
+					failed.update(
+						{
+							"status": STATUS_ERROR,
+							"stage1_status": record.get("status"),
+							"reason": str(exc),
+							"killed_by_test_module": None,
+						}
+					)
+					out.append(failed)
+					done = False
+				if done:
+					count += 1
+	finally:
+		lock.release()
+
+	_log(f"verify done. results: {verify_path}")
+	return 0
+
+
+def _verify_sites(
+	rel_path: str,
+	guard: safety.FileGuard,
+	cache: dict[tuple[str, str], dict[str, mutators.MutationSite]],
+) -> dict[str, mutators.MutationSite]:
+	"""Mutation sites of one file, keyed by mutant key, cached per (file, content sha)."""
+	cache_key = (rel_path, guard.original_sha)
+	if cache_key not in cache:
+		# mutate_strings=True so the lookup covers campaigns that were run with it; the
+		# extra sites do not shift any other site's key.
+		sites = mutators.collect_sites(guard.source, rel_path, mutate_strings=True)
+		cache[cache_key] = {s.key: s for s in sites}
+	return cache[cache_key]
+
+
+def _verify_one(
+	record: dict,
+	site: str,
+	timeout: int,
+	sites_cache: dict[tuple[str, str], dict[str, mutators.MutationSite]],
+	out: journal_mod.Journal,
+) -> bool:
+	"""Re-apply one survivor against the full suite. Returns True if it was evaluated."""
+	abs_path = APP_ROOT / record["file"]
+	if not abs_path.exists():
+		_log(f"  skipping {record['key'][:12]}: {record['file']} no longer exists")
+		return False
+
+	guard = safety.FileGuard(abs_path)
+	# Re-derive the site from the current source by its content-based key. The journalled
+	# node_index is an index into list(ast.walk(tree)) and shifts whenever the file is
+	# edited; build_mutant only type-checks the node, so a shifted index silently mutates
+	# a *different* site and the verdict gets filed under this record's key.
+	site_obj = _verify_sites(record["file"], guard, sites_cache).get(record["key"])
+	if site_obj is None:
+		_log(f"  skipping stale mutant {record['key'][:12]} (site no longer exists in {record['file']})")
+		return False
+
+	built = mutators.build_mutant(guard.source, site_obj.node_index, site_obj.mutator, site_obj.param)
+	if built is None:
+		_log(f"  skipping stale mutant {record['key'][:12]} (no longer produces a mutant)")
+		return False
+	mutated_source, mutated_segment = built
+	if record.get("mutated_segment") and mutated_segment != record["mutated_segment"]:
+		# Belt and braces: the key matched but the rendered mutation did not.
+		_log(
+			f"  skipping {record['key'][:12]}: rebuilt mutation {mutated_segment!r} "
+			f"!= journalled {record['mutated_segment']!r}"
+		)
+		return False
+
+	guard.install_backup()
+	safety.register(guard)
+	started = time.monotonic()
+	try:
+		guard.apply(mutated_source)
+		result = run_tests(site, None, timeout)
+		status = classify(result)
+		if status == STATUS_SURVIVED:
+			final = STATUS_SURVIVED
+		elif status in {STATUS_KILLED_TIMEOUT, STATUS_INFRA_ERROR}:
+			final = status
+		else:
+			final = STATUS_KILLED_BY_OTHER_SUITE
+	finally:
+		guard.release()
+		safety.unregister(guard)
+
+	new_record = dict(record)
+	new_record.update(
+		{
+			"status": final,
+			"stage1_status": record["status"],
+			"line": site_obj.line,
+			"col": site_obj.col,
+			"node_index": site_obj.node_index,
+			"duration_s": round(time.monotonic() - started, 2),
+			"killed_by_test_module": "<full-suite>" if final == STATUS_KILLED_BY_OTHER_SUITE else None,
+		}
+	)
+	out.append(new_record)
+	_log(f"  L{site_obj.line} {record['mutator']}: {final}")
+	return True

--- a/gameplan/tests/mutation/campaign.py
+++ b/gameplan/tests/mutation/campaign.py
@@ -18,40 +18,67 @@ from .config import (
 	APP_ROOT,
 	BACKUP_DIR,
 	JOURNAL_PATH,
-	MAX_CONSECUTIVE_INFRA_ERRORS,
+	MAX_CONSECUTIVE_NO_VERDICT,
+	NO_VERDICT_STATUSES,
 	RETRYABLE_STATUSES,
 	STATUS_BASELINE_SKIP,
 	STATUS_ERROR,
+	STATUS_INCOMPLETE,
 	STATUS_INFRA_ERROR,
 	STATUS_KILLED,
 	STATUS_KILLED_BY_OTHER_SUITE,
 	STATUS_KILLED_IMPORT_ERROR,
-	STATUS_KILLED_TIMEOUT,
 	STATUS_SURVIVED,
+	STATUS_TIMEOUT,
+	STATUS_UNCONFIRMED,
 	VERIFY_PATH,
 	target_map,
 )
 from .runner import RunResult, run_tests
+
+# Exit codes. A nightly job keys off these, so they are part of the interface: a run
+# that measured nothing must never share a code with a run that measured everything and
+# liked what it saw. See ``_campaign_exit_code``. report.py mirrors these numbers.
+EXIT_OK = 0
+EXIT_ABORTED = 1
+EXIT_USAGE = 2
+EXIT_NOTHING_MEASURED = 3
 
 
 def _log(message: str) -> None:
 	print(f"[mutation] {message}", flush=True)
 
 
-def classify(result: RunResult) -> str:
-	"""Map a test-run outcome to a mutant status."""
+def classify(result: RunResult, mutated_file: str | None = None) -> str:
+	"""Map a test-run outcome to a mutant status.
+
+	A "killed" status is a claim that the TEST SUITE DETECTED the mutation. Anything
+	that did not come from the suite making that judgement resolves to a non-verdict:
+	it is an absence of evidence, not evidence of coverage. See the invariant in
+	config.py for why that distinction is load-bearing (non-verdicts stay out of the
+	score and are retried; kills are cached forever).
+
+	``mutated_file`` is the repo-relative path currently holding the mutant. Without
+	it an import failure cannot be attributed to the mutant, so it is not scored.
+	"""
 	if result.timed_out:
-		return STATUS_KILLED_TIMEOUT
+		# Never a kill. A mutant that spun forever and a box that was merely busy (or a
+		# site still holding a lock from the previous run) produce identical evidence:
+		# a process we killed before it said anything about anything. Telling them
+		# apart would need a control re-run costing another full timeout per mutant and
+		# would still misjudge a loaded machine. So: no verdict, retry it later.
+		return STATUS_TIMEOUT
 	if result.passed:
-		return STATUS_SURVIVED
-	# Non-zero, but a broken import is a much weaker signal than a caught assertion.
-	if result.looks_like_import_error:
+		# Exit 0 with the runner never announcing a result is not a survivor; it is a
+		# bench invocation that never reached the suite.
+		return STATUS_SURVIVED if result.reached_verdict else STATUS_INFRA_ERROR
+	if result.mutant_broke_import(mutated_file):
 		return STATUS_KILLED_IMPORT_ERROR
-	# Non-zero with no tests run and nothing pointing at the mutant: the suite never
-	# happened. Not a verdict, so it is neither killed nor survived.
-	if result.looks_like_infra_error:
-		return STATUS_INFRA_ERROR
-	return STATUS_KILLED
+	if result.suite_reported_failure:
+		return STATUS_KILLED
+	# Non-zero exit and the suite never declared a failure. Tests had started -> it died
+	# mid-flight; no tests at all -> it never started. Neither judged the mutant.
+	return STATUS_INCOMPLETE if result.tests_ran else STATUS_INFRA_ERROR
 
 
 def _describe_orphan(manifest: dict) -> None:
@@ -156,7 +183,7 @@ def run_campaign(
 			merged = target_map("all")
 			if rel not in merged:
 				_log(f"no test mapping for {rel!r}; add it to config.TIER1/TIER2 first.")
-				return 2
+				return EXIT_USAGE
 			targets = {rel: merged[rel]}
 		else:
 			targets = {rel: targets[rel]}
@@ -180,6 +207,47 @@ def run_campaign(
 		)
 	finally:
 		lock.release()
+
+
+def _guard_for(abs_path: Path) -> safety.FileGuard:
+	"""FileGuard for one target, with any crashed run's leftover mutant already undone.
+
+	``install_backup`` is the only thing that recovers the original from an existing
+	sidecar backup, so it must run before anything else looks at the file. Reading the
+	source or running the baseline first would measure the previous run's mutant, and a
+	module with nothing pending would return without ever calling it - leaving the mutant
+	on disk for the rest of the campaign and for whoever next opens the file.
+	"""
+	guard = safety.FileGuard(abs_path)
+	guard.install_backup()
+	return guard
+
+
+def _campaign_exit_code(
+	targeted: int,
+	skipped: int,
+	pending: int,
+	evaluated: int,
+	aborted: bool,
+	limit: int | None = None,
+) -> int:
+	"""Exit code for a finished campaign.
+
+	Success has to mean "we measured what we set out to measure", not merely "nothing
+	raised". A nightly whose site is down skips every module and evaluates nothing, which
+	to any caller checking for exit 0 is indistinguishable from a clean sweep. So the two
+	ways of ending with an empty scoreboard get different codes: having nothing to do
+	because every mutant is already journalled is a real success, while measuring nothing
+	because the environment is broken is a failure.
+	"""
+	if aborted:
+		return EXIT_ABORTED
+	if targeted and skipped == targeted:
+		return EXIT_NOTHING_MEASURED
+	# ``--limit 0`` is an explicit request to evaluate nothing, so it is not a failure.
+	if pending and not evaluated and limit != 0:
+		return EXIT_NOTHING_MEASURED
+	return EXIT_OK
 
 
 def _run_campaign_locked(
@@ -208,7 +276,9 @@ def _run_campaign_locked(
 
 	done = journal_mod.completed_keys(journal_path, exclude_statuses=RETRYABLE_STATUSES)
 	evaluated = 0
-	consecutive_infra = 0
+	pending_total = 0
+	skipped_modules = 0
+	consecutive_no_verdict = 0
 	aborted = False
 
 	with journal_mod.Journal(journal_path) as journal:
@@ -216,44 +286,53 @@ def _run_campaign_locked(
 			abs_path = APP_ROOT / rel_path
 			if not abs_path.exists():
 				_log(f"skipping missing file {rel_path}")
+				skipped_modules += 1
 				continue
 
 			_log(f"=== {rel_path} ===")
-			_log(f"baseline: {len(test_modules)} test module(s)...")
-			ok, reason = _baseline_ok(site, test_modules, timeout)
-			if not ok:
-				_log(f"baseline RED -> skipping module. {reason}")
-				journal.append(
-					{
-						"key": f"baseline:{rel_path}",
-						"module": rel_path,
-						"file": rel_path,
-						"line": 0,
-						"col": 0,
-						"function": "",
-						"mutator": "",
-						"original_segment": "",
-						"mutated_segment": "",
-						"status": STATUS_BASELINE_SKIP,
-						"duration_s": 0.0,
-						"killed_by_test_module": None,
-						"reason": reason,
-					}
-				)
-				continue
-			_log("baseline GREEN")
-
-			guard = safety.FileGuard(abs_path)
-			sites = mutators.collect_sites(guard.source, rel_path, mutate_strings=mutate_strings)
-			pending = [s for s in sites if s.key not in done]
-			_log(f"{len(sites)} mutant(s), {len(sites) - len(pending)} already journaled")
-
-			if not pending:
+			try:
+				guard = _guard_for(abs_path)
+			except (safety.LockError, safety.RestoreError, OSError) as exc:
+				_log(f"skipping {rel_path}: {exc}")
+				skipped_modules += 1
 				continue
 
-			guard.install_backup()
 			safety.register(guard)
 			try:
+				_log(f"baseline: {len(test_modules)} test module(s)...")
+				ok, reason = _baseline_ok(site, test_modules, timeout)
+				if not ok:
+					_log(f"baseline RED -> skipping module. {reason}")
+					skipped_modules += 1
+					journal.append(
+						{
+							"key": f"baseline:{rel_path}",
+							"module": rel_path,
+							"file": rel_path,
+							"line": 0,
+							"col": 0,
+							"function": "",
+							"mutator": "",
+							"original_segment": "",
+							"mutated_segment": "",
+							"status": STATUS_BASELINE_SKIP,
+							"duration_s": 0.0,
+							"killed_by_test_module": None,
+							"reason": reason,
+						}
+					)
+					continue
+				_log("baseline GREEN")
+
+				# Read the source through the guard, after _guard_for has had its chance to
+				# undo a crashed run's leftover mutant. Sites collected from mutated source
+				# get content-derived keys that match nothing on a clean tree, so every
+				# mutant would be re-evaluated under a key the journal can never resume.
+				sites = mutators.collect_sites(guard.source, rel_path, mutate_strings=mutate_strings)
+				pending = [s for s in sites if s.key not in done]
+				pending_total += len(pending)
+				_log(f"{len(sites)} mutant(s), {len(sites) - len(pending)} already journaled")
+
 				for site_obj in pending:
 					if limit is not None and evaluated >= limit:
 						_log(f"limit of {limit} mutants reached")
@@ -266,7 +345,7 @@ def _run_campaign_locked(
 					mutated_source, _ = built
 
 					status, killed_by, duration = _evaluate_mutant(
-						guard, mutated_source, site, test_modules, timeout
+						guard, mutated_source, site, test_modules, timeout, rel_path
 					)
 					evaluated += 1
 					record = site_obj.to_dict()
@@ -285,20 +364,27 @@ def _run_campaign_locked(
 						f"({duration}s)"
 					)
 
-					if status == STATUS_INFRA_ERROR:
-						consecutive_infra += 1
-						if consecutive_infra >= MAX_CONSECUTIVE_INFRA_ERRORS:
+					# Every non-verdict trips the breaker, not just infra-error: a wedged
+					# site shows up as a run of timeouts just as readily as a run of
+					# failures to start, and both mean the campaign has stopped
+					# measuring anything.
+					if status in NO_VERDICT_STATUSES:
+						consecutive_no_verdict += 1
+						if consecutive_no_verdict >= MAX_CONSECUTIVE_NO_VERDICT:
 							_log(
-								f"{consecutive_infra} consecutive runs never executed a test "
-								f"(locked site? bench broken?). Aborting instead of scoring noise."
+								f"{consecutive_no_verdict} consecutive runs produced no verdict "
+								f"(timeouts? locked site? bench broken?). "
+								f"Aborting instead of scoring noise."
 							)
 							aborted = True
 							break
 					else:
-						consecutive_infra = 0
+						consecutive_no_verdict = 0
 			finally:
 				# try/finally is the first line of defence; atexit and the signal
-				# handlers cover the paths this cannot reach.
+				# handlers cover the paths this cannot reach. It also guarantees that the
+				# recovery done by _guard_for is committed even for a module that turned
+				# out to have nothing pending.
 				guard.release()
 				safety.unregister(guard)
 
@@ -306,7 +392,23 @@ def _run_campaign_locked(
 				break
 
 	_log(f"done. evaluated {evaluated} mutant(s). journal: {journal_path}")
-	return 1 if aborted else 0
+	code = _campaign_exit_code(
+		targeted=len(targets),
+		skipped=skipped_modules,
+		pending=pending_total,
+		evaluated=evaluated,
+		aborted=aborted,
+		limit=limit,
+	)
+	if code == EXIT_NOTHING_MEASURED:
+		_log(
+			f"NOTHING MEASURED: {skipped_modules} of {len(targets)} target module(s) were "
+			f"skipped and no mutant was evaluated. Reporting failure - a green exit here "
+			f"would claim a passing campaign for a run that measured nothing."
+		)
+	elif skipped_modules:
+		_log(f"WARNING: {skipped_modules} of {len(targets)} target module(s) were skipped.")
+	return code
 
 
 def _evaluate_mutant(
@@ -315,6 +417,7 @@ def _evaluate_mutant(
 	site: str,
 	test_modules: list[str],
 	timeout: int,
+	rel_path: str,
 ) -> tuple[str, str | None, float]:
 	"""Apply one mutant, run its mapped tests in sequence, restore, and classify."""
 	started = time.monotonic()
@@ -323,15 +426,36 @@ def _evaluate_mutant(
 		guard.apply(mutated_source)
 		for module in test_modules:
 			result = run_tests(site, module, timeout)
-			status = classify(result)
+			status = classify(result, rel_path)
 			if status != STATUS_SURVIVED:
-				return status, module, round(time.monotonic() - started, 2)
+				# Only a real kill names a killing module. Attributing a non-verdict to
+				# a test module reads as coverage in the journal when it is the exact
+				# opposite: that module's run never judged anything.
+				blamed = module if status not in NO_VERDICT_STATUSES else None
+				return status, blamed, round(time.monotonic() - started, 2)
 		return STATUS_SURVIVED, None, round(time.monotonic() - started, 2)
 	except Exception as exc:  # noqa: BLE001 - one bad mutant must not end the campaign
 		_log(f"  error while evaluating mutant: {exc}")
 		return STATUS_ERROR, None, round(time.monotonic() - started, 2)
 	finally:
 		guard.restore()
+
+
+def _control_ok(site: str, timeout: int) -> tuple[bool, str, RunResult]:
+	"""Run the FULL suite unmutated. Returns (healthy, reason-if-not, result).
+
+	"Healthy" means the suite ran to completion and passed, so any failure seen with a
+	mutant applied can be attributed to the mutant rather than to the suite.
+	"""
+	result = run_tests(site, None, timeout)
+	if result.timed_out:
+		return False, f"control run timed out after {timeout}s (raise --timeout)", result
+	if not result.passed:
+		tail = " | ".join(result.output.strip().splitlines()[-5:])
+		return False, f"control run is RED (exit {result.returncode}): {tail}", result
+	if not result.reached_verdict or result.tests_ran in (0, None):
+		return False, "control run never reported a result", result
+	return True, "", result
 
 
 def verify(
@@ -363,6 +487,7 @@ def verify(
 		_log("no survivors to verify.")
 		return 0
 
+	aborted = False
 	try:
 		lock = safety.CampaignLock()
 		lock.acquire()
@@ -383,21 +508,14 @@ def verify(
 		safety.install_handlers()
 
 		# Control run. Without it, a full suite that is red or slow for reasons that have
-		# nothing to do with mutation marks every survivor as killed-by-other-suite (or
-		# killed-timeout), and those verdicts supersede stage 1 in the report - producing
-		# exactly the "100%, no survivors" result the campaign exists to disprove.
+		# nothing to do with mutation marks every survivor as killed-by-other-suite, and
+		# those verdicts supersede stage 1 in the report - producing exactly the
+		# "100%, no survivors" result the campaign exists to disprove.
 		_log("control: running the FULL suite unmutated...")
-		control = run_tests(site, None, control_timeout)
-		if control.timed_out:
-			_log(f"control run timed out after {control_timeout}s. Raise --timeout. aborting.")
-			return 1
-		if not control.passed:
-			tail = " | ".join(control.output.strip().splitlines()[-5:])
-			_log(f"control run is RED (exit {control.returncode}): {tail}")
+		healthy, reason, control = _control_ok(site, control_timeout)
+		if not healthy:
+			_log(f"{reason}. aborting.")
 			_log("fix the suite first; every survivor would be scored against a red baseline.")
-			return 1
-		if control.tests_ran in (0, None):
-			_log("control run reported no tests. aborting.")
 			return 1
 		# Derive the per-mutant budget from what the suite actually costs rather than a
 		# fixed multiple of the per-module default.
@@ -412,15 +530,26 @@ def verify(
 		_log(f"{len(records)} survivor(s), {len(pending)} to verify against the full suite")
 
 		count = 0
+		consecutive_no_verdict = 0
 		sites_cache: dict[tuple[str, str], dict[str, mutators.MutationSite]] = {}
 		with journal_mod.Journal(verify_path) as out:
 			for record in pending:
 				if limit is not None and count >= limit:
 					break
-				# One bad survivor must not end the stage, exactly as in stage 1.
 				try:
-					done = _verify_one(record, site, timeout, sites_cache, out)
-				except Exception as exc:  # noqa: BLE001 - isolate per survivor
+					status = _verify_one(record, site, timeout, sites_cache, out)
+				except safety.RestoreError as exc:
+					# NOT isolated like the rest. The working tree still holds this
+					# mutant: every later survivor would be measured against doubly
+					# mutated source, and the next FileGuard for this file would
+					# overwrite the pristine backup with the mutant, destroying the
+					# only copy that can undo it.
+					_log(f"CRITICAL: could not restore {record['file']}: {exc}")
+					_log("the working tree is still mutated. Aborting the verify stage.")
+					_log("run 'python -m gameplan.tests.mutation restore' before anything else.")
+					aborted = True
+					break
+				except Exception as exc:  # noqa: BLE001 - isolate one bad survivor
 					_log(f"  error while verifying {record['key'][:12]}: {exc}")
 					failed = dict(record)
 					failed.update(
@@ -432,14 +561,29 @@ def verify(
 						}
 					)
 					out.append(failed)
-					done = False
-				if done:
-					count += 1
+					status = STATUS_ERROR
+				if status is None:
+					continue
+				count += 1
+				# Same breaker as stage 1. A verify pass is far longer than a campaign,
+				# so a suite that degrades halfway through has plenty of time to
+				# reclassify every remaining survivor if nothing stops it.
+				if status in NO_VERDICT_STATUSES:
+					consecutive_no_verdict += 1
+					if consecutive_no_verdict >= MAX_CONSECUTIVE_NO_VERDICT:
+						_log(
+							f"{consecutive_no_verdict} consecutive survivors produced no "
+							f"verdict. The suite or the site is unhealthy; aborting."
+						)
+						aborted = True
+						break
+				else:
+					consecutive_no_verdict = 0
 	finally:
 		lock.release()
 
 	_log(f"verify done. results: {verify_path}")
-	return 0
+	return 1 if aborted else 0
 
 
 def _verify_sites(
@@ -463,12 +607,17 @@ def _verify_one(
 	timeout: int,
 	sites_cache: dict[tuple[str, str], dict[str, mutators.MutationSite]],
 	out: journal_mod.Journal,
-) -> bool:
-	"""Re-apply one survivor against the full suite. Returns True if it was evaluated."""
+) -> str | None:
+	"""Re-apply one survivor against the full suite.
+
+	Returns the status journalled for it, or None if the mutant was skipped without
+	being evaluated. Lets ``safety.RestoreError`` escape: the caller must treat a
+	working tree it could not clean as fatal, never as one bad survivor.
+	"""
 	abs_path = APP_ROOT / record["file"]
 	if not abs_path.exists():
 		_log(f"  skipping {record['key'][:12]}: {record['file']} no longer exists")
-		return False
+		return None
 
 	guard = safety.FileGuard(abs_path)
 	# Re-derive the site from the current source by its content-based key. The journalled
@@ -478,12 +627,12 @@ def _verify_one(
 	site_obj = _verify_sites(record["file"], guard, sites_cache).get(record["key"])
 	if site_obj is None:
 		_log(f"  skipping stale mutant {record['key'][:12]} (site no longer exists in {record['file']})")
-		return False
+		return None
 
 	built = mutators.build_mutant(guard.source, site_obj.node_index, site_obj.mutator, site_obj.param)
 	if built is None:
 		_log(f"  skipping stale mutant {record['key'][:12]} (no longer produces a mutant)")
-		return False
+		return None
 	mutated_source, mutated_segment = built
 	if record.get("mutated_segment") and mutated_segment != record["mutated_segment"]:
 		# Belt and braces: the key matched but the rendered mutation did not.
@@ -491,7 +640,7 @@ def _verify_one(
 			f"  skipping {record['key'][:12]}: rebuilt mutation {mutated_segment!r} "
 			f"!= journalled {record['mutated_segment']!r}"
 		)
-		return False
+		return None
 
 	guard.install_backup()
 	safety.register(guard)
@@ -499,16 +648,29 @@ def _verify_one(
 	try:
 		guard.apply(mutated_source)
 		result = run_tests(site, None, timeout)
-		status = classify(result)
-		if status == STATUS_SURVIVED:
-			final = STATUS_SURVIVED
-		elif status in {STATUS_KILLED_TIMEOUT, STATUS_INFRA_ERROR}:
-			final = status
-		else:
-			final = STATUS_KILLED_BY_OTHER_SUITE
+		status = classify(result, record["file"])
 	finally:
+		# Restores first, so the control re-run below measures a pristine tree. If the
+		# restore fails this raises out of _verify_one on purpose.
 		guard.release()
 		safety.unregister(guard)
+
+	if status == STATUS_SURVIVED or status in NO_VERDICT_STATUSES:
+		final = status
+	else:
+		# The full suite claims to kill a mutant that its own module's tests missed, and
+		# that verdict permanently supersedes stage 1 in the report. One --failfast run
+		# over 500+ tests is not enough evidence: a flaky test, data leaked by an earlier
+		# mutant, or a site that degraded mid-pass all look exactly like this. Confirm
+		# the suite is still green without the mutant before believing it.
+		_log(f"  {record['key'][:12]} looks killed by the full suite; confirming with a control run")
+		healthy, reason, _control = _control_ok(site, timeout)
+		if healthy:
+			final = STATUS_KILLED_BY_OTHER_SUITE
+		else:
+			_log(f"  control re-run unhealthy: {reason}")
+			_log("  the suite, not the mutant, is the variable. Recording no verdict.")
+			final = STATUS_UNCONFIRMED
 
 	new_record = dict(record)
 	new_record.update(
@@ -524,4 +686,4 @@ def _verify_one(
 	)
 	out.append(new_record)
 	_log(f"  L{site_obj.line} {record['mutator']}: {final}")
-	return True
+	return final

--- a/gameplan/tests/mutation/campaign.py
+++ b/gameplan/tests/mutation/campaign.py
@@ -13,12 +13,13 @@ import time
 from pathlib import Path
 
 from . import journal as journal_mod
-from . import mutators, safety
+from . import mutators, safety, scope
 from .config import (
 	APP_ROOT,
 	BACKUP_DIR,
 	JOURNAL_PATH,
 	MAX_CONSECUTIVE_NO_VERDICT,
+	MODULE_STATUSES,
 	NO_VERDICT_STATUSES,
 	RETRYABLE_STATUSES,
 	STATUS_BASELINE_SKIP,
@@ -28,6 +29,8 @@ from .config import (
 	STATUS_KILLED,
 	STATUS_KILLED_BY_OTHER_SUITE,
 	STATUS_KILLED_IMPORT_ERROR,
+	STATUS_MODULE_CURRENT,
+	STATUS_MODULE_SKIP,
 	STATUS_SURVIVED,
 	STATUS_TIMEOUT,
 	STATUS_UNCONFIRMED,
@@ -43,6 +46,11 @@ EXIT_OK = 0
 EXIT_ABORTED = 1
 EXIT_USAGE = 2
 EXIT_NOTHING_MEASURED = 3
+# The wall-clock budget ran out with mutants still pending. A *fourth* outcome on purpose:
+# folding it into 0 makes a nightly that is falling behind indistinguishable from one that
+# finished the corpus, and folding it into a failure pages a human every single night for
+# the design working exactly as intended.
+EXIT_BUDGET_EXHAUSTED = 4
 
 
 def _log(message: str) -> None:
@@ -169,6 +177,8 @@ def run_campaign(
 	mutate_strings: bool = False,
 	assume_yes: bool = False,
 	journal_path: Path | None = None,
+	budget_seconds: float | None = None,
+	changed_files: list[str] | None = None,
 ) -> int:
 	from .config import DEFAULT_SITE, DEFAULT_TIMEOUT
 
@@ -177,6 +187,9 @@ def run_campaign(
 	journal_path = journal_path or JOURNAL_PATH
 
 	targets = target_map(tier)
+	if only_module and changed_files is not None:
+		_log("--module and --changed-files-from both narrow the target set; pass only one.")
+		return EXIT_USAGE
 	if only_module:
 		rel = only_module
 		if rel not in targets:
@@ -187,6 +200,23 @@ def run_campaign(
 			targets = {rel: merged[rel]}
 		else:
 			targets = {rel: targets[rel]}
+	if changed_files is not None:
+		targets = scope.changed_targets(changed_files, targets)
+		if not targets:
+			# Not a failure and not a silent pass: there is genuinely nothing in this diff
+			# that this harness can measure. Returning before the lock keeps the common
+			# frontend-only pull request fast.
+			_log(f"none of the {len(changed_files)} changed file(s) map to a mutation target.")
+			_log("nothing to measure.")
+			return EXIT_OK
+		_log(f"diff-scoped to {len(targets)} target(s): {', '.join(targets)}")
+
+	# Started here rather than inside the lock so setup done on our behalf - orphan
+	# recovery, the git cleanliness check - is spent from the same allowance. A budget the
+	# clock only starts on the first mutant is not a wall-clock budget.
+	budget = scope.Budget(budget_seconds)
+	if budget_seconds is not None:
+		_log(f"budget: {budget_seconds:g}s of mutation work")
 
 	try:
 		lock = safety.CampaignLock()
@@ -204,6 +234,7 @@ def run_campaign(
 			mutate_strings=mutate_strings,
 			assume_yes=assume_yes,
 			journal_path=journal_path,
+			budget=budget,
 		)
 	finally:
 		lock.release()
@@ -223,6 +254,43 @@ def _guard_for(abs_path: Path) -> safety.FileGuard:
 	return guard
 
 
+def _module_record(rel_path: str, status: str, reason: str, tests_sha: str) -> dict:
+	"""A journal record about a MODULE rather than a mutant, keyed "baseline:<path>".
+
+	Two things are said with it, and the second exists only to retract the first:
+
+	A SKIP says "this module produced no measurement, and here is why". Every path that
+	drops a module has to leave one. The report's only way to notice a module that fell out
+	of the corpus is the journal, so a skip that only ever reached stdout is a module that
+	goes quietly unmeasured for ever while its stale verdicts keep counting toward the
+	published score.
+
+	STATUS_MODULE_CURRENT says "this module has a current score". It is written whenever a
+	run establishes that, and it is the only thing that can retire a skip.
+
+	The key is FIXED per module and identical for both, so the journal's last-wins merge
+	leaves exactly one of them and it is authoritative. That is the whole design: currency
+	is a fact recorded under the key it supersedes, not something the reader infers from
+	how far down the file a mutant record happens to sit. See STATUS_MODULE_CURRENT.
+	"""
+	return {
+		"key": f"baseline:{rel_path}",
+		"module": rel_path,
+		"file": rel_path,
+		"line": 0,
+		"col": 0,
+		"function": "",
+		"mutator": "",
+		"original_segment": "",
+		"mutated_segment": "",
+		"status": status,
+		"duration_s": 0.0,
+		"killed_by_test_module": None,
+		"tests_sha": tests_sha,
+		"reason": reason,
+	}
+
+
 def _campaign_exit_code(
 	targeted: int,
 	skipped: int,
@@ -230,6 +298,8 @@ def _campaign_exit_code(
 	evaluated: int,
 	aborted: bool,
 	limit: int | None = None,
+	budget_stopped: bool = False,
+	budget_seconds: float | None = None,
 ) -> int:
 	"""Exit code for a finished campaign.
 
@@ -239,14 +309,33 @@ def _campaign_exit_code(
 	ways of ending with an empty scoreboard get different codes: having nothing to do
 	because every mutant is already journalled is a real success, while measuring nothing
 	because the environment is broken is a failure.
+
+	The order of the checks is the contract, strongest evidence of breakage first:
+
+	1. an abort outranks everything - the circuit breaker fired, nothing else is credible;
+	2. then "measured nothing", including when the budget is what stopped us. A run that
+	burned its whole allowance without landing a single verdict is a broken site, not a
+	budget working as designed, and it must page someone rather than report "stopped early,
+	resuming tomorrow" for a week;
+	3. then the budget - work remains, but real work was done;
+	4. otherwise success.
+
+	Note the shape of rule 2: it fires on ``budget_stopped`` even when ``pending`` is 0.
+	``pending`` only counts modules the loop actually reached, so a budget that expired
+	before the FIRST module was inspected reports 0 pending and would otherwise slip
+	through as "stopped on budget, resuming tomorrow" - green, for ever, having run no
+	tests at all.
 	"""
 	if aborted:
 		return EXIT_ABORTED
 	if targeted and skipped == targeted:
 		return EXIT_NOTHING_MEASURED
-	# ``--limit 0`` is an explicit request to evaluate nothing, so it is not a failure.
-	if pending and not evaluated and limit != 0:
+	# ``--limit 0`` and ``--budget-seconds 0`` are explicit requests to evaluate nothing,
+	# so neither is a failure.
+	if (pending or budget_stopped) and not evaluated and limit != 0 and budget_seconds != 0:
 		return EXIT_NOTHING_MEASURED
+	if budget_stopped:
+		return EXIT_BUDGET_EXHAUSTED
 	return EXIT_OK
 
 
@@ -258,7 +347,9 @@ def _run_campaign_locked(
 	mutate_strings: bool,
 	assume_yes: bool,
 	journal_path: Path,
+	budget: scope.Budget | None = None,
 ) -> int:
+	budget = budget or scope.Budget(None)
 	if not check_orphans(assume_yes=assume_yes):
 		return 1
 
@@ -274,19 +365,49 @@ def _run_campaign_locked(
 	safety.install_handlers()
 	BACKUP_DIR.mkdir(parents=True, exist_ok=True)
 
-	done = journal_mod.completed_keys(journal_path, exclude_statuses=RETRYABLE_STATUSES)
+	# What each module's verdicts were produced BY. A verdict is only settled while the
+	# tests that produced it are unchanged; see scope.test_fingerprint for the reasoning
+	# and for the cost this deliberately accepts.
+	fingerprints = {rel: scope.test_fingerprint(tests, APP_ROOT) for rel, tests in targets.items()}
+	done = journal_mod.completed_keys(
+		journal_path, exclude_statuses=RETRYABLE_STATUSES, fingerprints=fingerprints
+	)
+	# Least-recently-measured first. Only matters under a budget, where the tail of the
+	# list never gets reached - see scope.round_robin_order. NO module-level record counts
+	# as a measurement: a skip would sort the module the gate wants re-measured last, and a
+	# "score is current" record written just before the budget expired would do the same to
+	# a module whose mutants never ran.
+	order = scope.round_robin_order(
+		list(targets),
+		scope.last_measured_positions(
+			journal_mod.read_records(journal_path), ignore_statuses=MODULE_STATUSES
+		),
+	)
 	evaluated = 0
 	pending_total = 0
-	skipped_modules = 0
+	# (module, reason) for every module that produced no measurement, so the tail of the
+	# run can name them instead of printing a count nobody can act on.
+	skipped: list[tuple[str, str]] = []
 	consecutive_no_verdict = 0
 	aborted = False
+	budget_stopped = False
 
 	with journal_mod.Journal(journal_path) as journal:
-		for rel_path, test_modules in targets.items():
+		for rel_path in order:
+			test_modules = targets[rel_path]
+			if budget.expired:
+				# Checked before the module rather than only before each mutant: a
+				# baseline pass is several minutes of test runs, and starting one with no
+				# allowance left overruns the budget by more than a mutant would.
+				_log(f"budget exhausted ({budget.describe()}); stopping before {rel_path}")
+				budget_stopped = True
+				break
 			abs_path = APP_ROOT / rel_path
 			if not abs_path.exists():
+				reason = f"{rel_path} does not exist (renamed or deleted without updating config.py)"
 				_log(f"skipping missing file {rel_path}")
-				skipped_modules += 1
+				skipped.append((rel_path, reason))
+				journal.append(_module_record(rel_path, STATUS_MODULE_SKIP, reason, fingerprints[rel_path]))
 				continue
 
 			_log(f"=== {rel_path} ===")
@@ -294,36 +415,13 @@ def _run_campaign_locked(
 				guard = _guard_for(abs_path)
 			except (safety.LockError, safety.RestoreError, OSError) as exc:
 				_log(f"skipping {rel_path}: {exc}")
-				skipped_modules += 1
+				reason = f"could not take a restorable backup: {exc}"
+				skipped.append((rel_path, reason))
+				journal.append(_module_record(rel_path, STATUS_MODULE_SKIP, reason, fingerprints[rel_path]))
 				continue
 
 			safety.register(guard)
 			try:
-				_log(f"baseline: {len(test_modules)} test module(s)...")
-				ok, reason = _baseline_ok(site, test_modules, timeout)
-				if not ok:
-					_log(f"baseline RED -> skipping module. {reason}")
-					skipped_modules += 1
-					journal.append(
-						{
-							"key": f"baseline:{rel_path}",
-							"module": rel_path,
-							"file": rel_path,
-							"line": 0,
-							"col": 0,
-							"function": "",
-							"mutator": "",
-							"original_segment": "",
-							"mutated_segment": "",
-							"status": STATUS_BASELINE_SKIP,
-							"duration_s": 0.0,
-							"killed_by_test_module": None,
-							"reason": reason,
-						}
-					)
-					continue
-				_log("baseline GREEN")
-
 				# Read the source through the guard, after _guard_for has had its chance to
 				# undo a crashed run's leftover mutant. Sites collected from mutated source
 				# get content-derived keys that match nothing on a clean tree, so every
@@ -333,9 +431,63 @@ def _run_campaign_locked(
 				pending_total += len(pending)
 				_log(f"{len(sites)} mutant(s), {len(sites) - len(pending)} already journaled")
 
+				# Before the baseline, not after: the baseline exists to make this module's
+				# verdicts trustworthy, and a module with no pending mutant produces none.
+				# Paying for its test modules anyway is what turns a budgeted nightly into a
+				# run that spends most of its allowance re-proving settled work - the whole
+				# corpus is ~17 bench invocations of baseline before a single mutation.
+				if not pending:
+					# Settled, and that has to be SAID: every mutant of this module has a
+					# verdict produced by the tests exactly as they are now. Without this
+					# record a module that was skipped once and then has nothing pending
+					# never runs a baseline again, so nothing can ever clear the skip and
+					# the gate stays red for ever - the self-sustaining failure this
+					# record exists to make impossible.
+					journal.append(
+						_module_record(
+							rel_path,
+							STATUS_MODULE_CURRENT,
+							f"all {len(sites)} mutant(s) already settled against the current tests",
+							fingerprints[rel_path],
+						)
+					)
+					continue
+
+				_log(f"baseline: {len(test_modules)} test module(s)...")
+				ok, reason = _baseline_ok(site, test_modules, timeout)
+				if not ok:
+					_log(f"baseline RED -> skipping module. {reason}")
+					skipped.append((rel_path, f"red baseline: {reason}"))
+					journal.append(
+						_module_record(rel_path, STATUS_BASELINE_SKIP, reason, fingerprints[rel_path])
+					)
+					continue
+				_log("baseline GREEN")
+				# Journalled here, before the mutants rather than after them: this is the
+				# record that retires any earlier skip, and it has to survive the run being
+				# cut short by the budget, the circuit breaker or a hard kill - which is
+				# precisely when a stale skip would otherwise outlive its cause.
+				journal.append(
+					_module_record(
+						rel_path,
+						STATUS_MODULE_CURRENT,
+						f"baseline green; measuring {len(pending)} pending mutant(s)",
+						fingerprints[rel_path],
+					)
+				)
+
 				for site_obj in pending:
 					if limit is not None and evaluated >= limit:
 						_log(f"limit of {limit} mutants reached")
+						break
+					if budget.expired:
+						# Between mutants, with the file already restored by the previous
+						# iteration's guard.restore(). This is the only place the budget may
+						# stop the loop: a check inside _evaluate_mutant would abandon a
+						# mutated source file on disk, which is the one failure this harness
+						# exists to make impossible.
+						_log(f"budget exhausted ({budget.describe()}); stopping cleanly")
+						budget_stopped = True
 						break
 					built = mutators.build_mutant(
 						guard.source, site_obj.node_index, site_obj.mutator, site_obj.param
@@ -355,6 +507,9 @@ def _run_campaign_locked(
 							"status": status,
 							"duration_s": duration,
 							"killed_by_test_module": killed_by,
+							# The provenance of this verdict: which test files, at which
+							# bytes, produced it. Change them and it stops being settled.
+							"tests_sha": fingerprints[rel_path],
 						}
 					)
 					journal.append(record)
@@ -388,26 +543,35 @@ def _run_campaign_locked(
 				guard.release()
 				safety.unregister(guard)
 
-			if aborted or (limit is not None and evaluated >= limit):
+			if aborted or budget_stopped or (limit is not None and evaluated >= limit):
 				break
 
 	_log(f"done. evaluated {evaluated} mutant(s). journal: {journal_path}")
 	code = _campaign_exit_code(
 		targeted=len(targets),
-		skipped=skipped_modules,
+		skipped=len(skipped),
 		pending=pending_total,
 		evaluated=evaluated,
 		aborted=aborted,
 		limit=limit,
+		budget_stopped=budget_stopped,
+		budget_seconds=budget.seconds,
 	)
+	if code == EXIT_BUDGET_EXHAUSTED:
+		_log(
+			f"STOPPED ON BUDGET: {evaluated} mutant(s) evaluated, work remains. This is not a "
+			f"failure - the journal is the resume point and the next run continues from here."
+		)
 	if code == EXIT_NOTHING_MEASURED:
 		_log(
-			f"NOTHING MEASURED: {skipped_modules} of {len(targets)} target module(s) were "
+			f"NOTHING MEASURED: {len(skipped)} of {len(targets)} target module(s) were "
 			f"skipped and no mutant was evaluated. Reporting failure - a green exit here "
 			f"would claim a passing campaign for a run that measured nothing."
 		)
-	elif skipped_modules:
-		_log(f"WARNING: {skipped_modules} of {len(targets)} target module(s) were skipped.")
+	if skipped:
+		_log(f"WARNING: {len(skipped)} of {len(targets)} target module(s) were skipped:")
+		for rel_path, reason in skipped:
+			_log(f"  {rel_path}: {reason}")
 	return code
 
 

--- a/gameplan/tests/mutation/cli.py
+++ b/gameplan/tests/mutation/cli.py
@@ -18,13 +18,21 @@ RUN_EXIT_CODES = """exit codes:
   2  bad arguments (e.g. a module with no test mapping)
   3  nothing measured: every targeted module was skipped, or no pending mutant could
      be evaluated. Distinct from 0 so a nightly cannot read a broken site as success.
+  4  --budget-seconds ran out with mutants still pending. Work was done and journalled;
+     the next run resumes from it. NOT a failure - a budgeted nightly ends here most
+     nights, and a job that treats this as red pages someone every night for nothing.
 """
 
 REPORT_EXIT_CODES = """exit codes:
   0  a score was measured, and it meets --fail-under if given
   1  a score was measured and is below --fail-under
-  3  nothing measured: no results, or every mutant produced a non-verdict. This is not
-     a score of 0% and deliberately does not share an exit code with one.
+  3  nothing measured: mutants were considered and every one produced a non-verdict
+     (broken site, timeouts). This is not a score of 0% and deliberately does not share
+     an exit code with one.
+  5  nothing to report: the result set held no mutant verdict (it was empty, or it held
+     only module-level records). Distinct from 3 because "nothing was due" is a benign
+     outcome, while 3 is a degraded measurement - a caller that conflates them publishes
+     a claim about the code for a run whose signal broke, or calls a quiet night broken.
 """
 
 
@@ -50,6 +58,21 @@ def build_parser() -> argparse.ArgumentParser:
 	run.add_argument("--mutate-strings", action="store_true", help="also mutate string literals (noisy here)")
 	run.add_argument("--yes", action="store_true", help="auto-restore orphaned backups without prompting")
 	run.add_argument("--journal", type=Path, default=JOURNAL_PATH)
+	run.add_argument(
+		"--budget-seconds",
+		type=float,
+		default=None,
+		metavar="SECONDS",
+		help="stop cleanly between mutants once this much wall clock has been used (exit 4)",
+	)
+	run.add_argument(
+		"--changed-files-from",
+		dest="changed_files_from",
+		type=Path,
+		default=None,
+		metavar="PATH",
+		help='restrict targets to those implicated by a "git diff --name-only" list ("-" for stdin)',
+	)
 
 	rep = sub.add_parser(
 		"report",
@@ -68,11 +91,42 @@ def build_parser() -> argparse.ArgumentParser:
 		help="stage-2 results to merge in (default: the sibling of --journal)",
 	)
 	rep.add_argument(
+		"--new-since",
+		dest="new_since",
+		type=Path,
+		default=None,
+		metavar="PATH",
+		help="report only mutants absent from the journal at PATH (what this run added)",
+	)
+	rep.add_argument(
+		"--prune-stale",
+		dest="prune_stale",
+		action="store_true",
+		help="drop verdicts whose mutation site no longer exists in the source (needs the source tree)",
+	)
+	rep.add_argument(
 		"--fail-under",
 		type=float,
 		default=None,
 		metavar="PERCENT",
 		help="exit 1 if the overall mutation score is below this percentage",
+	)
+
+	# Deliberately not part of `report`: the report says what was DECIDED, and a run can
+	# decide nothing after hours of work (every re-measured verdict came back the same).
+	# A job summary that shows only the first cannot tell a quiet night from a dead one.
+	work = sub.add_parser(
+		"work",
+		help="say what a run actually did, whether or not it changed any verdict",
+		description="Print one line describing the work a run appended to the journal.",
+	)
+	work.add_argument("--journal", type=Path, default=JOURNAL_PATH)
+	work.add_argument(
+		"--since",
+		type=Path,
+		default=None,
+		metavar="PATH",
+		help="snapshot of the journal taken before the run (default: count the whole journal)",
 	)
 
 	ver = sub.add_parser("verify", help="re-run survivors against the full suite")
@@ -99,10 +153,20 @@ def main(argv: list[str] | None = None) -> int:
 	# campaign import chain is broken.
 	from . import campaign
 	from . import report as report_mod
+	from .scope import read_changed_paths
 
 	args = build_parser().parse_args(argv)
 
 	if args.command == "run":
+		changed_files = None
+		if args.changed_files_from is not None:
+			try:
+				changed_files = read_changed_paths(str(args.changed_files_from))
+			except OSError as exc:
+				# Usage, not "nothing measured": CI asked us to scope to a diff and the
+				# diff is missing, so we have no idea what we were meant to measure.
+				print(f"[mutation] cannot read --changed-files-from: {exc}", flush=True)
+				return 2
 		return campaign.run_campaign(
 			tier=args.tier,
 			only_module=args.module,
@@ -112,6 +176,8 @@ def main(argv: list[str] | None = None) -> int:
 			mutate_strings=args.mutate_strings,
 			assume_yes=args.yes,
 			journal_path=args.journal,
+			budget_seconds=args.budget_seconds,
+			changed_files=changed_files,
 		)
 	if args.command == "report":
 		return report_mod.report(
@@ -119,7 +185,13 @@ def main(argv: list[str] | None = None) -> int:
 			fmt=args.fmt,
 			verify_path=args.verify_path or report_mod.verify_path_for(args.journal),
 			fail_under=args.fail_under,
+			new_since=args.new_since,
+			prune_stale=args.prune_stale,
 		)
+	if args.command == "work":
+		# Always 0: this is an observation, not a gate. A job summary interpolates it.
+		print(report_mod.render_work(report_mod.work_done(args.journal, args.since)))
+		return 0
 	if args.command == "verify":
 		return campaign.verify(
 			journal_path=args.journal,

--- a/gameplan/tests/mutation/cli.py
+++ b/gameplan/tests/mutation/cli.py
@@ -1,0 +1,75 @@
+"""Argument parsing for ``python -m gameplan.tests.mutation``."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from .config import DEFAULT_SITE, DEFAULT_TIMEOUT, JOURNAL_PATH
+
+
+def build_parser() -> argparse.ArgumentParser:
+	parser = argparse.ArgumentParser(
+		prog="python -m gameplan.tests.mutation",
+		description="Mutation testing harness for the Gameplan Frappe app.",
+	)
+	sub = parser.add_subparsers(dest="command", required=True)
+
+	run = sub.add_parser("run", help="run a mutation campaign")
+	run.add_argument("--tier", choices=["1", "2", "all"], default="1")
+	run.add_argument("--module", dest="module", default=None, help="single source path, e.g. gameplan/api.py")
+	run.add_argument("--site", default=DEFAULT_SITE)
+	run.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT, help="per test-module timeout, seconds")
+	run.add_argument("--limit", type=int, default=None, help="stop after N mutants (smoke testing)")
+	run.add_argument("--mutate-strings", action="store_true", help="also mutate string literals (noisy here)")
+	run.add_argument("--yes", action="store_true", help="auto-restore orphaned backups without prompting")
+	run.add_argument("--journal", type=Path, default=JOURNAL_PATH)
+
+	rep = sub.add_parser("report", help="summarise journalled results")
+	rep.add_argument("--journal", type=Path, default=JOURNAL_PATH)
+	rep.add_argument("--format", dest="fmt", choices=["text", "md", "json"], default="text")
+
+	ver = sub.add_parser("verify", help="re-run survivors against the full suite")
+	ver.add_argument("--journal", type=Path, default=JOURNAL_PATH)
+	ver.add_argument("--site", default=DEFAULT_SITE)
+	ver.add_argument("--timeout", type=int, default=0, help="0 uses 10x the per-module default")
+	ver.add_argument("--limit", type=int, default=None)
+	ver.add_argument("--yes", action="store_true")
+
+	sub.add_parser("restore", help="restore source files from orphaned backups after a hard crash")
+
+	return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+	# Imported lazily so `restore` and `report` stay usable even if something in the
+	# campaign import chain is broken.
+	from . import campaign
+	from . import report as report_mod
+
+	args = build_parser().parse_args(argv)
+
+	if args.command == "run":
+		return campaign.run_campaign(
+			tier=args.tier,
+			only_module=args.module,
+			site=args.site,
+			timeout=args.timeout,
+			limit=args.limit,
+			mutate_strings=args.mutate_strings,
+			assume_yes=args.yes,
+			journal_path=args.journal,
+		)
+	if args.command == "report":
+		return report_mod.report(journal_path=args.journal, fmt=args.fmt)
+	if args.command == "verify":
+		return campaign.verify(
+			journal_path=args.journal,
+			site=args.site,
+			timeout=args.timeout,
+			limit=args.limit,
+			assume_yes=args.yes,
+		)
+	if args.command == "restore":
+		return campaign.restore_command()
+	return 2

--- a/gameplan/tests/mutation/cli.py
+++ b/gameplan/tests/mutation/cli.py
@@ -1,4 +1,9 @@
-"""Argument parsing for ``python -m gameplan.tests.mutation``."""
+"""Argument parsing for ``python -m gameplan.tests.mutation``.
+
+Exit codes are part of this program's contract with CI, so they are documented in
+``--help`` rather than only in the source. The rule they encode: a command that measured
+nothing never exits 0.
+"""
 
 from __future__ import annotations
 
@@ -6,6 +11,21 @@ import argparse
 from pathlib import Path
 
 from .config import DEFAULT_SITE, DEFAULT_TIMEOUT, JOURNAL_PATH
+
+RUN_EXIT_CODES = """exit codes:
+  0  mutants were evaluated, or every mutant was already journalled
+  1  the campaign aborted (too many runs produced no verdict), or it refused to start
+  2  bad arguments (e.g. a module with no test mapping)
+  3  nothing measured: every targeted module was skipped, or no pending mutant could
+     be evaluated. Distinct from 0 so a nightly cannot read a broken site as success.
+"""
+
+REPORT_EXIT_CODES = """exit codes:
+  0  a score was measured, and it meets --fail-under if given
+  1  a score was measured and is below --fail-under
+  3  nothing measured: no results, or every mutant produced a non-verdict. This is not
+     a score of 0% and deliberately does not share an exit code with one.
+"""
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -15,7 +35,13 @@ def build_parser() -> argparse.ArgumentParser:
 	)
 	sub = parser.add_subparsers(dest="command", required=True)
 
-	run = sub.add_parser("run", help="run a mutation campaign")
+	run = sub.add_parser(
+		"run",
+		help="run a mutation campaign",
+		description="Run a mutation campaign.",
+		epilog=RUN_EXIT_CODES,
+		formatter_class=argparse.RawDescriptionHelpFormatter,
+	)
 	run.add_argument("--tier", choices=["1", "2", "all"], default="1")
 	run.add_argument("--module", dest="module", default=None, help="single source path, e.g. gameplan/api.py")
 	run.add_argument("--site", default=DEFAULT_SITE)
@@ -25,12 +51,39 @@ def build_parser() -> argparse.ArgumentParser:
 	run.add_argument("--yes", action="store_true", help="auto-restore orphaned backups without prompting")
 	run.add_argument("--journal", type=Path, default=JOURNAL_PATH)
 
-	rep = sub.add_parser("report", help="summarise journalled results")
+	rep = sub.add_parser(
+		"report",
+		help="summarise journalled results",
+		description="Summarise journalled results and gate on them.",
+		epilog=REPORT_EXIT_CODES,
+		formatter_class=argparse.RawDescriptionHelpFormatter,
+	)
 	rep.add_argument("--journal", type=Path, default=JOURNAL_PATH)
 	rep.add_argument("--format", dest="fmt", choices=["text", "md", "json"], default="text")
+	rep.add_argument(
+		"--verify-journal",
+		dest="verify_path",
+		type=Path,
+		default=None,
+		help="stage-2 results to merge in (default: the sibling of --journal)",
+	)
+	rep.add_argument(
+		"--fail-under",
+		type=float,
+		default=None,
+		metavar="PERCENT",
+		help="exit 1 if the overall mutation score is below this percentage",
+	)
 
 	ver = sub.add_parser("verify", help="re-run survivors against the full suite")
 	ver.add_argument("--journal", type=Path, default=JOURNAL_PATH)
+	ver.add_argument(
+		"--verify-journal",
+		dest="verify_path",
+		type=Path,
+		default=None,
+		help="where to write stage-2 verdicts (default: the sibling of --journal)",
+	)
 	ver.add_argument("--site", default=DEFAULT_SITE)
 	ver.add_argument("--timeout", type=int, default=0, help="0 uses 10x the per-module default")
 	ver.add_argument("--limit", type=int, default=None)
@@ -61,10 +114,20 @@ def main(argv: list[str] | None = None) -> int:
 			journal_path=args.journal,
 		)
 	if args.command == "report":
-		return report_mod.report(journal_path=args.journal, fmt=args.fmt)
+		return report_mod.report(
+			journal_path=args.journal,
+			fmt=args.fmt,
+			verify_path=args.verify_path or report_mod.verify_path_for(args.journal),
+			fail_under=args.fail_under,
+		)
 	if args.command == "verify":
 		return campaign.verify(
 			journal_path=args.journal,
+			# Derived from the same helper the report reads, so stage 2 always writes where
+			# stage 3 looks. Left unset, verify wrote the default .mutation/verify.jsonl for
+			# every journal: an alternate campaign's verdicts were invisible to its own
+			# report and silently overwrote the default campaign's.
+			verify_path=args.verify_path or report_mod.verify_path_for(args.journal),
 			site=args.site,
 			timeout=args.timeout,
 			limit=args.limit,

--- a/gameplan/tests/mutation/config.py
+++ b/gameplan/tests/mutation/config.py
@@ -96,6 +96,25 @@ STATUS_KILLED_IMPORT_ERROR = "killed-import-error"
 STATUS_KILLED_BY_OTHER_SUITE = "killed-by-other-suite"
 STATUS_SURVIVED = "survived"
 STATUS_BASELINE_SKIP = "baseline-skip"
+# The module was never even offered to the suite: its source file is gone (usually a
+# rename that config.py did not follow) or its FileGuard could not be built. Journalled
+# for the same reason as a red baseline - a module that silently drops out of the corpus
+# while its stale verdicts keep counting toward the published score is the exact failure
+# this harness is supposed to make impossible.
+STATUS_MODULE_SKIP = "module-skip"
+# The opposite claim, and the record that CLEARS a skip: "this module has a current
+# score". Written whenever a run establishes that - a green baseline, or a module whose
+# every mutant is already settled against the current tests.
+#
+# It exists because a skip's key is fixed per module ("baseline:<path>"), so without a
+# later record under the same key nothing ever supersedes it and the skip is immortal.
+# Inferring instead that "a mutant record further down the journal means the skip is old"
+# is the bug this replaces: journal position is only meaningful over the WHOLE journal,
+# and every caller of the report is free to filter it (--new-since, --prune-stale). A
+# filtered view then keeps the skip, loses the evidence that aged it out, and resurrects a
+# dead skip - turning every pull request red for a module it never touched. Currency is
+# therefore stated as data, under the key it supersedes, and no filter can separate them.
+STATUS_MODULE_CURRENT = "module-current"
 # The harness itself blew up on this mutant (bad AST rewrite, unwritable file).
 STATUS_ERROR = "error"
 # The suite never started: bench failed to launch, the site was locked, the disk filled up.
@@ -113,6 +132,25 @@ STATUS_UNCONFIRMED = "unconfirmed"
 # Legacy: campaigns run before timeouts were demoted to non-verdicts journalled this.
 # Kept only so those cached fake kills are re-evaluated rather than counted.
 STATUS_KILLED_TIMEOUT = "killed-timeout"
+
+# Records that describe a MODULE rather than a mutant. They are never scored and never
+# retried (there is no mutant to retry); they exist so that "this module produced no
+# measurement tonight" is a fact in the journal instead of a line of stdout nobody reads.
+SKIP_STATUSES = frozenset(
+	{
+		STATUS_BASELINE_SKIP,
+		STATUS_MODULE_SKIP,
+	}
+)
+
+# Every record that describes a MODULE rather than a mutant, i.e. every record keyed
+# "baseline:<path>". They all share one key per module, so the journal's last-wins merge
+# leaves exactly one of them per module and that one IS the module's current state: either
+# "no current score" (a skip) or "score is current" (STATUS_MODULE_CURRENT). Report
+# filters must keep or drop them as a class - never score them, never count them as a
+# measurement in the rotation, and never let a filter keep the skip while dropping what
+# supersedes it.
+MODULE_STATUSES = SKIP_STATUSES | {STATUS_MODULE_CURRENT}
 
 KILLED_STATUSES = frozenset(
 	{

--- a/gameplan/tests/mutation/config.py
+++ b/gameplan/tests/mutation/config.py
@@ -29,12 +29,42 @@ MAX_CONSECUTIVE_NO_VERDICT = 3
 
 # Source module -> test modules that are expected to cover it. Tier 1 is the
 # security/correctness-critical core; tier 2 is everything else worth measuring.
+#
+# WHAT BELONGS IN A TARGET'S LIST
+# -------------------------------
+# Stage 1 asks one question - "do the tests that OWN this module pin its behaviour?" -
+# so the list is deliberately narrower than "every test file that happens to execute a
+# line of it". Stage 2 (verify) is where the whole suite gets a say. Add a module here
+# only when it is the primary - usually the only - place some behaviour of the target is
+# asserted. Adding one because it merely touches the target buys nothing and costs on
+# every mutant.
+#
+# The cost is real and asymmetric. campaign.run_one_mutant runs the list IN ORDER and
+# stops at the first kill, so a module costs its own runtime once per mutant that
+# survived everything before it - never once per mutant. The same 7s module is ~18
+# minutes on permissions.py (~150 survivors) and under a minute on gp_poll.py (~9).
+# Hence the ordering rule: the module that owns most of the target goes first, so the
+# later entries are only ever paid for the mutants nothing before them caught.
+#
+# The other cost is invalidation: a target's list feeds scope.test_fingerprint, so
+# editing the list re-measures every verdict that target already had. That is intended
+# - a verdict produced by a different set of tests is stale, not settled.
 TIER1: dict[str, list[str]] = {
 	"gameplan/permissions.py": [
 		"gameplan.tests.permissions.test_permission_matrix",
 		"gameplan.tests.permissions.test_content_access",
 		"gameplan.tests.permissions.test_guest_access",
 		"gameplan.tests.permissions.test_visibility",
+		# Written FOR this file: it calls content_has_permission, can_interact_with_content
+		# and can_delete_content directly with assertIs, to pin the defaults that mutation
+		# testing flagged as survivors. Read its module docstring before deleting a branch
+		# it covers - and before adding a test for one it says it cannot reach.
+		"gameplan.tests.permissions.test_permission_defaults",
+		# The community half of guest access. test_guest_access above scopes a guest to
+		# their granted SPACES; nothing there reads a GP Team, so can_view_community's
+		# guest branch and team_access_criterion's guest criterion answer to this module
+		# alone - see its "SPA navigation" section, which exists to pin exactly those two.
+		"gameplan.tests.features.test_guest_participation",
 	],
 	"gameplan/email_digest.py": [
 		"gameplan.tests.features.test_email_digest",
@@ -53,21 +83,45 @@ TIER1: dict[str, list[str]] = {
 TIER2: dict[str, list[str]] = {
 	"gameplan/gameplan/doctype/gp_user_profile/gp_user_profile.py": [
 		"gameplan.tests.features.test_profiles",
+		# test_profiles covers bento cards, emojis and quick reactions; the account-
+		# management methods on the same doctype (change_user_role, disable_user) are
+		# specced only here, as the privilege-escalation guards they are.
+		"gameplan.tests.features.test_members",
 	],
 	"gameplan/api.py": [
 		"gameplan.tests.platform.test_api_endpoints",
+		# api.py is a grab-bag, and two of its endpoints are owned by feature specs
+		# rather than by the endpoint suite: _invite_by_email and accept_invitation are
+		# called directly by test_invitations...
+		"gameplan.tests.features.test_invitations",
+		# ...and invite_by_email's admin gate and role allow-list, plus get_user_info's
+		# "strip other members' emails for a guest" branch, only by test_members.
+		"gameplan.tests.features.test_members",
 	],
 	"gameplan/gameplan/doctype/gp_draft/gp_draft.py": [
 		"gameplan.tests.features.test_drafts",
 	],
 	"gameplan/gameplan/doctype/gp_poll/gp_poll.py": [
 		"gameplan.tests.features.test_polls",
+		# ongoing_polls_clause has no caller inside the poll doctype - it is the feed's
+		# query-builder mirror of poll_has_stopped, and the test that holds the two in
+		# step at the closing instant is TestFeedOngoingPolls, which lives with the feed.
+		"gameplan.tests.features.test_discussions",
 	],
 	"gameplan/gameplan/doctype/gp_discussion/api.py": [
 		"gameplan.tests.features.test_discussions",
+		# The bookmarks feed is the one feed_type test_discussions does not exercise:
+		# clause_discussions_bookmarked_by_user is reached only from the Bookmarks page,
+		# which is specced with the rest of bookmarking.
+		"gameplan.tests.features.test_bookmarks",
 	],
 	"gameplan/mixins/reactions.py": [
 		"gameplan.tests.features.test_reactions",
+		# test_reactions owns WHICH change notifies (add/withdraw/swap/own reaction);
+		# WHO gets the row and WHICH row it lands in - the can_view_content guard and the
+		# per-doctype dispatch that keeps a poll, comment and discussion reaction on
+		# separate notifications - are pinned by TestReactionNotifications instead.
+		"gameplan.tests.features.test_notifications",
 	],
 }
 

--- a/gameplan/tests/mutation/config.py
+++ b/gameplan/tests/mutation/config.py
@@ -1,0 +1,113 @@
+"""Paths, target map and status vocabulary for the mutation harness.
+
+Everything here is plain data so the target map stays trivially editable.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+# Derived rather than hardcoded so the harness keeps working if the bench is moved or
+# cloned elsewhere. config.py lives at <app>/gameplan/tests/mutation/config.py.
+APP_ROOT: Path = Path(__file__).resolve().parents[3]
+BENCH_ROOT: Path = Path(os.environ.get("GAMEPLAN_BENCH_ROOT") or APP_ROOT.parents[1])
+
+MUTATION_DIR: Path = APP_ROOT / ".mutation"
+BACKUP_DIR: Path = MUTATION_DIR / "backup"
+JOURNAL_PATH: Path = MUTATION_DIR / "journal.jsonl"
+VERIFY_PATH: Path = MUTATION_DIR / "verify.jsonl"
+LOCK_PATH: Path = MUTATION_DIR / "campaign.lock"
+
+DEFAULT_SITE = "gp-sqlite.test"
+DEFAULT_TIMEOUT = 120
+
+# Every mutant needs the test site to itself. Once the site is wedged (a leftover
+# process holding the lock, a bench that will not start), every remaining mutant
+# produces the same infrastructure failure, so bail instead of scoring noise.
+MAX_CONSECUTIVE_INFRA_ERRORS = 3
+
+# Source module -> test modules that are expected to cover it. Tier 1 is the
+# security/correctness-critical core; tier 2 is everything else worth measuring.
+TIER1: dict[str, list[str]] = {
+	"gameplan/permissions.py": [
+		"gameplan.tests.permissions.test_permission_matrix",
+		"gameplan.tests.permissions.test_content_access",
+		"gameplan.tests.permissions.test_guest_access",
+		"gameplan.tests.permissions.test_visibility",
+	],
+	"gameplan/email_digest.py": [
+		"gameplan.tests.features.test_email_digest",
+	],
+	"gameplan/gameplan/doctype/gp_unread_record/gp_unread_record.py": [
+		"gameplan.tests.features.test_unread",
+	],
+	"gameplan/gameplan/doctype/gp_team/gp_team.py": [
+		"gameplan.tests.features.test_communities",
+	],
+	"gameplan/gameplan/doctype/gp_project/gp_project.py": [
+		"gameplan.tests.features.test_spaces",
+	],
+}
+
+TIER2: dict[str, list[str]] = {
+	"gameplan/gameplan/doctype/gp_user_profile/gp_user_profile.py": [
+		"gameplan.tests.features.test_profiles",
+	],
+	"gameplan/api.py": [
+		"gameplan.tests.platform.test_api_endpoints",
+	],
+	"gameplan/gameplan/doctype/gp_draft/gp_draft.py": [
+		"gameplan.tests.features.test_drafts",
+	],
+	"gameplan/gameplan/doctype/gp_poll/gp_poll.py": [
+		"gameplan.tests.features.test_polls",
+	],
+	"gameplan/gameplan/doctype/gp_discussion/api.py": [
+		"gameplan.tests.features.test_discussions",
+	],
+	"gameplan/mixins/reactions.py": [
+		"gameplan.tests.features.test_reactions",
+	],
+}
+
+# Mutant outcome vocabulary. Kept explicit because the report and the verify stage
+# both key off these exact strings.
+STATUS_KILLED = "killed"
+STATUS_KILLED_IMPORT_ERROR = "killed-import-error"
+STATUS_KILLED_TIMEOUT = "killed-timeout"
+STATUS_KILLED_BY_OTHER_SUITE = "killed-by-other-suite"
+STATUS_SURVIVED = "survived"
+STATUS_BASELINE_SKIP = "baseline-skip"
+STATUS_ERROR = "error"
+# The suite never ran: bench failed to start, the site was locked, the disk filled up.
+# Says nothing about the mutant, so it must never reach the score.
+STATUS_INFRA_ERROR = "infra-error"
+
+KILLED_STATUSES = frozenset(
+	{
+		STATUS_KILLED,
+		STATUS_KILLED_IMPORT_ERROR,
+		STATUS_KILLED_TIMEOUT,
+		STATUS_KILLED_BY_OTHER_SUITE,
+	}
+)
+
+# Outcomes that carry no verdict about the mutant. They are excluded from both the
+# numerator and the denominator of the mutation score, and reported on their own.
+NON_SCORING_STATUSES = frozenset({STATUS_ERROR, STATUS_INFRA_ERROR})
+
+# ...and because their cause is transient, they are re-evaluated on the next run
+# instead of being treated as completed work by the resume logic.
+RETRYABLE_STATUSES = NON_SCORING_STATUSES
+
+
+def target_map(tier: str) -> dict[str, list[str]]:
+	"""Return the source->tests map for ``tier`` ("1", "2" or "all")."""
+	if tier == "1":
+		return dict(TIER1)
+	if tier == "2":
+		return dict(TIER2)
+	if tier == "all":
+		return {**TIER1, **TIER2}
+	raise ValueError(f"unknown tier: {tier!r} (expected 1, 2 or all)")

--- a/gameplan/tests/mutation/config.py
+++ b/gameplan/tests/mutation/config.py
@@ -24,8 +24,8 @@ DEFAULT_TIMEOUT = 120
 
 # Every mutant needs the test site to itself. Once the site is wedged (a leftover
 # process holding the lock, a bench that will not start), every remaining mutant
-# produces the same infrastructure failure, so bail instead of scoring noise.
-MAX_CONSECUTIVE_INFRA_ERRORS = 3
+# produces the same non-verdict, so bail instead of scoring noise.
+MAX_CONSECUTIVE_NO_VERDICT = 3
 
 # Source module -> test modules that are expected to cover it. Tier 1 is the
 # security/correctness-critical core; tier 2 is everything else worth measuring.
@@ -73,33 +73,75 @@ TIER2: dict[str, list[str]] = {
 
 # Mutant outcome vocabulary. Kept explicit because the report and the verify stage
 # both key off these exact strings.
+#
+# THE INVARIANT THAT HOLDS THIS HARNESS TOGETHER
+# ----------------------------------------------
+# Every status is either a VERDICT - the test suite itself judged this mutant - or a
+# NON-VERDICT - something other than the suite decided the outcome (a timeout, a wedged
+# site, a broken venv, a runner that died mid-suite, a harness bug). A "kill" is a claim
+# that the tests detected the mutation; a non-verdict is an ABSENCE of evidence, never
+# evidence of coverage. Resolving that ambiguity toward "killed" inflates the score and,
+# because the resume logic caches completed work, caches the lie forever. So:
+#
+#     NO_VERDICT_STATUSES & KILLED_STATUSES == frozenset()   never counted as a kill
+#     NO_VERDICT_STATUSES <= NON_SCORING_STATUSES            never reaches the score
+#     NO_VERDICT_STATUSES <= RETRYABLE_STATUSES              never cached as done
+#
+# If you add a status, decide which side of that line it falls on. Anything that is not
+# a judgement made by the test suite goes in NO_VERDICT_STATUSES. The three relations
+# above are asserted by gameplan/tests/platform/test_mutation_classification.py, so
+# breaking one fails the suite instead of silently inflating the mutation score.
 STATUS_KILLED = "killed"
 STATUS_KILLED_IMPORT_ERROR = "killed-import-error"
-STATUS_KILLED_TIMEOUT = "killed-timeout"
 STATUS_KILLED_BY_OTHER_SUITE = "killed-by-other-suite"
 STATUS_SURVIVED = "survived"
 STATUS_BASELINE_SKIP = "baseline-skip"
+# The harness itself blew up on this mutant (bad AST rewrite, unwritable file).
 STATUS_ERROR = "error"
-# The suite never ran: bench failed to start, the site was locked, the disk filled up.
-# Says nothing about the mutant, so it must never reach the score.
+# The suite never started: bench failed to launch, the site was locked, the disk filled up.
 STATUS_INFRA_ERROR = "infra-error"
+# The run exceeded its budget and was killed. A hung run is not a detection: nothing in
+# the suite ever asserted anything about the mutant. See runner/classify for why we do
+# not try to separate "mutant caused an infinite loop" from "the box was busy".
+STATUS_TIMEOUT = "timeout"
+# The suite started and then died without printing a judgement (OOM, lost site lock,
+# a crashed worker). Whatever it had run so far proves nothing about this mutant.
+STATUS_INCOMPLETE = "incomplete"
+# Verify only: the full suite failed with the mutant applied, but the control re-run
+# without it failed too, so the suite - not the mutant - is the variable.
+STATUS_UNCONFIRMED = "unconfirmed"
+# Legacy: campaigns run before timeouts were demoted to non-verdicts journalled this.
+# Kept only so those cached fake kills are re-evaluated rather than counted.
+STATUS_KILLED_TIMEOUT = "killed-timeout"
 
 KILLED_STATUSES = frozenset(
 	{
 		STATUS_KILLED,
 		STATUS_KILLED_IMPORT_ERROR,
-		STATUS_KILLED_TIMEOUT,
 		STATUS_KILLED_BY_OTHER_SUITE,
 	}
 )
 
-# Outcomes that carry no verdict about the mutant. They are excluded from both the
-# numerator and the denominator of the mutation score, and reported on their own.
-NON_SCORING_STATUSES = frozenset({STATUS_ERROR, STATUS_INFRA_ERROR})
+# Outcomes where the suite never delivered a judgement about the mutant.
+NO_VERDICT_STATUSES = frozenset(
+	{
+		STATUS_ERROR,
+		STATUS_INFRA_ERROR,
+		STATUS_TIMEOUT,
+		STATUS_INCOMPLETE,
+		STATUS_UNCONFIRMED,
+		STATUS_KILLED_TIMEOUT,
+	}
+)
+
+# Excluded from both the numerator and the denominator of the mutation score, and
+# reported on their own. Counting them as kills reports 100% for a suite that never ran;
+# counting them in the denominator alone punishes the tests for an infrastructure fault.
+NON_SCORING_STATUSES = NO_VERDICT_STATUSES
 
 # ...and because their cause is transient, they are re-evaluated on the next run
 # instead of being treated as completed work by the resume logic.
-RETRYABLE_STATUSES = NON_SCORING_STATUSES
+RETRYABLE_STATUSES = NO_VERDICT_STATUSES
 
 
 def target_map(tier: str) -> dict[str, list[str]]:

--- a/gameplan/tests/mutation/journal.py
+++ b/gameplan/tests/mutation/journal.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import os
+from collections.abc import Mapping
 from pathlib import Path
 from typing import IO
 
@@ -59,17 +60,40 @@ def read_records(path: Path) -> list[dict]:
 	return records
 
 
-def completed_keys(path: Path, exclude_statuses: frozenset[str] | set[str] | None = None) -> set[str]:
+def completed_keys(
+	path: Path,
+	exclude_statuses: frozenset[str] | set[str] | None = None,
+	fingerprints: Mapping[str, str] | None = None,
+) -> set[str]:
 	"""Keys that count as done for resume purposes.
 
 	``exclude_statuses`` keeps transient outcomes (a bench that failed to spawn, a
 	locked site) out of the set so the next run re-evaluates them instead of leaving
 	them stuck at their non-verdict forever.
+
+	``fingerprints`` maps a module to the fingerprint of the test files that currently
+	decide its verdicts (see ``scope.test_fingerprint``). A record whose stored
+	``tests_sha`` differs is STALE: the verdict is a fact about a suite that no longer
+	exists, so it is dropped from the "done" set and re-measured. A record with no
+	``tests_sha`` at all - written before verdicts carried their provenance - is stale for
+	the same reason: we cannot show which suite produced it. Pass ``None`` to disable the
+	check entirely (the verify stage re-runs against the full suite, so a per-module
+	fingerprint says nothing about it).
 	"""
 	exclude = exclude_statuses or frozenset()
+	done = set()
 	# Keyed on the *latest* record so a re-run that errored is retried again, and a
 	# re-run that produced a real verdict is not.
-	return {key for key, record in latest_by_key(path).items() if record.get("status") not in exclude}
+	for key, record in latest_by_key(path).items():
+		if record.get("status") in exclude:
+			continue
+		if fingerprints is not None:
+			module = record.get("module") or record.get("file")
+			current = fingerprints.get(module) if isinstance(module, str) else None
+			if current is not None and record.get("tests_sha") != current:
+				continue
+		done.add(key)
+	return done
 
 
 def latest_by_key(path: Path) -> dict[str, dict]:

--- a/gameplan/tests/mutation/journal.py
+++ b/gameplan/tests/mutation/journal.py
@@ -1,0 +1,82 @@
+"""Append-only JSONL journal used for resumability.
+
+Every record is flushed and fsynced immediately: a campaign is hours long and a crash
+must never cost more than the single mutant that was in flight.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import IO
+
+
+class Journal:
+	"""Durable append-only record store keyed by mutant key."""
+
+	def __init__(self, path: Path) -> None:
+		self.path = path
+		self._handle: IO[str] | None = None
+
+	def __enter__(self) -> Journal:
+		self.path.parent.mkdir(parents=True, exist_ok=True)
+		self._handle = open(self.path, "a", encoding="utf-8")
+		return self
+
+	def __exit__(self, *exc: object) -> None:
+		self.close()
+
+	def close(self) -> None:
+		if self._handle is not None:
+			self._handle.close()
+			self._handle = None
+
+	def append(self, record: dict) -> None:
+		if self._handle is None:
+			raise RuntimeError("journal is not open")
+		self._handle.write(json.dumps(record, sort_keys=True) + "\n")
+		self._handle.flush()
+		# fsync so an abrupt kill cannot lose already-completed work sitting in the
+		# OS page cache.
+		os.fsync(self._handle.fileno())
+
+
+def read_records(path: Path) -> list[dict]:
+	"""Read a JSONL journal, tolerating a truncated final line from a hard crash."""
+	if not path.exists():
+		return []
+	records: list[dict] = []
+	with open(path, encoding="utf-8") as handle:
+		for line in handle:
+			line = line.strip()
+			if not line:
+				continue
+			try:
+				records.append(json.loads(line))
+			except ValueError:
+				continue
+	return records
+
+
+def completed_keys(path: Path, exclude_statuses: frozenset[str] | set[str] | None = None) -> set[str]:
+	"""Keys that count as done for resume purposes.
+
+	``exclude_statuses`` keeps transient outcomes (a bench that failed to spawn, a
+	locked site) out of the set so the next run re-evaluates them instead of leaving
+	them stuck at their non-verdict forever.
+	"""
+	exclude = exclude_statuses or frozenset()
+	# Keyed on the *latest* record so a re-run that errored is retried again, and a
+	# re-run that produced a real verdict is not.
+	return {key for key, record in latest_by_key(path).items() if record.get("status") not in exclude}
+
+
+def latest_by_key(path: Path) -> dict[str, dict]:
+	"""Last record wins, so a re-run of a mutant supersedes the earlier verdict."""
+	result: dict[str, dict] = {}
+	for record in read_records(path):
+		key = record.get("key")
+		if key:
+			result[key] = record
+	return result

--- a/gameplan/tests/mutation/mutators.py
+++ b/gameplan/tests/mutation/mutators.py
@@ -10,12 +10,19 @@ source text is guaranteed pristine at address time because the harness restores 
 file after every run. It is NOT stable across edits to the file: anything re-applying
 a journalled mutant later must re-derive the site from the current source via its
 ``key`` (see ``campaign._verify_one``), never trust a stored ``node_index``.
+
+Every text that feeds a mutant key comes from ``ast.unparse``, never from the raw
+source. Unparsing normalises formatting and drops comments, so a reformat or a comment
+edit cannot invalidate a journalled verdict; only a real change to the code the key
+describes can. See ``mutant_key`` for the full stability envelope.
 """
 
 from __future__ import annotations
 
 import ast
+import copy
 import hashlib
+from collections import Counter
 from dataclasses import dataclass, field
 
 # Comparison operators are flipped to their adjacent/negated form. Boundary flips
@@ -145,20 +152,21 @@ def _excluded_ids(tree: ast.AST) -> set[int]:
 	return excluded
 
 
-def _qualnames(tree: ast.AST) -> dict[int, str]:
-	"""Map every node id to the dotted name of its enclosing class/function scope."""
-	names: dict[int, str] = {}
+def _scopes(tree: ast.AST) -> dict[int, tuple[str, ast.AST]]:
+	"""Map every node id to its enclosing class/function scope: dotted name and node."""
+	scopes: dict[int, tuple[str, ast.AST]] = {}
 
-	def visit(node: ast.AST, scope: str) -> None:
-		names[id(node)] = scope
+	def visit(node: ast.AST, name: str, owner: ast.AST) -> None:
+		scopes[id(node)] = (name, owner)
 		for child in ast.iter_child_nodes(node):
-			child_scope = scope
+			child_name, child_owner = name, owner
 			if isinstance(child, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
-				child_scope = f"{scope}.{child.name}" if scope else child.name
-			visit(child, child_scope)
+				child_name = f"{name}.{child.name}" if name else child.name
+				child_owner = child
+			visit(child, child_name, child_owner)
 
-	visit(tree, "")
-	return names
+	visit(tree, "", tree)
+	return scopes
 
 
 def _enclosing_statement(node: ast.AST, parents: dict[int, tuple[ast.AST, str, int | None]]) -> ast.AST:
@@ -171,29 +179,103 @@ def _enclosing_statement(node: ast.AST, parents: dict[int, tuple[ast.AST, str, i
 	return current
 
 
-def _segment(source: str, node: ast.AST) -> str:
-	try:
-		text = ast.get_source_segment(source, node)
-	except (ValueError, IndexError):
-		text = None
-	if text is None:
-		try:
-			text = ast.unparse(node)
-		except Exception:  # noqa: BLE001 - segment text is cosmetic, never fatal
-			text = f"<{type(node).__name__}>"
+def _normalise(text: str) -> str:
 	return " ".join(text.split())
 
 
+def _segment(node: ast.AST) -> str:
+	"""Normalised source-equivalent text of one node.
+
+	Unparsed rather than sliced out of the source: the slice would carry the file's
+	comments and line breaks into the mutant key, and it would not be comparable with
+	``mutated_segment``, which ``build_mutant`` produces with ``ast.unparse``.
+	"""
+	try:
+		return _normalise(ast.unparse(node))
+	except Exception:  # noqa: BLE001 - segment text is cosmetic, never fatal
+		return f"<{type(node).__name__}>"
+
+
+def _statement_header(node: ast.AST) -> str:
+	"""The statement's own line, without the block it introduces.
+
+	``ast.unparse`` always renders a header on one line, so the first line of a
+	compound statement is exactly its header. Excluding the body is what keeps a
+	mutant in an ``if``/``for``/``def`` header independent of every edit inside the
+	block it governs.
+	"""
+	if getattr(node, "decorator_list", None):
+		# Decorators unparse *above* the def line and would hide the signature, where
+		# default-argument mutants live.
+		node = copy.copy(node)
+		node.decorator_list = []
+	try:
+		text = ast.unparse(node)
+	except Exception:  # noqa: BLE001 - context text is cosmetic, never fatal
+		return f"<{type(node).__name__}>"
+	return _normalise(text.split("\n", 1)[0])
+
+
+def _scope_path(node: ast.AST, parents: dict[int, tuple[ast.AST, str, int | None]], scope: ast.AST) -> str:
+	"""Structural route from ``scope`` down to ``node``, e.g. ``body[3]/orelse[0]/test``.
+
+	Unique per node and blind to comments and formatting, so it can tell two otherwise
+	identical mutation sites apart. Positional, though: it is only ever used together
+	with a fingerprint of the whole scope, so that a deletion or a reorder changes the
+	fingerprint rather than quietly handing one site another's route.
+	"""
+	steps: list[str] = []
+	current = node
+	while current is not scope:
+		entry = parents.get(id(current))
+		if entry is None:
+			break
+		parent, field_name, index = entry
+		steps.append(field_name if index is None else f"{field_name}[{index}]")
+		current = parent
+	return "/".join(reversed(steps))
+
+
+def _digest(payload: str) -> str:
+	return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
 def mutant_key(
-	rel_path: str, mutator: str, function: str, original: str, mutated: str, context: str, ordinal: int
+	rel_path: str,
+	mutator: str,
+	param: int | None,
+	function: str,
+	original: str,
+	mutated: str,
+	context: str,
+	discriminator: str,
 ) -> str:
 	"""Stable identity for a mutant.
 
 	Deliberately excludes line/column: editing a file shifts every line below the edit,
-	which would make a line-based key skip brand-new mutants and re-run stale ones.
+	which would make a line-based key skip brand-new mutants and re-run stale ones. Every
+	component is unparsed AST text, so comments and formatting are invisible to the key.
+
+	``context`` is the enclosing statement's header only, and ``discriminator`` comes from
+	``collect_sites``: empty when nothing else in the file shares those components, and a
+	scope fingerprint when something does. The envelope this buys:
+
+	* reformatting, comment edits and edits inside an unrelated block: key unchanged.
+	* The site's own code changes: key changes, and the mutant is re-run.
+	* Two or more sites in one scope identical in every other component: each is pinned to
+	its route through a fingerprint of that whole scope, so deleting or reordering one
+	re-keys the group and every member is re-evaluated. A bare positional ordinal instead
+	hands the deleted site's verdict to a survivor, which is the one failure mode a
+	resumable journal must never have.
+
+	The residual: a mutant deleted and an identical one later added to the same scope,
+	with no other change to that scope, reuses the old key. Both are the same mutation of
+	the same statement, so the inherited verdict is at least about the same code.
 	"""
-	payload = "\x00".join([rel_path, mutator, function, original, mutated, context, str(ordinal)])
-	return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+	payload = "\x00".join(
+		[rel_path, mutator, str(param), function, original, mutated, context, discriminator]
+	)
+	return _digest(payload)
 
 
 def _candidate_specs(
@@ -339,16 +421,37 @@ def build_mutant(source: str, node_index: int, mutator: str, param: int | None) 
 	return mutated_text, " ".join(ast.unparse(rendered).split())
 
 
+@dataclass
+class _Draft:
+	"""A discovered site, before its ambiguity with other sites has been resolved."""
+
+	node_index: int
+	mutator: str
+	param: int | None
+	line: int
+	col: int
+	function: str
+	original_segment: str
+	mutated_segment: str
+	context: str
+	scope: ast.AST
+	path: str
+
+	@property
+	def ident(self) -> tuple[str, str, str, str, str]:
+		"""Everything about the mutant except where in its scope it sits."""
+		return (self.mutator, self.function, self.original_segment, self.mutated_segment, self.context)
+
+
 def collect_sites(source: str, rel_path: str, mutate_strings: bool = False) -> list[MutationSite]:
 	"""Discover every viable mutation site in ``source``."""
 	tree = ast.parse(source)
 	excluded = _excluded_ids(tree)
-	qualnames = _qualnames(tree)
+	scopes = _scopes(tree)
 	parents = _parent_map(tree)
 	nodes = list(ast.walk(tree))
 
-	sites: list[MutationSite] = []
-	seen_ordinals: dict[tuple[str, str, str, str, str], int] = {}
+	drafts: list[_Draft] = []
 	seen_texts: set[str] = set()
 
 	for node_index, mutator, param in _candidate_specs(tree, excluded, mutate_strings):
@@ -360,30 +463,67 @@ def collect_sites(source: str, rel_path: str, mutate_strings: bool = False) -> l
 		# the same module. build_mutant only compares against the pristine baseline, so
 		# it cannot see that. Without this, the duplicate burns a second full bench run
 		# and counts twice in the score denominator.
-		text_hash = hashlib.sha256(mutated_text.encode("utf-8")).hexdigest()
+		text_hash = _digest(mutated_text)
 		if text_hash in seen_texts:
 			continue
 		seen_texts.add(text_hash)
 		node = nodes[node_index]
-		original_segment = _segment(source, node)
-		context = _segment(source, _enclosing_statement(node, parents))
-		function = qualnames.get(id(node), "")
-		ident = (mutator, function, original_segment, mutated_segment, context)
-		ordinal = seen_ordinals.get(ident, 0)
-		seen_ordinals[ident] = ordinal + 1
-		sites.append(
-			MutationSite(
-				rel_path=rel_path,
+		statement = _enclosing_statement(node, parents)
+		function, scope = scopes.get(id(node), ("", tree))
+		drafts.append(
+			_Draft(
 				node_index=node_index,
 				mutator=mutator,
 				param=param,
 				line=getattr(node, "lineno", 0),
 				col=getattr(node, "col_offset", 0),
 				function=function,
-				original_segment=original_segment,
+				original_segment=_segment(node),
 				mutated_segment=mutated_segment,
+				context=_statement_header(statement),
+				scope=scope,
+				path=_scope_path(node, parents, scope),
+			)
+		)
+
+	# A site nothing else in the file can be confused with needs no discriminator, and
+	# leaving it out is what keeps its key alive across edits elsewhere in the file.
+	# Sites that ARE confusable get one built from their route through the scope plus a
+	# fingerprint of the whole scope: the route separates them, and the fingerprint means
+	# any edit to that scope - a deletion, a reorder, a new duplicate - re-keys every
+	# member of the group, so they are re-measured instead of one silently inheriting
+	# another's verdict. Scope text is unparsed, so comments and layout do not disturb it.
+	group_sizes = Counter(draft.ident for draft in drafts)
+	scope_texts: dict[int, str] = {}
+
+	sites: list[MutationSite] = []
+	for draft in drafts:
+		discriminator = ""
+		if group_sizes[draft.ident] > 1:
+			text = scope_texts.get(id(draft.scope))
+			if text is None:
+				text = scope_texts[id(draft.scope)] = _segment(draft.scope)
+			discriminator = _digest(f"{draft.path}\x00{text}")[:16]
+		sites.append(
+			MutationSite(
+				rel_path=rel_path,
+				node_index=draft.node_index,
+				mutator=draft.mutator,
+				param=draft.param,
+				line=draft.line,
+				col=draft.col,
+				function=draft.function,
+				original_segment=draft.original_segment,
+				mutated_segment=draft.mutated_segment,
 				key=mutant_key(
-					rel_path, mutator, function, original_segment, mutated_segment, context, ordinal
+					rel_path,
+					draft.mutator,
+					draft.param,
+					draft.function,
+					draft.original_segment,
+					draft.mutated_segment,
+					draft.context,
+					discriminator,
 				),
 			)
 		)

--- a/gameplan/tests/mutation/mutators.py
+++ b/gameplan/tests/mutation/mutators.py
@@ -1,0 +1,390 @@
+"""AST mutation site discovery and application.
+
+A mutant is produced by re-parsing the pristine source, mutating exactly one site,
+and unparsing the whole module. Re-parsing per mutant keeps every mutant independent
+and means a site never has to be "undone" in a shared tree.
+
+Sites are addressed by their index in ``list(ast.walk(tree))``. That ordering is a
+pure function of the tree shape, so it is stable for a given source text, and the
+source text is guaranteed pristine at address time because the harness restores the
+file after every run. It is NOT stable across edits to the file: anything re-applying
+a journalled mutant later must re-derive the site from the current source via its
+``key`` (see ``campaign._verify_one``), never trust a stored ``node_index``.
+"""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+from dataclasses import dataclass, field
+
+# Comparison operators are flipped to their adjacent/negated form. Boundary flips
+# (< <-> <=) catch off-by-one bugs; negation flips catch inverted guards.
+COMPARE_FLIP: dict[type[ast.cmpop], type[ast.cmpop]] = {
+	ast.Lt: ast.LtE,
+	ast.LtE: ast.Lt,
+	ast.Gt: ast.GtE,
+	ast.GtE: ast.Gt,
+	ast.Eq: ast.NotEq,
+	ast.NotEq: ast.Eq,
+	ast.Is: ast.IsNot,
+	ast.IsNot: ast.Is,
+	ast.In: ast.NotIn,
+	ast.NotIn: ast.In,
+}
+
+ARITH_FLIP: dict[type[ast.operator], type[ast.operator]] = {
+	ast.Add: ast.Sub,
+	ast.Sub: ast.Add,
+	ast.Mult: ast.Div,
+	ast.Div: ast.Mult,
+}
+
+MUTATOR_COMPARISON = "comparison"
+MUTATOR_BOOLEAN_OP = "boolean-op"
+MUTATOR_REMOVE_NOT = "remove-not"
+MUTATOR_BOOLEAN_CONST = "boolean-const"
+MUTATOR_NUMBER_INCREMENT = "number-increment"
+MUTATOR_NUMBER_ZERO = "number-zero"
+MUTATOR_ARITHMETIC = "arithmetic"
+MUTATOR_RETURN_NONE = "return-none"
+MUTATOR_STRING_CONST = "string-const"
+
+
+@dataclass
+class MutationSite:
+	"""One candidate mutation, addressable independently of line numbers."""
+
+	rel_path: str
+	node_index: int
+	mutator: str
+	param: int | None
+	line: int
+	col: int
+	function: str
+	original_segment: str
+	mutated_segment: str
+	key: str = field(default="")
+
+	def to_dict(self) -> dict:
+		return {
+			"file": self.rel_path,
+			"line": self.line,
+			"col": self.col,
+			"function": self.function,
+			"mutator": self.mutator,
+			"original_segment": self.original_segment,
+			"mutated_segment": self.mutated_segment,
+			"node_index": self.node_index,
+			"param": self.param,
+			"key": self.key,
+		}
+
+
+def _parent_map(tree: ast.AST) -> dict[int, tuple[ast.AST, str, int | None]]:
+	mapping: dict[int, tuple[ast.AST, str, int | None]] = {}
+	for parent in ast.walk(tree):
+		for field_name, value in ast.iter_fields(parent):
+			if isinstance(value, list):
+				for index, item in enumerate(value):
+					if isinstance(item, ast.AST):
+						mapping[id(item)] = (parent, field_name, index)
+			elif isinstance(value, ast.AST):
+				mapping[id(value)] = (parent, field_name, None)
+	return mapping
+
+
+def _is_type_checking_test(test: ast.expr) -> bool:
+	if isinstance(test, ast.Name):
+		return test.id == "TYPE_CHECKING"
+	if isinstance(test, ast.Attribute):
+		return test.attr == "TYPE_CHECKING"
+	return False
+
+
+def _docstring_constant(node: ast.AST) -> ast.Constant | None:
+	body = getattr(node, "body", None)
+	if not body or not isinstance(body, list):
+		return None
+	first = body[0]
+	if isinstance(first, ast.Expr) and isinstance(first.value, ast.Constant):
+		if isinstance(first.value.value, str):
+			return first.value
+	return None
+
+
+def _targets_dunder_all(node: ast.AST) -> bool:
+	targets: list[ast.expr] = []
+	if isinstance(node, ast.Assign):
+		targets = list(node.targets)
+	elif isinstance(node, ast.AugAssign | ast.AnnAssign):
+		targets = [node.target]
+	return any(isinstance(t, ast.Name) and t.id == "__all__" for t in targets)
+
+
+def _excluded_ids(tree: ast.AST) -> set[int]:
+	"""Node ids that must never be mutated (imports, docstrings, __all__, TYPE_CHECKING)."""
+	excluded: set[int] = set()
+
+	def mark(subtree: ast.AST) -> None:
+		for node in ast.walk(subtree):
+			excluded.add(id(node))
+
+	for node in ast.walk(tree):
+		if isinstance(node, ast.Import | ast.ImportFrom):
+			mark(node)
+		elif isinstance(node, ast.If) and _is_type_checking_test(node.test):
+			for stmt in node.body:
+				mark(stmt)
+		elif isinstance(node, ast.Assign | ast.AugAssign | ast.AnnAssign) and _targets_dunder_all(node):
+			mark(node)
+		if isinstance(node, ast.Module | ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
+			doc = _docstring_constant(node)
+			if doc is not None:
+				excluded.add(id(doc))
+	return excluded
+
+
+def _qualnames(tree: ast.AST) -> dict[int, str]:
+	"""Map every node id to the dotted name of its enclosing class/function scope."""
+	names: dict[int, str] = {}
+
+	def visit(node: ast.AST, scope: str) -> None:
+		names[id(node)] = scope
+		for child in ast.iter_child_nodes(node):
+			child_scope = scope
+			if isinstance(child, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
+				child_scope = f"{scope}.{child.name}" if scope else child.name
+			visit(child, child_scope)
+
+	visit(tree, "")
+	return names
+
+
+def _enclosing_statement(node: ast.AST, parents: dict[int, tuple[ast.AST, str, int | None]]) -> ast.AST:
+	current = node
+	while not isinstance(current, ast.stmt):
+		entry = parents.get(id(current))
+		if entry is None:
+			return current
+		current = entry[0]
+	return current
+
+
+def _segment(source: str, node: ast.AST) -> str:
+	try:
+		text = ast.get_source_segment(source, node)
+	except (ValueError, IndexError):
+		text = None
+	if text is None:
+		try:
+			text = ast.unparse(node)
+		except Exception:  # noqa: BLE001 - segment text is cosmetic, never fatal
+			text = f"<{type(node).__name__}>"
+	return " ".join(text.split())
+
+
+def mutant_key(
+	rel_path: str, mutator: str, function: str, original: str, mutated: str, context: str, ordinal: int
+) -> str:
+	"""Stable identity for a mutant.
+
+	Deliberately excludes line/column: editing a file shifts every line below the edit,
+	which would make a line-based key skip brand-new mutants and re-run stale ones.
+	"""
+	payload = "\x00".join([rel_path, mutator, function, original, mutated, context, str(ordinal)])
+	return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _candidate_specs(
+	tree: ast.AST, excluded: set[int], mutate_strings: bool
+) -> list[tuple[int, str, int | None]]:
+	"""Enumerate (node_index, mutator, param) triples without applying anything."""
+	specs: list[tuple[int, str, int | None]] = []
+	for index, node in enumerate(ast.walk(tree)):
+		if id(node) in excluded:
+			continue
+		if isinstance(node, ast.Compare):
+			for op_index, op in enumerate(node.ops):
+				if type(op) in COMPARE_FLIP:
+					specs.append((index, MUTATOR_COMPARISON, op_index))
+		elif isinstance(node, ast.BoolOp):
+			specs.append((index, MUTATOR_BOOLEAN_OP, None))
+		elif isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.Not):
+			specs.append((index, MUTATOR_REMOVE_NOT, None))
+		elif isinstance(node, ast.BinOp) and type(node.op) in ARITH_FLIP:
+			specs.append((index, MUTATOR_ARITHMETIC, None))
+		elif isinstance(node, ast.Return):
+			# A bare `return` or an explicit `return None` already returns None.
+			if node.value is not None and not (
+				isinstance(node.value, ast.Constant) and node.value.value is None
+			):
+				specs.append((index, MUTATOR_RETURN_NONE, None))
+		elif isinstance(node, ast.Constant):
+			value = node.value
+			if isinstance(value, bool):
+				specs.append((index, MUTATOR_BOOLEAN_CONST, None))
+			elif isinstance(value, int | float) and not isinstance(value, complex):
+				specs.append((index, MUTATOR_NUMBER_INCREMENT, None))
+				specs.append((index, MUTATOR_NUMBER_ZERO, None))
+			elif isinstance(value, str) and mutate_strings:
+				specs.append((index, MUTATOR_STRING_CONST, None))
+	return specs
+
+
+def apply_to_tree(tree: ast.AST, node_index: int, mutator: str, param: int | None) -> ast.AST | None:
+	"""Mutate ``tree`` in place at one site. Returns the node to render, or None if unapplicable."""
+	nodes = list(ast.walk(tree))
+	if node_index >= len(nodes):
+		return None
+	node = nodes[node_index]
+
+	if mutator == MUTATOR_COMPARISON:
+		if not isinstance(node, ast.Compare) or param is None or param >= len(node.ops):
+			return None
+		flipped = COMPARE_FLIP.get(type(node.ops[param]))
+		if flipped is None:
+			return None
+		node.ops[param] = flipped()
+		return node
+
+	if mutator == MUTATOR_BOOLEAN_OP:
+		if not isinstance(node, ast.BoolOp):
+			return None
+		node.op = ast.Or() if isinstance(node.op, ast.And) else ast.And()
+		return node
+
+	if mutator == MUTATOR_REMOVE_NOT:
+		if not isinstance(node, ast.UnaryOp) or not isinstance(node.op, ast.Not):
+			return None
+		parents = _parent_map(tree)
+		entry = parents.get(id(node))
+		if entry is None:
+			return None
+		parent, field_name, list_index = entry
+		if list_index is None:
+			setattr(parent, field_name, node.operand)
+		else:
+			getattr(parent, field_name)[list_index] = node.operand
+		return node.operand
+
+	if mutator == MUTATOR_ARITHMETIC:
+		if not isinstance(node, ast.BinOp):
+			return None
+		flipped = ARITH_FLIP.get(type(node.op))
+		if flipped is None:
+			return None
+		node.op = flipped()
+		return node
+
+	if mutator == MUTATOR_RETURN_NONE:
+		if not isinstance(node, ast.Return):
+			return None
+		node.value = ast.Constant(value=None)
+		return node
+
+	if mutator == MUTATOR_BOOLEAN_CONST:
+		if not isinstance(node, ast.Constant) or not isinstance(node.value, bool):
+			return None
+		node.value = not node.value
+		return node
+
+	if mutator == MUTATOR_NUMBER_INCREMENT:
+		if not isinstance(node, ast.Constant) or isinstance(node.value, bool):
+			return None
+		if not isinstance(node.value, int | float):
+			return None
+		node.value = node.value + 1
+		return node
+
+	if mutator == MUTATOR_NUMBER_ZERO:
+		if not isinstance(node, ast.Constant) or isinstance(node.value, bool):
+			return None
+		if not isinstance(node.value, int | float):
+			return None
+		# Zeroing an already-zero constant is a no-op, so flip to 1 to keep a real mutant.
+		# Keep the literal's type: `0.0 -> 1` would otherwise differ from the increment
+		# mutant's `0.0 -> 1.0` in text while being identical in behaviour.
+		node.value = type(node.value)(1) if node.value == 0 else type(node.value)(0)
+		return node
+
+	if mutator == MUTATOR_STRING_CONST:
+		if not isinstance(node, ast.Constant) or not isinstance(node.value, str):
+			return None
+		node.value = node.value + "XX"
+		return node
+
+	return None
+
+
+def build_mutant(source: str, node_index: int, mutator: str, param: int | None) -> tuple[str, str] | None:
+	"""Return ``(mutated_source, mutated_segment)`` or None if the mutant is a no-op."""
+	baseline_tree = ast.parse(source)
+	baseline_text = ast.unparse(baseline_tree)
+
+	tree = ast.parse(source)
+	rendered = apply_to_tree(tree, node_index, mutator, param)
+	if rendered is None:
+		return None
+	ast.fix_missing_locations(tree)
+	mutated_text = ast.unparse(tree)
+	# An identical unparse means the mutation had no observable effect; running the
+	# suite for it would burn a full bench invocation for nothing.
+	if mutated_text == baseline_text:
+		return None
+	try:
+		ast.parse(mutated_text)
+	except SyntaxError:
+		return None
+	return mutated_text, " ".join(ast.unparse(rendered).split())
+
+
+def collect_sites(source: str, rel_path: str, mutate_strings: bool = False) -> list[MutationSite]:
+	"""Discover every viable mutation site in ``source``."""
+	tree = ast.parse(source)
+	excluded = _excluded_ids(tree)
+	qualnames = _qualnames(tree)
+	parents = _parent_map(tree)
+	nodes = list(ast.walk(tree))
+
+	sites: list[MutationSite] = []
+	seen_ordinals: dict[tuple[str, str, str, str, str], int] = {}
+	seen_texts: set[str] = set()
+
+	for node_index, mutator, param in _candidate_specs(tree, excluded, mutate_strings):
+		built = build_mutant(source, node_index, mutator, param)
+		if built is None:
+			continue
+		mutated_text, mutated_segment = built
+		# Two mutators can land on identical code: `0 + 1` and "zero -> 1" both render
+		# the same module. build_mutant only compares against the pristine baseline, so
+		# it cannot see that. Without this, the duplicate burns a second full bench run
+		# and counts twice in the score denominator.
+		text_hash = hashlib.sha256(mutated_text.encode("utf-8")).hexdigest()
+		if text_hash in seen_texts:
+			continue
+		seen_texts.add(text_hash)
+		node = nodes[node_index]
+		original_segment = _segment(source, node)
+		context = _segment(source, _enclosing_statement(node, parents))
+		function = qualnames.get(id(node), "")
+		ident = (mutator, function, original_segment, mutated_segment, context)
+		ordinal = seen_ordinals.get(ident, 0)
+		seen_ordinals[ident] = ordinal + 1
+		sites.append(
+			MutationSite(
+				rel_path=rel_path,
+				node_index=node_index,
+				mutator=mutator,
+				param=param,
+				line=getattr(node, "lineno", 0),
+				col=getattr(node, "col_offset", 0),
+				function=function,
+				original_segment=original_segment,
+				mutated_segment=mutated_segment,
+				key=mutant_key(
+					rel_path, mutator, function, original_segment, mutated_segment, context, ordinal
+				),
+			)
+		)
+	return sites

--- a/gameplan/tests/mutation/report.py
+++ b/gameplan/tests/mutation/report.py
@@ -1,4 +1,15 @@
-"""Mutation score and survivor report rendering."""
+"""Mutation score and survivor report rendering.
+
+THE RULE THIS FILE EXISTS TO ENFORCE
+------------------------------------
+The report is the only artefact a human reads, so it must never present an ABSENCE of
+evidence as a result. "We could not measure this" and "we measured 0%" are different
+claims and must look different: a module whose mutants all timed out or died on infra
+has no score at all (``None`` -> rendered "n/a"), never a fabricated 0%. Every mutant
+without a verdict is excluded from both sides of the ratio and surfaced as an explicit
+count, so a run degraded by infrastructure problems reads as degraded rather than as a
+flattering low-denominator score.
+"""
 
 from __future__ import annotations
 
@@ -16,16 +27,53 @@ from .config import (
 	VERIFY_PATH,
 )
 
+# Exit codes, mirroring campaign.py so a nightly can key off both the same way.
+# "We could not measure this" is a third outcome, not a flavour of pass or fail: a gate
+# that collapses it into either one reports a healthy suite for a run that never
+# happened, or blames the tests for a broken site.
+EXIT_OK = 0
+EXIT_BELOW_THRESHOLD = 1
+EXIT_NOTHING_MEASURED = 3
+
+
+def verify_path_for(journal_path: Path) -> Path:
+	"""Stage-2 journal belonging to ``journal_path``.
+
+	Mutant keys are content hashes, so they collide across journals: merging the live
+	``.mutation/verify.jsonl`` into a report over an archived or alternate journal would
+	convert that campaign's survivors into kills using another campaign's verdicts. Each
+	journal therefore gets its own stage-2 sibling, and only the default journal keeps
+	the historical ``verify.jsonl`` name.
+	"""
+	if journal_path.resolve() == JOURNAL_PATH.resolve():
+		return VERIFY_PATH
+	return journal_path.with_name(f"{journal_path.stem}.verify{journal_path.suffix}")
+
 
 def load_results(journal_path: Path, verify_path: Path | None = None) -> list[dict]:
-	"""Merge stage-1 results with any stage-2 verdicts, which supersede them."""
-	merged = journal_mod.latest_by_key(journal_path)
+	"""Merge stage-1 results with any stage-2 verdicts, which supersede them.
+
+	The journal is append-only and legitimately contains re-runs of the same mutant, so
+	the last record for a key wins. The returned list is ordered by the position of each
+	winning record, which is what lets :func:`summarise` tell "this module was skipped,
+	then later measured" apart from "this module was measured, then later skipped".
+	"""
+	merged: dict[str, dict] = {}
+	for record in journal_mod.read_records(journal_path):
+		key = record.get("key")
+		if key:
+			# pop-then-set moves the key to the end: plain reassignment would keep the
+			# first occurrence's position and lose the ordering this function promises.
+			merged.pop(key, None)
+			merged[key] = record
+
 	if verify_path and verify_path.exists():
 		for key, record in journal_mod.latest_by_key(verify_path).items():
 			# A verify run that errored or never reached the suite carries no verdict, so
 			# it must not overwrite the stage-1 result for that mutant.
 			if record.get("status") in NON_SCORING_STATUSES and key in merged:
 				continue
+			merged.pop(key, None)
 			merged[key] = record
 	return list(merged.values())
 
@@ -33,24 +81,40 @@ def load_results(journal_path: Path, verify_path: Path | None = None) -> list[di
 def summarise(records: list[dict]) -> dict:
 	by_module: dict[str, Counter] = defaultdict(Counter)
 	survivors: dict[str, dict[str, list[dict]]] = defaultdict(lambda: defaultdict(list))
-	skipped: dict[str, str] = {}
+	# A red baseline is journalled under the fixed key "baseline:<path>", and a later
+	# GREEN baseline writes nothing to clear it, so the skip record is immortal. Track
+	# where each skip and each mutant verdict sits in journal order: a skip only still
+	# describes the module if nothing was measured for that module afterwards.
+	skip_reason: dict[str, str] = {}
+	last_skip_at: dict[str, int] = {}
+	last_mutant_at: dict[str, int] = {}
 
-	for record in records:
+	for position, record in enumerate(records):
 		module = record.get("module") or record.get("file") or "?"
 		status = record.get("status", "?")
 		if status == STATUS_BASELINE_SKIP:
-			skipped[module] = record.get("reason", "")
+			skip_reason[module] = record.get("reason", "")
+			last_skip_at[module] = position
 			continue
+		last_mutant_at[module] = position
 		by_module[module][status] += 1
 		if status == STATUS_SURVIVED:
 			survivors[record.get("file", module)][record.get("function") or "<module>"].append(record)
 
+	skipped = {
+		module: reason
+		for module, reason in skip_reason.items()
+		if last_skip_at[module] > last_mutant_at.get(module, -1)
+	}
+
 	scores = {}
 	for module, counts in by_module.items():
-		# Mutants whose run never produced a verdict (bench failed, site locked, harness
-		# error) are excluded from BOTH sides of the ratio. Counting them as kills
-		# reports 100% for a suite that never ran; counting them in the denominator
-		# alone punishes the tests for an infrastructure failure.
+		# Mutants whose run never produced a verdict (bench failed, site locked, timeout,
+		# harness error) are excluded from BOTH sides of the ratio. Counting them as kills
+		# reports 100% for a suite that never ran; counting them in the denominator alone
+		# punishes the tests for an infrastructure failure. When that leaves nothing to
+		# divide by, the score is None - "not measured" - never 0.0, which would be
+		# indistinguishable from a module whose tests genuinely killed nothing.
 		total = sum(counts.values())
 		unscored = sum(counts[s] for s in NON_SCORING_STATUSES)
 		scored = total - unscored
@@ -60,8 +124,11 @@ def summarise(records: list[dict]) -> dict:
 			"scored": scored,
 			"unscored": unscored,
 			"killed": killed,
-			"score": round(killed / scored, 4) if scored else 0.0,
+			"score": round(killed / scored, 4) if scored else None,
 			"counts": dict(counts),
+			# Set when the module's most recent journal entry is a red-baseline skip:
+			# the counts above are then leftovers from an earlier, greener run.
+			"baseline_skip": skipped.get(module),
 		}
 
 	overall_scored = sum(s["scored"] for s in scores.values())
@@ -72,14 +139,20 @@ def summarise(records: list[dict]) -> dict:
 		"modules": scores,
 		"survivors": {f: {fn: rs for fn, rs in fns.items()} for f, fns in survivors.items()},
 		"baseline_skipped": skipped,
+		"unmeasured_modules": sorted(m for m, s in scores.items() if s["score"] is None),
 		"overall": {
 			"total": sum(s["total"] for s in scores.values()),
 			"scored": overall_scored,
 			"unscored": overall_unscored,
 			"killed": overall_killed,
-			"score": round(overall_killed / overall_scored, 4) if overall_scored else 0.0,
+			"score": round(overall_killed / overall_scored, 4) if overall_scored else None,
 		},
 	}
+
+
+def format_score(score: float | None) -> str:
+	"""Render a score, or "n/a" when there was nothing to measure."""
+	return "n/a" if score is None else f"{score:.0%}"
 
 
 def render_text(summary: dict) -> str:
@@ -90,18 +163,34 @@ def render_text(summary: dict) -> str:
 	for module in sorted(summary["modules"]):
 		info = summary["modules"][module]
 		lines.append(f"{module}")
-		lines.append(f"  score: {info['score']:.0%}  ({info['killed']}/{info['scored']} killed)")
-		if info["unscored"]:
-			lines.append(f"  unscored (no verdict): {info['unscored']}")
+		if info["score"] is None:
+			lines.append(f"  score: n/a - NOT MEASURED ({info['total']} mutant(s), none produced a verdict)")
+		else:
+			lines.append(f"  score: {info['score']:.0%}  ({info['killed']}/{info['scored']} killed)")
+			if info["unscored"]:
+				lines.append(f"  unscored (no verdict): {info['unscored']}")
+		if info["baseline_skip"]:
+			lines.append(
+				f"  STALE: the latest run skipped this module (red baseline: "
+				f"{info['baseline_skip']}); the counts above predate that run"
+			)
 		for status in sorted(info["counts"]):
 			lines.append(f"    {status}: {info['counts'][status]}")
 	overall = summary["overall"]
 	lines.append("")
-	lines.append(f"OVERALL: {overall['score']:.0%}  ({overall['killed']}/{overall['scored']} killed)")
+	if overall["score"] is None:
+		lines.append(f"OVERALL: n/a - NOTHING MEASURED ({overall['total']} mutant(s), no verdicts)")
+	else:
+		lines.append(f"OVERALL: {overall['score']:.0%}  ({overall['killed']}/{overall['scored']} killed)")
 	if overall["unscored"]:
 		lines.append(
 			f"WARNING: {overall['unscored']} mutant(s) produced no verdict and are excluded "
 			f"from the score. Re-run to re-evaluate them."
+		)
+	if summary["unmeasured_modules"]:
+		lines.append(
+			f"WARNING: {len(summary['unmeasured_modules'])} module(s) have no score at all: "
+			f"{', '.join(summary['unmeasured_modules'])}"
 		)
 
 	if summary["baseline_skipped"]:
@@ -130,15 +219,31 @@ def render_markdown(summary: dict) -> str:
 	lines += ["| Module | Score | Killed | Scored | No verdict |", "| --- | --- | --- | --- | --- |"]
 	for module in sorted(summary["modules"]):
 		info = summary["modules"][module]
-		lines.append(
-			f"| `{module}` | {info['score']:.0%} | {info['killed']} | {info['scored']} | "
-			f"{info['unscored']} |"
-		)
+		label = f"`{module}`"
+		if info["baseline_skip"]:
+			label += " (stale: skipped, red baseline)"
+		score = "**n/a** (not measured)" if info["score"] is None else f"{info['score']:.0%}"
+		lines.append(f"| {label} | {score} | {info['killed']} | {info['scored']} | {info['unscored']} |")
 	overall = summary["overall"]
+	overall_score = (
+		"**n/a** (nothing measured)" if overall["score"] is None else f"**{overall['score']:.0%}**"
+	)
 	lines.append(
-		f"| **overall** | **{overall['score']:.0%}** | {overall['killed']} | {overall['scored']} | "
+		f"| **overall** | {overall_score} | {overall['killed']} | {overall['scored']} | "
 		f"{overall['unscored']} |"
 	)
+	if overall["unscored"]:
+		lines += [
+			"",
+			f"> {overall['unscored']} mutant(s) produced no verdict and are excluded from the "
+			f"score. Re-run to re-evaluate them.",
+		]
+	if summary["unmeasured_modules"]:
+		lines += [
+			"",
+			f"> {len(summary['unmeasured_modules'])} module(s) have no score at all: "
+			+ ", ".join(f"`{m}`" for m in summary["unmeasured_modules"]),
+		]
 
 	if summary["baseline_skipped"]:
 		lines += ["", "## Skipped (red baseline)", ""]
@@ -163,12 +268,25 @@ def render_markdown(summary: dict) -> str:
 	return "\n".join(lines) + "\n"
 
 
-def report(journal_path: Path | None = None, fmt: str = "text") -> int:
+def report(
+	journal_path: Path | None = None,
+	fmt: str = "text",
+	verify_path: Path | None = None,
+	fail_under: float | None = None,
+) -> int:
+	"""Render the report and return the gate verdict.
+
+	The three outcomes are kept distinct on purpose - see the exit code constants above.
+	Rendering always happens first: the numbers are the point, the exit code only decides
+	whether a machine should act on them.
+	"""
 	journal_path = journal_path or JOURNAL_PATH
-	records = load_results(journal_path, VERIFY_PATH)
+	records = load_results(journal_path, verify_path or verify_path_for(journal_path))
 	if not records:
 		print(f"[mutation] no results in {journal_path}")
-		return 0
+		# An empty journal is the purest form of "nothing measured": exiting 0 here would
+		# let a nightly whose campaign never started report a passing mutation score.
+		return EXIT_NOTHING_MEASURED
 	summary = summarise(records)
 	if fmt == "json":
 		print(json.dumps(summary, indent=2, sort_keys=True))
@@ -176,4 +294,23 @@ def report(journal_path: Path | None = None, fmt: str = "text") -> int:
 		print(render_markdown(summary), end="")
 	else:
 		print(render_text(summary), end="")
-	return 0
+	return gate(summary, fail_under)
+
+
+def gate(summary: dict, fail_under: float | None = None) -> int:
+	"""Turn a summary into an exit code, explaining any non-zero one on stdout."""
+	score = summary["overall"]["score"]
+	if score is None:
+		print(
+			"[mutation] FAIL: nothing was measured - every mutant produced a non-verdict "
+			"(broken site, timeouts, or a campaign that never ran). This is not a score of 0%."
+		)
+		return EXIT_NOTHING_MEASURED
+	if fail_under is not None:
+		percent = score * 100
+		# The score is rounded to 4 decimal places, so compare with a tolerance rather
+		# than failing a run that is exactly on the threshold.
+		if percent + 1e-9 < fail_under:
+			print(f"[mutation] FAIL: overall score {percent:.1f}% is below --fail-under {fail_under:g}%")
+			return EXIT_BELOW_THRESHOLD
+	return EXIT_OK

--- a/gameplan/tests/mutation/report.py
+++ b/gameplan/tests/mutation/report.py
@@ -1,0 +1,179 @@
+"""Mutation score and survivor report rendering."""
+
+from __future__ import annotations
+
+import json
+from collections import Counter, defaultdict
+from pathlib import Path
+
+from . import journal as journal_mod
+from .config import (
+	JOURNAL_PATH,
+	KILLED_STATUSES,
+	NON_SCORING_STATUSES,
+	STATUS_BASELINE_SKIP,
+	STATUS_SURVIVED,
+	VERIFY_PATH,
+)
+
+
+def load_results(journal_path: Path, verify_path: Path | None = None) -> list[dict]:
+	"""Merge stage-1 results with any stage-2 verdicts, which supersede them."""
+	merged = journal_mod.latest_by_key(journal_path)
+	if verify_path and verify_path.exists():
+		for key, record in journal_mod.latest_by_key(verify_path).items():
+			# A verify run that errored or never reached the suite carries no verdict, so
+			# it must not overwrite the stage-1 result for that mutant.
+			if record.get("status") in NON_SCORING_STATUSES and key in merged:
+				continue
+			merged[key] = record
+	return list(merged.values())
+
+
+def summarise(records: list[dict]) -> dict:
+	by_module: dict[str, Counter] = defaultdict(Counter)
+	survivors: dict[str, dict[str, list[dict]]] = defaultdict(lambda: defaultdict(list))
+	skipped: dict[str, str] = {}
+
+	for record in records:
+		module = record.get("module") or record.get("file") or "?"
+		status = record.get("status", "?")
+		if status == STATUS_BASELINE_SKIP:
+			skipped[module] = record.get("reason", "")
+			continue
+		by_module[module][status] += 1
+		if status == STATUS_SURVIVED:
+			survivors[record.get("file", module)][record.get("function") or "<module>"].append(record)
+
+	scores = {}
+	for module, counts in by_module.items():
+		# Mutants whose run never produced a verdict (bench failed, site locked, harness
+		# error) are excluded from BOTH sides of the ratio. Counting them as kills
+		# reports 100% for a suite that never ran; counting them in the denominator
+		# alone punishes the tests for an infrastructure failure.
+		total = sum(counts.values())
+		unscored = sum(counts[s] for s in NON_SCORING_STATUSES)
+		scored = total - unscored
+		killed = sum(counts[s] for s in KILLED_STATUSES)
+		scores[module] = {
+			"total": total,
+			"scored": scored,
+			"unscored": unscored,
+			"killed": killed,
+			"score": round(killed / scored, 4) if scored else 0.0,
+			"counts": dict(counts),
+		}
+
+	overall_scored = sum(s["scored"] for s in scores.values())
+	overall_unscored = sum(s["unscored"] for s in scores.values())
+	overall_killed = sum(s["killed"] for s in scores.values())
+
+	return {
+		"modules": scores,
+		"survivors": {f: {fn: rs for fn, rs in fns.items()} for f, fns in survivors.items()},
+		"baseline_skipped": skipped,
+		"overall": {
+			"total": sum(s["total"] for s in scores.values()),
+			"scored": overall_scored,
+			"unscored": overall_unscored,
+			"killed": overall_killed,
+			"score": round(overall_killed / overall_scored, 4) if overall_scored else 0.0,
+		},
+	}
+
+
+def render_text(summary: dict) -> str:
+	lines: list[str] = ["Mutation report", "=" * 60, ""]
+
+	lines.append("Scores")
+	lines.append("-" * 60)
+	for module in sorted(summary["modules"]):
+		info = summary["modules"][module]
+		lines.append(f"{module}")
+		lines.append(f"  score: {info['score']:.0%}  ({info['killed']}/{info['scored']} killed)")
+		if info["unscored"]:
+			lines.append(f"  unscored (no verdict): {info['unscored']}")
+		for status in sorted(info["counts"]):
+			lines.append(f"    {status}: {info['counts'][status]}")
+	overall = summary["overall"]
+	lines.append("")
+	lines.append(f"OVERALL: {overall['score']:.0%}  ({overall['killed']}/{overall['scored']} killed)")
+	if overall["unscored"]:
+		lines.append(
+			f"WARNING: {overall['unscored']} mutant(s) produced no verdict and are excluded "
+			f"from the score. Re-run to re-evaluate them."
+		)
+
+	if summary["baseline_skipped"]:
+		lines += ["", "Skipped (red baseline)", "-" * 60]
+		for module, reason in sorted(summary["baseline_skipped"].items()):
+			lines.append(f"{module}: {reason}")
+
+	lines += ["", "Survivors", "-" * 60]
+	if not summary["survivors"]:
+		lines.append("none")
+	for path in sorted(summary["survivors"]):
+		lines.append(f"\n{path}")
+		for function in sorted(summary["survivors"][path]):
+			lines.append(f"  {function}()")
+			for record in sorted(summary["survivors"][path][function], key=lambda r: r.get("line", 0)):
+				lines.append(
+					f"    line {record.get('line')}: "
+					f"{record.get('original_segment')} -> {record.get('mutated_segment')}"
+					f"   [{record.get('mutator')}]"
+				)
+	return "\n".join(lines) + "\n"
+
+
+def render_markdown(summary: dict) -> str:
+	lines = ["# Mutation report", "", "## Scores", ""]
+	lines += ["| Module | Score | Killed | Scored | No verdict |", "| --- | --- | --- | --- | --- |"]
+	for module in sorted(summary["modules"]):
+		info = summary["modules"][module]
+		lines.append(
+			f"| `{module}` | {info['score']:.0%} | {info['killed']} | {info['scored']} | "
+			f"{info['unscored']} |"
+		)
+	overall = summary["overall"]
+	lines.append(
+		f"| **overall** | **{overall['score']:.0%}** | {overall['killed']} | {overall['scored']} | "
+		f"{overall['unscored']} |"
+	)
+
+	if summary["baseline_skipped"]:
+		lines += ["", "## Skipped (red baseline)", ""]
+		for module, reason in sorted(summary["baseline_skipped"].items()):
+			lines.append(f"- `{module}` - {reason}")
+
+	lines += ["", "## Survivors", ""]
+	if not summary["survivors"]:
+		lines.append("None.")
+	for path in sorted(summary["survivors"]):
+		lines.append(f"### `{path}`")
+		lines.append("")
+		for function in sorted(summary["survivors"][path]):
+			lines.append(f"**{function}()**")
+			lines.append("")
+			for record in sorted(summary["survivors"][path][function], key=lambda r: r.get("line", 0)):
+				lines.append(
+					f"- line {record.get('line')}: `{record.get('original_segment')}` -> "
+					f"`{record.get('mutated_segment')}` ({record.get('mutator')})"
+				)
+			lines.append("")
+	return "\n".join(lines) + "\n"
+
+
+def report(journal_path: Path | None = None, fmt: str = "text") -> int:
+	journal_path = journal_path or JOURNAL_PATH
+	records = load_results(journal_path, VERIFY_PATH)
+	if not records:
+		print(f"[mutation] no results in {journal_path}")
+		return 0
+	summary = summarise(records)
+	if fmt == "json":
+		print(json.dumps(summary, indent=2, sort_keys=True))
+	elif fmt == "md":
+		print(render_markdown(summary), end="")
+	else:
+		print(render_text(summary), end="")
+	return 0

--- a/gameplan/tests/mutation/report.py
+++ b/gameplan/tests/mutation/report.py
@@ -9,19 +9,35 @@ has no score at all (``None`` -> rendered "n/a"), never a fabricated 0%. Every m
 without a verdict is excluded from both sides of the ratio and surfaced as an explicit
 count, so a run degraded by infrastructure problems reads as degraded rather than as a
 flattering low-denominator score.
+
+THE SECOND RULE: CURRENCY IS DATA, NEVER POSITION
+-------------------------------------------------
+"This module has no current score" is a claim about NOW, and it is reported if and only if
+the module's own latest module-level record says so - whatever filtering a caller applies
+(``--new-since``, ``--prune-stale``). It is never inferred from where records sit relative
+to each other, because every caller here is free to remove records: a filter that keeps
+skips and drops the measurements that retired them turns a dead skip into a live one, and
+a fixed-key skip that nothing can retire is red for ever, in every pull request, for a
+module nobody touched. :func:`load_results` settles currency once, against the complete
+journal, and everything downstream only reads the answer.
 """
 
 from __future__ import annotations
 
 import json
+import sys
 from collections import Counter, defaultdict
+from collections.abc import Collection, Mapping
 from pathlib import Path
 
 from . import journal as journal_mod
 from .config import (
+	APP_ROOT,
 	JOURNAL_PATH,
 	KILLED_STATUSES,
+	MODULE_STATUSES,
 	NON_SCORING_STATUSES,
+	SKIP_STATUSES,
 	STATUS_BASELINE_SKIP,
 	STATUS_SURVIVED,
 	VERIFY_PATH,
@@ -34,6 +50,25 @@ from .config import (
 EXIT_OK = 0
 EXIT_BELOW_THRESHOLD = 1
 EXIT_NOTHING_MEASURED = 3
+# The result set held no mutant verdict at all - either it was empty, or it contained only
+# module-level statements. Nothing was attempted, so there is nothing to be degraded about.
+# Distinct from 3 because the two license opposite statements: 3 means "we tried to measure
+# and got no verdict" (a degraded signal that must not be reported as a clean bill of
+# health), while 5 means "there was nothing new here", the expected, benign outcome of a
+# pull-request run whose mutants were all already settled by the nightly. A caller that
+# collapses them prints a claim about the code for a run whose measurement broke - or, in
+# the other direction, calls a quiet night a degraded one because one skip record was in
+# scope.
+EXIT_NOTHING_TO_REPORT = 5
+
+
+def _notice(message: str) -> None:
+	"""Progress chatter for a human, on stderr.
+
+	stdout is the report itself and is piped into ``$GITHUB_STEP_SUMMARY`` and into
+	``json.load``, so a stray line there is either noise in the summary or a parse error.
+	"""
+	print(f"[mutation] {message}", file=sys.stderr, flush=True)
 
 
 def verify_path_for(journal_path: Path) -> Path:
@@ -50,13 +85,54 @@ def verify_path_for(journal_path: Path) -> Path:
 	return journal_path.with_name(f"{journal_path.stem}.verify{journal_path.suffix}")
 
 
+def module_of(record: Mapping[str, object]) -> str:
+	"""Which module a record is about. ``file`` is the pre-``module`` spelling."""
+	module = record.get("module") or record.get("file")
+	return module if isinstance(module, str) and module else "?"
+
+
+def _retire_superseded_skips(records: list[dict]) -> list[dict]:
+	"""Drop skips that a later measurement of the same module has already answered.
+
+	This is the compatibility half of the currency rule, for journals written before
+	STATUS_MODULE_CURRENT existed. Those journals contain a skip and then, further down,
+	mutant records for the same module - the measurement that retired it - but nothing
+	under the skip's own key to say so.
+
+	It runs HERE and nowhere else, deliberately. Journal position only means "later" over
+	the COMPLETE journal, and every caller downstream is free to filter that list
+	(``--new-since``, ``--prune-stale``). Deciding currency after a filter is how a dead
+	skip came back from the dead: the filter keeps the skip (skips are never filtered) and
+	removes the mutant records that aged it out, and the module reads as skipped again -
+	permanently, since nothing in a fixed-key skip can ever expire. Settling it once,
+	against the unfiltered set, makes the answer immune to whatever any caller does next.
+	"""
+	last_measured: dict[str, int] = {}
+	skip_positions: dict[int, str] = {}
+	for position, record in enumerate(records):
+		status = record.get("status")
+		if status in SKIP_STATUSES:
+			skip_positions[position] = module_of(record)
+		elif status not in MODULE_STATUSES:
+			last_measured[module_of(record)] = position
+	return [
+		record
+		for position, record in enumerate(records)
+		if position not in skip_positions or last_measured.get(skip_positions[position], -1) < position
+	]
+
+
 def load_results(journal_path: Path, verify_path: Path | None = None) -> list[dict]:
 	"""Merge stage-1 results with any stage-2 verdicts, which supersede them.
 
 	The journal is append-only and legitimately contains re-runs of the same mutant, so
-	the last record for a key wins. The returned list is ordered by the position of each
-	winning record, which is what lets :func:`summarise` tell "this module was skipped,
-	then later measured" apart from "this module was measured, then later skipped".
+	the last record for a key wins. Module-level records share one fixed key per module, so
+	that same rule is what makes "this module has a current score" retire an earlier skip:
+	they are two records under one key, and only the later one survives here.
+
+	Stage 2 is merged after currency is settled, on purpose: ``verify`` re-runs old
+	survivors against the full suite and says nothing about whether this module is
+	measurable today, so it must not be able to retire a skip.
 	"""
 	merged: dict[str, dict] = {}
 	for record in journal_mod.read_records(journal_path):
@@ -66,6 +142,8 @@ def load_results(journal_path: Path, verify_path: Path | None = None) -> list[di
 			# first occurrence's position and lose the ordering this function promises.
 			merged.pop(key, None)
 			merged[key] = record
+
+	merged = {record["key"]: record for record in _retire_superseded_skips(list(merged.values()))}
 
 	if verify_path and verify_path.exists():
 		for key, record in journal_mod.latest_by_key(verify_path).items():
@@ -78,33 +156,174 @@ def load_results(journal_path: Path, verify_path: Path | None = None) -> list[di
 	return list(merged.values())
 
 
-def summarise(records: list[dict]) -> dict:
+def only_new_since(records: list[dict], baseline_path: Path | None) -> list[dict]:
+	"""Keep the mutants this run actually decided: new keys, and CHANGED verdicts.
+
+	This is how a pull-request job reports on *its own* diff. It runs against a journal
+	restored from the nightly, so the resume logic spends its small budget only on mutants
+	whose keys are new - and mutant keys are content-derived, so a key that survived from
+	the nightly describes code this pull request did not touch. Filtering the report by the
+	same set means the summary shows exactly what this run added, not the whole corpus.
+
+	A key whose verdict CHANGED is kept even though the key is not new. That is the whole
+	point of the nightly: a mutant that was killed last night and survives tonight is the
+	regression the job exists to catch, and it is invisible in a cumulative report of 500+
+	survivors. Filtering purely on key would drop it - and now that a test edit invalidates
+	and re-measures settled verdicts, dropping it is the common case, not a corner.
+
+	A missing baseline (the first ever run, an evicted cache) filters nothing, so the
+	report degrades to "everything measured" rather than to silence.
+
+	Module-skip records are never filtered. Their key is a fixed string per module, not a
+	content hash, so the argument above does not apply to them: if the nightly already
+	journalled the same skip, subtracting it would delete the only evidence that one of
+	the files this pull request changed was never measured, and the summary would show a
+	clean score for the other file with no mention of it.
+
+	Keeping them is only safe because :func:`load_results` has already settled which skips
+	are current, over the unfiltered journal. Never re-decide that here: this function
+	cannot see the records that retire a skip, so anything it concludes about currency is a
+	guess made with the evidence removed.
+	"""
+	if baseline_path is None or not baseline_path.exists():
+		return records
+	settled = {key: record.get("status") for key, record in journal_mod.latest_by_key(baseline_path).items()}
+	return [
+		record
+		for record in records
+		if record.get("key") not in settled
+		or settled[record.get("key")] != record.get("status")
+		or record.get("status") in SKIP_STATUSES
+	]
+
+
+def drop_stale_sites(
+	records: list[dict], app_root: Path, unreadable_files: Collection[str] = ()
+) -> tuple[list[dict], int]:
+	"""Drop verdicts about mutation sites that no longer exist in the source.
+
+	The journal is cumulative and mutant keys are content-derived, so refactoring a target
+	does not delete its old records - it just re-keys the sites and adds new ones. The old
+	verdicts stay in both the numerator and the denominator for ever, and their survivor
+	entries keep printing line numbers into code that has since moved. One edit to a large
+	function re-keys every mutant in that scope, so this is not a slow drift: a single
+	refactor can orphan dozens of records at once, and the headline percentage stops being
+	a fact about the repository.
+
+	A file that cannot be read or parsed keeps all of its records: "I could not check"
+	must never be resolved into "these results are stale". Module-level records are keyed
+	per module rather than per site and are always kept - including the record that says a
+	module's score is current, which no filter may separate from the skip it retires.
+
+	``unreadable_files`` names repo-relative files whose contents cannot be trusted to
+	answer the question - in practice, a file a crashed run left mutated. Their records are
+	kept whatever the source says: one applied mutant re-keys every site in its scope, so
+	pruning against a mutated tree deletes dozens of perfectly good verdicts and reports
+	them as "sites that no longer exist".
+
+	Returns the surviving records and how many were dropped.
+	"""
+	# Imported here, not at module level: rendering a report must not depend on the AST
+	# layer, so a broken mutator can never stop a human reading yesterday's numbers.
+	from . import mutators
+
+	live: dict[str, set[str] | None] = {}
+	kept: list[dict] = []
+	for record in records:
+		rel = record.get("file") or record.get("module")
+		if not isinstance(rel, str) or not rel or record.get("status") in MODULE_STATUSES:
+			kept.append(record)
+			continue
+		if rel in unreadable_files:
+			kept.append(record)
+			continue
+		if rel not in live:
+			try:
+				source = (app_root / rel).read_text(encoding="utf-8")
+				# mutate_strings=True so a campaign run with it is not read as stale.
+				live[rel] = {s.key for s in mutators.collect_sites(source, rel, mutate_strings=True)}
+			except (OSError, SyntaxError, ValueError):
+				live[rel] = None
+		known = live[rel]
+		if known is None or record.get("key") in known:
+			kept.append(record)
+	return kept, len(records) - len(kept)
+
+
+def current_fingerprints() -> dict[str, str]:
+	"""What each target's tests hash to right now, or ``{}`` if that cannot be answered.
+
+	Best effort on purpose: this only adds a marker to a report, so a tree the fingerprint
+	cannot be computed against must degrade to "no marker", never to a failed report.
+	"""
+	try:
+		from . import scope
+		from .config import target_map
+
+		return {rel: scope.test_fingerprint(tests, APP_ROOT) for rel, tests in target_map("all").items()}
+	except Exception:  # noqa: BLE001 - a report must never fail because of this
+		return {}
+
+
+def _provenance(shas: set[str | None], current: str) -> str:
+	"""Whether a module's verdicts were produced by the tests as they are now.
+
+	``stale`` is not ``wrong``: the verdicts were true of the suite that produced them. But
+	the resume logic has already flagged them for re-measurement, and a big module can take
+	several budgeted nights to work through, so for those nights the published number is a
+	fact about a suite that no longer exists. Saying so is the difference between a report
+	that is out of date and a report that is quietly misleading.
+	"""
+	if shas == {current}:
+		return "current"
+	if None in shas:
+		# Written before verdicts carried their provenance: we cannot show what produced it.
+		return "unknown"
+	return "stale"
+
+
+def summarise(records: list[dict], fingerprints: Mapping[str, str] | None = None) -> dict:
 	by_module: dict[str, Counter] = defaultdict(Counter)
 	survivors: dict[str, dict[str, list[dict]]] = defaultdict(lambda: defaultdict(list))
-	# A red baseline is journalled under the fixed key "baseline:<path>", and a later
-	# GREEN baseline writes nothing to clear it, so the skip record is immortal. Track
-	# where each skip and each mutant verdict sits in journal order: a skip only still
-	# describes the module if nothing was measured for that module afterwards.
-	skip_reason: dict[str, str] = {}
-	last_skip_at: dict[str, int] = {}
-	last_mutant_at: dict[str, int] = {}
+	# The module-level record for each module, i.e. its own statement about whether it has
+	# a current score. There is one per module by construction (a fixed key per module, and
+	# load_results keeps only the last record for a key), so this reads a FACT. It used to
+	# be inferred from where the records sat relative to each other, which silently became
+	# a lie as soon as a caller filtered the list - see _retire_superseded_skips.
+	module_state: dict[str, dict] = {}
+	# Which test files each module's verdicts claim to have been produced by.
+	module_shas: dict[str, set[str | None]] = defaultdict(set)
 
-	for position, record in enumerate(records):
-		module = record.get("module") or record.get("file") or "?"
+	for record in records:
+		module = module_of(record)
 		status = record.get("status", "?")
-		if status == STATUS_BASELINE_SKIP:
-			skip_reason[module] = record.get("reason", "")
-			last_skip_at[module] = position
+		if status in MODULE_STATUSES:
+			module_state[module] = record
 			continue
-		last_mutant_at[module] = position
+		module_shas[module].add(record.get("tests_sha"))
 		by_module[module][status] += 1
 		if status == STATUS_SURVIVED:
 			survivors[record.get("file", module)][record.get("function") or "<module>"].append(record)
 
 	skipped = {
-		module: reason
-		for module, reason in skip_reason.items()
-		if last_skip_at[module] > last_mutant_at.get(module, -1)
+		module: record.get("reason", "")
+		for module, record in module_state.items()
+		if record.get("status") in SKIP_STATUSES
+	}
+	# Every module-level skip, whatever dropped it: a red baseline, a source file that no
+	# longer exists, a backup that could not be taken. All three mean the same thing to a
+	# reader - this module has no current score - and a gate that only sees one of them
+	# lets the other two go green having measured nothing.
+	skipped_modules = {
+		module: {
+			"reason": reason,
+			"kind": (
+				"red baseline"
+				if module_state[module].get("status") == STATUS_BASELINE_SKIP
+				else "not measurable"
+			),
+		}
+		for module, reason in skipped.items()
 	}
 
 	scores = {}
@@ -129,17 +348,41 @@ def summarise(records: list[dict]) -> dict:
 			# Set when the module's most recent journal entry is a red-baseline skip:
 			# the counts above are then leftovers from an earlier, greener run.
 			"baseline_skip": skipped.get(module),
+			# "current" / "stale" / "unknown", or absent when nothing was passed to compare
+			# against. The score above is only a fact about the suite as it is now when
+			# this says "current".
+			**(
+				{"provenance": _provenance(module_shas[module], fingerprints[module])}
+				if fingerprints is not None and module in fingerprints
+				else {}
+			),
 		}
 
 	overall_scored = sum(s["scored"] for s in scores.values())
 	overall_unscored = sum(s["unscored"] for s in scores.values())
 	overall_killed = sum(s["killed"] for s in scores.values())
 
+	# A skip deliberately creates no entry in ``modules``: it is not a mutant and must
+	# never look like one with a score of n/a. ``skipped_modules`` below is where a module
+	# that measured nothing is visible, and it is what both CI gates read.
 	return {
 		"modules": scores,
 		"survivors": {f: {fn: rs for fn, rs in fns.items()} for f, fns in survivors.items()},
-		"baseline_skipped": skipped,
+		# Red baselines only, kept as its own key because it is the one skip whose counts
+		# above are a stale score rather than an absent one.
+		"baseline_skipped": {
+			module: info["reason"]
+			for module, info in skipped_modules.items()
+			if info["kind"] == "red baseline"
+		},
+		"skipped_modules": skipped_modules,
 		"unmeasured_modules": sorted(m for m, s in scores.items() if s["score"] is None),
+		# Modules whose verdicts were produced by a suite that has since changed. They are
+		# already queued for re-measurement, but a big module takes several budgeted nights
+		# to work through and the headline is computed from them meanwhile.
+		"stale_test_modules": sorted(
+			m for m, s in scores.items() if s.get("provenance", "current") != "current"
+		),
 		"overall": {
 			"total": sum(s["total"] for s in scores.values()),
 			"scored": overall_scored,
@@ -150,13 +393,34 @@ def summarise(records: list[dict]) -> dict:
 	}
 
 
+def provenance_note(provenance: str) -> str:
+	"""Say which of the two ways a module's verdicts fail to describe its current tests.
+
+	They are different facts and must not share a sentence: "the tests were edited and this
+	number predates the edit" is a dated measurement, while "nothing records what produced
+	this number" is a measurement with no provenance at all.
+	"""
+	if provenance == "stale":
+		return "tests changed since these verdicts were measured"
+	return "no record of which tests produced these verdicts"
+
+
 def format_score(score: float | None) -> str:
 	"""Render a score, or "n/a" when there was nothing to measure."""
 	return "n/a" if score is None else f"{score:.0%}"
 
 
+def is_empty(summary: dict) -> bool:
+	"""True when there is genuinely nothing to say: no mutant, no module statement."""
+	return not summary["modules"] and not summary["skipped_modules"]
+
+
 def render_text(summary: dict) -> str:
 	lines: list[str] = ["Mutation report", "=" * 60, ""]
+	if is_empty(summary):
+		# Not a table of zeros: an all-zero table with "OVERALL: n/a - NOTHING MEASURED"
+		# reads as a broken run, and this is the benign case where nothing was due.
+		return "\n".join(lines + ["Nothing to report: no mutant was measured in this view.", ""])
 
 	lines.append("Scores")
 	lines.append("-" * 60)
@@ -173,6 +437,11 @@ def render_text(summary: dict) -> str:
 			lines.append(
 				f"  STALE: the latest run skipped this module (red baseline: "
 				f"{info['baseline_skip']}); the counts above predate that run"
+			)
+		if info.get("provenance", "current") != "current":
+			lines.append(
+				f"  STALE: {provenance_note(info['provenance'])}; "
+				f"this module is queued for re-measurement"
 			)
 		for status in sorted(info["counts"]):
 			lines.append(f"    {status}: {info['counts'][status]}")
@@ -192,13 +461,19 @@ def render_text(summary: dict) -> str:
 			f"WARNING: {len(summary['unmeasured_modules'])} module(s) have no score at all: "
 			f"{', '.join(summary['unmeasured_modules'])}"
 		)
+	if summary.get("stale_test_modules"):
+		lines.append(
+			f"WARNING: {len(summary['stale_test_modules'])} module(s) are scored from verdicts "
+			f"that cannot be shown to come from their current tests: "
+			f"{', '.join(summary['stale_test_modules'])}"
+		)
 
-	if summary["baseline_skipped"]:
-		lines += ["", "Skipped (red baseline)", "-" * 60]
-		for module, reason in sorted(summary["baseline_skipped"].items()):
-			lines.append(f"{module}: {reason}")
+	if summary["skipped_modules"]:
+		lines += ["", "Skipped - measured nothing this run", "-" * 60]
+		for module, info in sorted(summary["skipped_modules"].items()):
+			lines.append(f"{module} [{info['kind']}]: {info['reason']}")
 
-	lines += ["", "Survivors", "-" * 60]
+	lines += ["", "Survivors (stage 1: only each module's own mapped tests were run)", "-" * 60]
 	if not summary["survivors"]:
 		lines.append("none")
 	for path in sorted(summary["survivors"]):
@@ -215,6 +490,8 @@ def render_text(summary: dict) -> str:
 
 
 def render_markdown(summary: dict) -> str:
+	if is_empty(summary):
+		return "Nothing to report: no mutant was measured in this view.\n"
 	lines = ["# Mutation report", "", "## Scores", ""]
 	lines += ["| Module | Score | Killed | Scored | No verdict |", "| --- | --- | --- | --- | --- |"]
 	for module in sorted(summary["modules"]):
@@ -222,6 +499,8 @@ def render_markdown(summary: dict) -> str:
 		label = f"`{module}`"
 		if info["baseline_skip"]:
 			label += " (stale: skipped, red baseline)"
+		if info.get("provenance", "current") != "current":
+			label += f" (stale: {provenance_note(info['provenance'])})"
 		score = "**n/a** (not measured)" if info["score"] is None else f"{info['score']:.0%}"
 		lines.append(f"| {label} | {score} | {info['killed']} | {info['scored']} | {info['unscored']} |")
 	overall = summary["overall"]
@@ -244,13 +523,26 @@ def render_markdown(summary: dict) -> str:
 			f"> {len(summary['unmeasured_modules'])} module(s) have no score at all: "
 			+ ", ".join(f"`{m}`" for m in summary["unmeasured_modules"]),
 		]
+	if summary.get("stale_test_modules"):
+		lines += [
+			"",
+			f"> {len(summary['stale_test_modules'])} module(s) are scored from verdicts that "
+			f"cannot be shown to come from their current tests, and are queued for "
+			f"re-measurement: " + ", ".join(f"`{m}`" for m in summary["stale_test_modules"]),
+		]
 
-	if summary["baseline_skipped"]:
-		lines += ["", "## Skipped (red baseline)", ""]
-		for module, reason in sorted(summary["baseline_skipped"].items()):
-			lines.append(f"- `{module}` - {reason}")
+	if summary["skipped_modules"]:
+		lines += ["", "## Skipped - measured nothing this run", ""]
+		for module, info in sorted(summary["skipped_modules"].items()):
+			lines.append(f"- `{module}` ({info['kind']}) - {info['reason']}")
 
 	lines += ["", "## Survivors", ""]
+	lines += [
+		"Stage 1 only: each mutant was run against its module's own mapped tests, so a"
+		" survivor here may still be caught by another module's suite. `verify` is what"
+		" separates the two.",
+		"",
+	]
 	if not summary["survivors"]:
 		lines.append("None.")
 	for path in sorted(summary["survivors"]):
@@ -273,21 +565,41 @@ def report(
 	fmt: str = "text",
 	verify_path: Path | None = None,
 	fail_under: float | None = None,
+	new_since: Path | None = None,
+	prune_stale: bool = False,
 ) -> int:
 	"""Render the report and return the gate verdict.
 
-	The three outcomes are kept distinct on purpose - see the exit code constants above.
+	The outcomes are kept distinct on purpose - see the exit code constants above.
 	Rendering always happens first: the numbers are the point, the exit code only decides
 	whether a machine should act on them.
 	"""
 	journal_path = journal_path or JOURNAL_PATH
 	records = load_results(journal_path, verify_path or verify_path_for(journal_path))
+	if prune_stale:
+		mutated = mutated_files(APP_ROOT)
+		if mutated:
+			_notice(
+				f"not pruning {', '.join(sorted(mutated))}: a crashed run left a mutant applied, "
+				f"and mutated source re-keys every site in its scope"
+			)
+		records, dropped = drop_stale_sites(records, APP_ROOT, unreadable_files=mutated)
+		if dropped:
+			_notice(f"dropped {dropped} verdict(s) about mutation sites that no longer exist")
+	if new_since is not None:
+		before = len(records)
+		records = only_new_since(records, new_since)
+		_notice(f"{len(records)} of {before} record(s) are new since {new_since}")
 	if not records:
-		print(f"[mutation] no results in {journal_path}")
-		# An empty journal is the purest form of "nothing measured": exiting 0 here would
-		# let a nightly whose campaign never started report a passing mutation score.
-		return EXIT_NOTHING_MEASURED
-	summary = summarise(records)
+		_notice(f"no results in {journal_path}")
+	# Marked, not silently published: between a test edit and the re-measurement it
+	# triggers - up to several budgeted nights for a big module - the score is computed
+	# from verdicts the harness has itself already flagged as describing a suite that no
+	# longer exists.
+	summary = summarise(records, fingerprints=current_fingerprints())
+	# Rendered even when the result set is empty: the summary is what the CI gates parse,
+	# and a step that emits nothing forces its caller to guess whether the report was empty
+	# or crashed. render_* prints one honest line for the empty case.
 	if fmt == "json":
 		print(json.dumps(summary, indent=2, sort_keys=True))
 	elif fmt == "md":
@@ -297,12 +609,43 @@ def report(
 	return gate(summary, fail_under)
 
 
+def mutated_files(app_root: Path) -> set[str]:
+	"""Repo-relative paths a crashed run left mutated, as far as the backup dir knows.
+
+	Best effort by design: this only guards a report from pruning against source it cannot
+	trust, so a safety layer that cannot be read must not stop the report rendering.
+	"""
+	try:
+		from . import safety
+
+		orphans = safety.find_orphaned_backups()
+	except Exception:  # noqa: BLE001 - a report must never fail because of the safety layer
+		return set()
+	mutated: set[str] = set()
+	for manifest in orphans:
+		if safety.orphan_state(manifest) == "clean":
+			continue
+		try:
+			mutated.add(Path(manifest["path"]).resolve().relative_to(app_root.resolve()).as_posix())
+		except (KeyError, ValueError):
+			continue
+	return mutated
+
+
 def gate(summary: dict, fail_under: float | None = None) -> int:
 	"""Turn a summary into an exit code, explaining any non-zero one on stdout."""
+	if summary["overall"]["total"] == 0:
+		# No mutant record at all in this view - nothing was even attempted, so there is
+		# nothing to be degraded about. Deliberately NOT the same code as "we ran mutants
+		# and none of them produced a verdict": see EXIT_NOTHING_TO_REPORT. A skip record
+		# lands here too, and is surfaced through ``skipped_modules`` rather than through
+		# an exit code that would claim the measurement broke.
+		_notice("nothing to report: this view contains no mutant verdicts")
+		return EXIT_NOTHING_TO_REPORT
 	score = summary["overall"]["score"]
 	if score is None:
-		print(
-			"[mutation] FAIL: nothing was measured - every mutant produced a non-verdict "
+		_notice(
+			"FAIL: nothing was measured - every mutant produced a non-verdict "
 			"(broken site, timeouts, or a campaign that never ran). This is not a score of 0%."
 		)
 		return EXIT_NOTHING_MEASURED
@@ -311,6 +654,52 @@ def gate(summary: dict, fail_under: float | None = None) -> int:
 		# The score is rounded to 4 decimal places, so compare with a tolerance rather
 		# than failing a run that is exactly on the threshold.
 		if percent + 1e-9 < fail_under:
-			print(f"[mutation] FAIL: overall score {percent:.1f}% is below --fail-under {fail_under:g}%")
+			_notice(f"FAIL: overall score {percent:.1f}% is below --fail-under {fail_under:g}%")
 			return EXIT_BELOW_THRESHOLD
 	return EXIT_OK
+
+
+def work_done(journal_path: Path, since_path: Path | None = None) -> dict:
+	"""What a run DID, as opposed to what it decided.
+
+	The two are not the same and a summary that only reports the second is unreadable. A
+	night that re-measures 400 mutants because a test file was touched, and confirms every
+	single verdict, has decided nothing: ``--new-since`` correctly filters all of it away
+	and the summary says "nothing new". So does a night whose campaign never started. A
+	reader cannot tell "nothing changed" from "nothing ran" without this, which is exactly
+	the state a broken nightly hides in.
+
+	The journal is append-only, so the run's own work is whatever sits past the snapshot
+	taken before it started. If the journal is SHORTER than the snapshot it was not
+	appended to but replaced, and the honest answer is then "unknown" rather than a
+	subtraction that would invent a number.
+	"""
+	journal_records = journal_mod.read_records(journal_path)
+	before = len(journal_mod.read_records(since_path)) if since_path and since_path.exists() else 0
+	if len(journal_records) < before:
+		return {"unknown": True, "evaluated": 0, "modules": [], "skipped": []}
+	added = journal_records[before:]
+	modules = {module_of(r) for r in added if r.get("status") not in MODULE_STATUSES}
+	skipped = {module_of(r) for r in added if r.get("status") in SKIP_STATUSES}
+	return {
+		"unknown": False,
+		"evaluated": sum(1 for r in added if r.get("status") not in MODULE_STATUSES),
+		"modules": sorted(modules),
+		"skipped": sorted(skipped),
+	}
+
+
+def render_work(work: dict) -> str:
+	"""One line naming the work a run did, for a job summary."""
+	if work["unknown"]:
+		return "Work this run: unknown - the journal was replaced rather than appended to."
+	if not work["evaluated"]:
+		line = "Work this run: no mutant was evaluated."
+	else:
+		line = (
+			f"Work this run: {work['evaluated']} mutant(s) evaluated across "
+			f"{len(work['modules'])} module(s) ({', '.join(work['modules'])})."
+		)
+	if work["skipped"]:
+		line += f" {len(work['skipped'])} module(s) measured nothing: {', '.join(work['skipped'])}."
+	return line

--- a/gameplan/tests/mutation/runner.py
+++ b/gameplan/tests/mutation/runner.py
@@ -7,6 +7,10 @@ Two things here are load-bearing:
 * Timeouts kill the whole process group. ``bench`` spawns python children; killing
   only the parent leaves them holding the test site's lock, which then breaks every
   subsequent mutant run and silently invalidates the campaign.
+
+``RunResult`` deliberately exposes *facts about the output* rather than a verdict.
+Deciding what an outcome means about a mutant is ``campaign.classify``'s job, and
+keeping the two apart is what makes the classification unit-testable without a site.
 """
 
 from __future__ import annotations
@@ -21,15 +25,26 @@ from .config import BENCH_ROOT
 
 RAN_TESTS_RE = re.compile(r"^Ran (\d+) tests?", re.MULTILINE)
 
-# Markers that mean the module never got as far as executing tests. These make a
-# non-zero exit a much weaker signal than a genuine assertion failure.
+# ``unittest.TextTestRunner`` closes every suite it finishes with exactly one of these
+# at the start of a line, after the "Ran N tests" line. Their presence is the only
+# positive proof that the runner reached the end of a suite and announced a result,
+# rather than being killed somewhere in the middle. Frappe subclasses TextTestRunner
+# and does not override that tail, and it runs one suite per app+category, so a healthy
+# invocation can print several of these.
+VERDICT_RE = re.compile(r"^(?:OK|FAILED|NO TESTS RAN)\b", re.MULTILINE)
+# The only line that means "the test suite judged something to have failed". A non-zero
+# exit code on its own does not: bench, the site loader and the process supervisor can
+# all produce one without a single assertion having been evaluated.
+FAILURE_VERDICT_RE = re.compile(r"^FAILED\b", re.MULTILINE)
+
+# Markers that mean a module never got as far as executing tests. On their own they are
+# far too weak to score anything - see ``RunResult.mutant_broke_import``.
 IMPORT_ERROR_MARKERS = (
 	"ImportError",
 	"ModuleNotFoundError",
 	"SyntaxError",
 	"IndentationError",
 	"Failed to import test module",
-	"ImportError: Failed to import",
 )
 
 
@@ -42,34 +57,63 @@ class RunResult:
 
 	@property
 	def tests_ran(self) -> int | None:
-		"""Number of tests unittest reported running, or None if it never said."""
+		"""Total tests unittest reported running, or None if it never said.
+
+		Summed across suites because bench prints one "Ran N tests" block per
+		app+category. This answers "did anything execute at all", NOT "did the run
+		finish" - use ``reached_verdict`` for that.
+		"""
 		matches = RAN_TESTS_RE.findall(self.output)
 		if not matches:
 			return None
 		return sum(int(m) for m in matches)
 
 	@property
-	def looks_like_import_error(self) -> bool:
-		"""The mutant broke the module before any test could run.
+	def reached_verdict(self) -> bool:
+		"""The test runner itself announced a result (OK / FAILED / NO TESTS RAN)."""
+		return bool(VERDICT_RE.search(self.output))
 
-		Requires an actual import/syntax marker in the output. Treating "no ``Ran N
-		tests`` line" as sufficient made every bench or site failure look like a mutant
-		kill, which inflates the score to 100% while nothing is being tested at all.
+	@property
+	def suite_reported_failure(self) -> bool:
+		"""The test suite declared a failure, as opposed to the process merely dying."""
+		return bool(FAILURE_VERDICT_RE.search(self.output))
+
+	@property
+	def has_import_error_marker(self) -> bool:
+		return any(marker in self.output for marker in IMPORT_ERROR_MARKERS)
+
+	def blames_file(self, rel_path: str | None) -> bool:
+		"""The output contains a traceback frame in ``rel_path``.
+
+		Matched on the path form only. Any Python traceback through that file prints
+		``File "<abs path>"``, and the absolute path ends with the repo-relative one,
+		so this is both reliable and much harder to trip accidentally than the dotted
+		module name (which shows up in ordinary log lines and error messages).
+		"""
+		if not rel_path:
+			return False
+		return rel_path in self.output
+
+	def mutant_broke_import(self, rel_path: str | None) -> bool:
+		"""The mutant made its own module unimportable - a genuine detection.
+
+		All three conditions are required, because each one alone is a known way to
+		score an infrastructure failure as a kill:
+
+		* non-zero exit, not a timeout;
+		* zero tests executed - if tests ran, the module imported fine and any import
+		marker in the output belongs to something else;
+		* the traceback actually names the file we mutated - a broken venv, a missing
+		app or a bench wrapper traceback all emit "ImportError" while saying nothing
+		whatsoever about the mutant.
 		"""
 		if self.timed_out or self.passed:
 			return False
-		return any(marker in self.output for marker in IMPORT_ERROR_MARKERS)
-
-	@property
-	def looks_like_infra_error(self) -> bool:
-		"""Non-zero exit, no tests ran, and no sign the mutant caused it.
-
-		A locked site, a bench that failed to start, a missing site, a full disk. Says
-		nothing about the mutant, so it must be reported rather than scored.
-		"""
-		if self.timed_out or self.passed or self.looks_like_import_error:
+		if self.tests_ran not in (0, None):
 			return False
-		return self.tests_ran in (0, None)
+		if not self.has_import_error_marker:
+			return False
+		return self.blames_file(rel_path)
 
 	@property
 	def passed(self) -> bool:

--- a/gameplan/tests/mutation/runner.py
+++ b/gameplan/tests/mutation/runner.py
@@ -1,0 +1,127 @@
+"""Subprocess wrapper around ``bench run-tests``.
+
+Two things here are load-bearing:
+
+* ``cwd`` is the bench root. ``bench`` resolves the sites directory relative to the
+  working directory, so invoking it from the app directory simply fails.
+* Timeouts kill the whole process group. ``bench`` spawns python children; killing
+  only the parent leaves them holding the test site's lock, which then breaks every
+  subsequent mutant run and silently invalidates the campaign.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import time
+from dataclasses import dataclass
+
+from . import safety
+from .config import BENCH_ROOT
+
+RAN_TESTS_RE = re.compile(r"^Ran (\d+) tests?", re.MULTILINE)
+
+# Markers that mean the module never got as far as executing tests. These make a
+# non-zero exit a much weaker signal than a genuine assertion failure.
+IMPORT_ERROR_MARKERS = (
+	"ImportError",
+	"ModuleNotFoundError",
+	"SyntaxError",
+	"IndentationError",
+	"Failed to import test module",
+	"ImportError: Failed to import",
+)
+
+
+@dataclass
+class RunResult:
+	returncode: int | None
+	output: str
+	duration_s: float
+	timed_out: bool
+
+	@property
+	def tests_ran(self) -> int | None:
+		"""Number of tests unittest reported running, or None if it never said."""
+		matches = RAN_TESTS_RE.findall(self.output)
+		if not matches:
+			return None
+		return sum(int(m) for m in matches)
+
+	@property
+	def looks_like_import_error(self) -> bool:
+		"""The mutant broke the module before any test could run.
+
+		Requires an actual import/syntax marker in the output. Treating "no ``Ran N
+		tests`` line" as sufficient made every bench or site failure look like a mutant
+		kill, which inflates the score to 100% while nothing is being tested at all.
+		"""
+		if self.timed_out or self.passed:
+			return False
+		return any(marker in self.output for marker in IMPORT_ERROR_MARKERS)
+
+	@property
+	def looks_like_infra_error(self) -> bool:
+		"""Non-zero exit, no tests ran, and no sign the mutant caused it.
+
+		A locked site, a bench that failed to start, a missing site, a full disk. Says
+		nothing about the mutant, so it must be reported rather than scored.
+		"""
+		if self.timed_out or self.passed or self.looks_like_import_error:
+			return False
+		return self.tests_ran in (0, None)
+
+	@property
+	def passed(self) -> bool:
+		return self.returncode == 0
+
+
+def build_command(site: str, test_module: str | None) -> list[str]:
+	cmd = ["bench", "--site", site, "run-tests", "--app", "gameplan"]
+	if test_module:
+		cmd += ["--module", test_module]
+	cmd.append("--failfast")
+	return cmd
+
+
+def run_tests(site: str, test_module: str | None, timeout: int) -> RunResult:
+	"""Run one bench test invocation, hard-killing the process group on timeout."""
+	cmd = build_command(site, test_module)
+	started = time.monotonic()
+	proc = subprocess.Popen(
+		cmd,
+		cwd=str(BENCH_ROOT),
+		stdout=subprocess.PIPE,
+		stderr=subprocess.STDOUT,
+		text=True,
+		errors="replace",
+		# Its own session/process group so os.killpg can reap bench AND its children.
+		start_new_session=True,
+	)
+	# start_new_session makes the child a session/group leader, so its pgid is its pid.
+	# Capture it now: by the time a timeout fires the `bench` wrapper has usually exited
+	# and os.getpgid(proc.pid) would raise, leaving its children unkillable.
+	pgid = proc.pid
+	safety.set_active_child(proc, pgid)
+	timed_out = False
+	try:
+		try:
+			output, _ = proc.communicate(timeout=timeout)
+		except subprocess.TimeoutExpired:
+			timed_out = True
+			safety.kill_process_group(proc, pgid)
+			try:
+				output, _ = proc.communicate(timeout=30)
+			except subprocess.TimeoutExpired:
+				# The group refused to die; surface it rather than pretend it is gone.
+				safety.kill_process_group(proc, pgid)
+				output = ""
+	finally:
+		safety.set_active_child(None)
+
+	return RunResult(
+		returncode=proc.returncode,
+		output=output or "",
+		duration_s=round(time.monotonic() - started, 2),
+		timed_out=timed_out,
+	)

--- a/gameplan/tests/mutation/safety.py
+++ b/gameplan/tests/mutation/safety.py
@@ -405,10 +405,23 @@ def unregister(guard: FileGuard) -> None:
 
 
 def restore_all() -> None:
-	"""Best-effort restore of every registered guard. Never raises."""
+	"""Best-effort restore-and-release of every registered guard. Never raises.
+
+	``release`` rather than ``restore``: it restores first and only then drops the sidecar,
+	so the backup is deleted exactly when it has provably done its job. Leaving the sidecar
+	behind used to look like the safer choice, but the file is already back - what remains
+	is a manifest describing a crash that has been fully undone, and the next run has no
+	way to tell it from a real one. It classifies the target as an orphan, and if the file
+	has changed since (a new commit, a fresh clone at another revision) it classifies it
+	"unknown" and REFUSES TO START, which ``--yes`` cannot override. That is a permanently
+	wedged campaign as the price of a backup nobody needs.
+
+	If the restore fails, ``release`` raises before unlinking anything, so the one case
+	where the sidecar is still the only copy of the original keeps it.
+	"""
 	for guard in list(_ACTIVE_GUARDS):
 		try:
-			guard.restore()
+			guard.release()
 		except Exception as exc:  # noqa: BLE001 - last-ditch handler, must not raise
 			print(f"[mutation] CRITICAL: could not restore {guard.path}: {exc}", file=sys.stderr)
 		else:

--- a/gameplan/tests/mutation/safety.py
+++ b/gameplan/tests/mutation/safety.py
@@ -1,0 +1,502 @@
+"""Crash-safe in-place source file mutation.
+
+The harness edits files in the developer's real working tree, so every layer here
+exists to make an interrupted run recoverable:
+
+1. ``try/finally`` restores after each mutant.
+2. ``atexit`` restores if an exception unwinds past the finally.
+3. SIGINT/SIGTERM/SIGHUP/SIGQUIT handlers restore before the process dies. SIGHUP in
+   particular matters: an hours-long campaign outlives many terminals and SSH sessions,
+   and a default-disposition signal does not run ``atexit``.
+4. A sidecar ``.orig`` backup on disk survives SIGKILL and power loss, which none of
+   the in-process mechanisms can.
+5. A sha256 comparison after every restore proves the bytes actually went back.
+6. An exclusive campaign lock stops a second invocation from restoring (and deleting
+   the backup of) a mutant that another process is still measuring.
+"""
+
+from __future__ import annotations
+
+import atexit
+import difflib
+import hashlib
+import json
+import os
+import signal
+import stat
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+from .config import APP_ROOT, BACKUP_DIR, LOCK_PATH
+
+
+class RestoreError(RuntimeError):
+	"""Raised when a source file could not be put back exactly as it was found."""
+
+
+class LockError(RuntimeError):
+	"""Raised when another live harness process owns the working tree."""
+
+
+def sha256_bytes(data: bytes) -> str:
+	return hashlib.sha256(data).hexdigest()
+
+
+def sha256_text(text: str) -> str:
+	return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _default_file_mode() -> int:
+	umask = os.umask(0)
+	os.umask(umask)
+	return 0o666 & ~umask
+
+
+def write_atomic(path: Path, data: bytes) -> None:
+	"""Replace ``path`` with ``data`` such that a crash can never leave it truncated.
+
+	The temp file must live in the same directory so ``os.replace`` stays an atomic
+	rename on the same filesystem.
+
+	``os.replace`` swaps the whole inode, so the target would otherwise inherit
+	mkstemp's 0600 and the running user's ownership. git tracks only the exec bit, so
+	that change would be invisible in ``git status`` and would survive a "restore".
+	"""
+	directory = path.parent
+	try:
+		st: os.stat_result | None = os.stat(path)
+	except FileNotFoundError:
+		st = None
+	mode = stat.S_IMODE(st.st_mode) if st is not None else _default_file_mode()
+
+	fd, tmp_name = tempfile.mkstemp(dir=directory, prefix=f".{path.name}.", suffix=".tmp")
+	try:
+		with os.fdopen(fd, "wb") as handle:
+			handle.write(data)
+			handle.flush()
+			os.fsync(handle.fileno())
+		os.chmod(tmp_name, mode)
+		if st is not None and (st.st_uid != os.getuid() or st.st_gid != os.getgid()):
+			try:
+				os.chown(tmp_name, st.st_uid, st.st_gid)
+			except OSError:
+				# Not privileged enough to hand the file back to its owner; the mode is
+				# still correct, and refusing to write at all would be worse.
+				pass
+		os.replace(tmp_name, path)
+	except BaseException:
+		# Never leave a stray temp file behind in the user's source tree.
+		if os.path.exists(tmp_name):
+			os.unlink(tmp_name)
+		raise
+
+
+def pid_is_alive(pid: int | None) -> bool:
+	if not pid or pid <= 0:
+		return False
+	try:
+		os.kill(pid, 0)
+	except ProcessLookupError:
+		return False
+	except PermissionError:
+		# Exists, owned by somebody else.
+		return True
+	return True
+
+
+class CampaignLock:
+	"""Exclusive, cross-process claim on the working tree.
+
+	Backup paths are derived from the target path alone, so two harness processes
+	would share them: one would restore (and delete the sidecar of) the other's
+	in-flight mutant, leaving the campaign measuring clean code and, after a later
+	SIGKILL, a mutant on disk with nothing left to detect it.
+	"""
+
+	def __init__(self, path: Path = LOCK_PATH) -> None:
+		self.path = path
+		self._held = False
+
+	def _read_owner(self) -> int | None:
+		try:
+			payload = json.loads(self.path.read_text())
+		except (OSError, ValueError):
+			return None
+		pid = payload.get("pid")
+		return pid if isinstance(pid, int) else None
+
+	def acquire(self) -> None:
+		self.path.parent.mkdir(parents=True, exist_ok=True)
+		for _ in range(2):
+			try:
+				fd = os.open(self.path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+			except FileExistsError:
+				owner = self._read_owner()
+				if pid_is_alive(owner) and owner != os.getpid():
+					raise LockError(
+						f"another mutation run (pid {owner}) is using this working tree. "
+						f"Wait for it, or remove {self.path} if you are sure it is dead."
+					) from None
+				# Stale lock from a crashed run: its pid is gone, so reclaim it.
+				try:
+					self.path.unlink()
+				except FileNotFoundError:
+					pass
+				continue
+			with os.fdopen(fd, "w") as handle:
+				json.dump({"pid": os.getpid(), "started": time.time()}, handle)
+			self._held = True
+			return
+		raise LockError(f"could not acquire {self.path}")
+
+	def release(self) -> None:
+		if not self._held:
+			return
+		# Only drop the lock if it is still ours.
+		if self._read_owner() == os.getpid():
+			try:
+				self.path.unlink()
+			except FileNotFoundError:
+				pass
+		self._held = False
+
+	def __enter__(self) -> CampaignLock:
+		self.acquire()
+		return self
+
+	def __exit__(self, *exc: object) -> None:
+		self.release()
+
+
+def lock_owner() -> int | None:
+	"""Pid of a live process currently holding the campaign lock, if any."""
+	owner = CampaignLock()._read_owner()
+	return owner if pid_is_alive(owner) else None
+
+
+def _backup_slug(path: Path) -> str:
+	return sha256_text(str(path.resolve()))
+
+
+class FileGuard:
+	"""Owns the pristine bytes of one source file and can always put them back."""
+
+	def __init__(self, path: Path) -> None:
+		self.path = path.resolve()
+		self.original_bytes = self.path.read_bytes()
+		self.original_sha = sha256_bytes(self.original_bytes)
+		slug = _backup_slug(self.path)
+		self.backup_path = BACKUP_DIR / f"{slug}.orig"
+		self.manifest_path = BACKUP_DIR / f"{slug}.json"
+		self._backed_up = False
+
+	@property
+	def source(self) -> str:
+		return self.original_bytes.decode("utf-8")
+
+	def _write_manifest(self, mutated_sha: str | None) -> None:
+		manifest = {
+			"path": str(self.path),
+			"sha256": self.original_sha,
+			"mutated_sha256": mutated_sha,
+			"pid": os.getpid(),
+		}
+		write_atomic(self.manifest_path, json.dumps(manifest, indent=2).encode("utf-8"))
+
+	def install_backup(self) -> None:
+		"""Persist the pristine copy before the first mutation of this file."""
+		if self._backed_up:
+			return
+		BACKUP_DIR.mkdir(parents=True, exist_ok=True)
+		write_atomic(self.backup_path, self.original_bytes)
+		self._write_manifest(None)
+		self._backed_up = True
+
+	def apply(self, mutated_source: str) -> None:
+		data = mutated_source.encode("utf-8")
+		if self._backed_up:
+			# Record what we are about to put on disk *before* writing it, so a crash
+			# recovery can tell "this file still holds our mutant" (safe to overwrite)
+			# from "somebody has edited this file since" (must not be overwritten).
+			self._write_manifest(sha256_bytes(data))
+		write_atomic(self.path, data)
+
+	def restore(self) -> None:
+		"""Put the original bytes back and prove it worked."""
+		write_atomic(self.path, self.original_bytes)
+		current = sha256_bytes(self.path.read_bytes())
+		if current != self.original_sha:
+			raise RestoreError(
+				f"failed to restore {self.path}: sha256 {current} != expected {self.original_sha}. "
+				f"Pristine copy is at {self.backup_path}"
+			)
+		if self._backed_up:
+			self._write_manifest(None)
+
+	def release(self) -> None:
+		"""Drop the on-disk backup once the file is verified clean again."""
+		self.restore()
+		if self._backed_up and _manifest_owned_by_other_live_process(self.manifest_path):
+			# Somebody else's manifest is sitting at our slug; deleting their backup
+			# would strand their mutant. Leave it and let them clean up.
+			print(
+				f"[mutation] WARNING: not deleting {self.backup_path}; "
+				f"it belongs to another live process.",
+				file=sys.stderr,
+			)
+			self._backed_up = False
+			return
+		for path in (self.backup_path, self.manifest_path):
+			if path.exists():
+				path.unlink()
+		self._backed_up = False
+
+
+def _manifest_owned_by_other_live_process(manifest_path: Path) -> bool:
+	try:
+		manifest = json.loads(manifest_path.read_text())
+	except (OSError, ValueError):
+		return False
+	pid = manifest.get("pid")
+	return pid != os.getpid() and pid_is_alive(pid)
+
+
+# Guards that currently have (or may have) a mutated file on disk. The signal and
+# atexit handlers walk this so no exit path can leave a mutant behind.
+_ACTIVE_GUARDS: list[FileGuard] = []
+_HANDLERS_INSTALLED = False
+_PREVIOUS_HANDLERS: dict[int, object] = {}
+
+
+def register(guard: FileGuard) -> None:
+	if guard not in _ACTIVE_GUARDS:
+		_ACTIVE_GUARDS.append(guard)
+
+
+def unregister(guard: FileGuard) -> None:
+	if guard in _ACTIVE_GUARDS:
+		_ACTIVE_GUARDS.remove(guard)
+
+
+def restore_all() -> None:
+	"""Best-effort restore of every registered guard. Never raises."""
+	for guard in list(_ACTIVE_GUARDS):
+		try:
+			guard.restore()
+		except Exception as exc:  # noqa: BLE001 - last-ditch handler, must not raise
+			print(f"[mutation] CRITICAL: could not restore {guard.path}: {exc}", file=sys.stderr)
+		else:
+			unregister(guard)
+
+
+def _signal_handler(signum: int, frame: object) -> None:
+	print(f"\n[mutation] signal {signum} received - restoring source files...", file=sys.stderr)
+	restore_all()
+	kill_active_child()
+	previous = _PREVIOUS_HANDLERS.get(signum)
+	if callable(previous):
+		previous(signum, frame)
+	# Re-raise with the default disposition so the exit status reflects the signal.
+	signal.signal(signum, signal.SIG_DFL)
+	os.kill(os.getpid(), signum)
+
+
+# SIGHUP (closed terminal, dropped SSH) and SIGQUIT (Ctrl-\) kill the process with
+# their default disposition, which does not run atexit. A campaign is hours long, so
+# both are ordinary events rather than edge cases.
+_RESTORE_SIGNALS = tuple(
+	getattr(signal, name) for name in ("SIGINT", "SIGTERM", "SIGHUP", "SIGQUIT") if hasattr(signal, name)
+)
+
+
+def install_handlers() -> None:
+	"""Wire atexit + the fatal signals to the restore path. Idempotent."""
+	global _HANDLERS_INSTALLED
+	if _HANDLERS_INSTALLED:
+		return
+	atexit.register(restore_all)
+	for signum in _RESTORE_SIGNALS:
+		_PREVIOUS_HANDLERS[signum] = signal.getsignal(signum)
+		signal.signal(signum, _signal_handler)
+	_HANDLERS_INSTALLED = True
+
+
+# The currently running test subprocess and the process group it was spawned into,
+# tracked so a signal can tear down the whole group instead of orphaning bench
+# children that hold the site's file lock.
+_ACTIVE_CHILD: tuple[subprocess.Popen, int | None] | None = None
+
+
+def set_active_child(proc: subprocess.Popen | None, pgid: int | None = None) -> None:
+	global _ACTIVE_CHILD
+	_ACTIVE_CHILD = None if proc is None else (proc, pgid)
+
+
+def kill_process_group(proc: subprocess.Popen, pgid: int | None = None) -> None:
+	"""SIGKILL the subprocess's entire process group.
+
+	``bench`` forks a python child and exits, so by the time a timeout fires the direct
+	child is usually already reaped: ``proc.poll()`` returns an exit status and
+	``os.getpgid(proc.pid)`` raises, while the grandchildren are still alive holding the
+	SQLite site lock and the inherited stdout pipe. The group id is therefore captured at
+	spawn time and killed unconditionally - checking liveness first is exactly what lets
+	the orphans survive.
+	"""
+	if pgid is None:
+		try:
+			pgid = os.getpgid(proc.pid)
+		except (ProcessLookupError, PermissionError):
+			pgid = None
+
+	if pgid is not None:
+		for attempt in range(3):
+			try:
+				os.killpg(pgid, signal.SIGKILL)
+			except ProcessLookupError:
+				break  # the whole group is gone
+			except PermissionError:
+				break
+			if attempt < 2:
+				time.sleep(0.2)
+
+	try:
+		proc.kill()
+	except (ProcessLookupError, OSError):
+		pass
+
+
+def kill_active_child() -> None:
+	if _ACTIVE_CHILD is not None:
+		proc, pgid = _ACTIVE_CHILD
+		kill_process_group(proc, pgid)
+
+
+def find_orphaned_backups() -> list[dict]:
+	"""Return manifests for backups left behind by a hard crash.
+
+	Backups whose owning pid is still alive are *not* orphans: they belong to a
+	campaign that is running right now, and restoring them would both invalidate that
+	mutant's verdict and delete the only copy of the pristine file.
+	"""
+	if not BACKUP_DIR.exists():
+		return []
+	orphans = []
+	for manifest_path in sorted(BACKUP_DIR.glob("*.json")):
+		try:
+			manifest = json.loads(manifest_path.read_text())
+		except (OSError, ValueError):
+			continue
+		orig_path = manifest_path.with_suffix(".orig")
+		if not orig_path.exists():
+			continue
+		if _manifest_owned_by_other_live_process(manifest_path):
+			continue
+		manifest["manifest_path"] = str(manifest_path)
+		manifest["backup_path"] = str(orig_path)
+		orphans.append(manifest)
+	return orphans
+
+
+def orphan_state(manifest: dict) -> str:
+	"""Classify what is currently on disk at an orphan's target path.
+
+	``clean``   - already identical to the pristine backup, nothing to do.
+	``mutated`` - still holds the exact mutant we recorded, safe to overwrite.
+	``missing`` - the file is gone.
+	``unknown`` - neither; somebody has written to this file since the crash.
+	"""
+	target = Path(manifest["path"])
+	try:
+		current = sha256_bytes(target.read_bytes())
+	except FileNotFoundError:
+		return "missing"
+	if current == manifest.get("sha256"):
+		return "clean"
+	if manifest.get("mutated_sha256") and current == manifest["mutated_sha256"]:
+		return "mutated"
+	return "unknown"
+
+
+def orphan_diff(manifest: dict, max_lines: int = 40) -> str:
+	"""Unified diff from the pristine backup to whatever is on disk right now."""
+	target = Path(manifest["path"])
+	try:
+		current = target.read_text(encoding="utf-8", errors="replace").splitlines()
+	except OSError:
+		return "<target unreadable>"
+	try:
+		pristine = Path(manifest["backup_path"]).read_text(encoding="utf-8", errors="replace").splitlines()
+	except OSError:
+		return "<backup unreadable>"
+	lines = list(
+		difflib.unified_diff(pristine, current, fromfile="pristine backup", tofile=str(target), lineterm="")
+	)
+	if not lines:
+		return "<no difference>"
+	if len(lines) > max_lines:
+		lines = lines[:max_lines] + [f"... ({len(lines) - max_lines} more diff lines)"]
+	return "\n".join(lines)
+
+
+def restore_orphan(manifest: dict) -> bool:
+	"""Restore one orphaned backup. Returns True if the file now matches the backup.
+
+	Refuses to overwrite a target whose current contents are neither the pristine bytes
+	nor the mutant we recorded: that means the file has been edited since the crash, and
+	those edits may be the only copy in existence.
+	"""
+	target = Path(manifest["path"])
+	backup = Path(manifest["backup_path"])
+	data = backup.read_bytes()
+	expected = manifest.get("sha256") or sha256_bytes(data)
+	if sha256_bytes(data) != expected:
+		raise RestoreError(f"backup {backup} is itself corrupt (sha256 mismatch)")
+
+	state = orphan_state(manifest)
+	if state == "unknown":
+		raise RestoreError(
+			f"refusing to restore {target}: its current contents match neither the pristine "
+			f"backup nor the mutant this harness wrote, so it has been edited since the crash. "
+			f"Inspect it, then either delete {manifest['manifest_path']} and {backup} to keep "
+			f"what is on disk, or copy {backup} over it yourself."
+		)
+
+	if state != "clean":
+		if state != "missing":
+			# Unconditional escape hatch: whatever we are about to destroy is kept.
+			rescue = backup.with_suffix(".rescue")
+			try:
+				write_atomic(rescue, target.read_bytes())
+				print(f"[mutation] saved pre-restore copy of {target} to {rescue}", file=sys.stderr)
+			except OSError as exc:
+				raise RestoreError(f"could not save a rescue copy of {target}: {exc}") from exc
+		write_atomic(target, data)
+		if sha256_bytes(target.read_bytes()) != expected:
+			raise RestoreError(f"failed to restore {target} from {backup}")
+
+	backup.unlink()
+	Path(manifest["manifest_path"]).unlink()
+	return True
+
+
+def git_is_clean(rel_paths: list[str]) -> tuple[bool, list[str]]:
+	"""Check that none of ``rel_paths`` has uncommitted (staged or unstaged) changes.
+
+	A clean tree is the escape hatch of last resort: if the process is SIGKILLed and
+	the sidecar backup is also lost, ``git checkout -- <file>`` still recovers it.
+	"""
+	dirty: list[str] = []
+	for rel in rel_paths:
+		for args in (["diff", "--quiet", "--"], ["diff", "--cached", "--quiet", "--"]):
+			result = subprocess.run(
+				["git", *args, rel],
+				cwd=APP_ROOT,
+				capture_output=True,
+			)
+			if result.returncode != 0:
+				dirty.append(rel)
+				break
+	return (not dirty), dirty

--- a/gameplan/tests/mutation/safety.py
+++ b/gameplan/tests/mutation/safety.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import atexit
 import difflib
+import fcntl
 import hashlib
 import json
 import os
@@ -94,6 +95,15 @@ def write_atomic(path: Path, data: bytes) -> None:
 		raise
 
 
+def _read_json(path: Path) -> dict:
+	"""Parse a sidecar json file. A missing or corrupt one reads as ``{}``."""
+	try:
+		payload = json.loads(path.read_text())
+	except (OSError, ValueError):
+		return {}
+	return payload if isinstance(payload, dict) else {}
+
+
 def pid_is_alive(pid: int | None) -> bool:
 	if not pid or pid <= 0:
 		return False
@@ -119,35 +129,93 @@ class CampaignLock:
 	def __init__(self, path: Path = LOCK_PATH) -> None:
 		self.path = path
 		self._held = False
+		self._fd: int | None = None
 
 	def _read_owner(self) -> int | None:
-		try:
-			payload = json.loads(self.path.read_text())
-		except (OSError, ValueError):
-			return None
+		payload = _read_json(self.path)
 		pid = payload.get("pid")
 		return pid if isinstance(pid, int) else None
 
+	def _flock_is_held(self) -> bool:
+		"""True if some open file description still holds the advisory lock.
+
+		The kernel drops an ``flock`` however the owning process dies, so this answers
+		"is the owner still running?" without trusting a pid that may since have been
+		recycled onto an unrelated process.
+		"""
+		try:
+			fd = os.open(self.path, os.O_RDONLY)
+		except OSError:
+			return False
+		try:
+			try:
+				fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+			except OSError:
+				return True
+			# We took it only to ask the question; hand it straight back.
+			fcntl.flock(fd, fcntl.LOCK_UN)
+			return False
+		finally:
+			os.close(fd)
+
+	def _is_live(self) -> bool:
+		"""Whether the existing lock file must be left alone."""
+		owner = self._read_owner()
+		if owner == os.getpid():
+			# Our own leftover, and flock would report it held by our own descriptor.
+			return False
+		if self._flock_is_held():
+			return True
+		# A lock file we cannot parse has an unknown owner, and an unknown owner cannot
+		# be proven dead. Refusing is recoverable by hand; stealing is not.
+		return owner is None or pid_is_alive(owner)
+
+	def _claim(self, payload: bytes) -> bool:
+		"""Publish a fully-formed lock file at ``self.path``. False if one already exists.
+
+		``os.link`` fails when the destination exists, so the lock becomes visible only
+		once it already holds the owning pid. Creating an empty file and writing the pid
+		afterwards would leave a window in which a second process reads no owner, calls
+		the live lock stale, and steals it.
+		"""
+		fd, tmp_name = tempfile.mkstemp(dir=self.path.parent, prefix=f".{self.path.name}.", suffix=".tmp")
+		try:
+			with os.fdopen(fd, "wb") as handle:
+				handle.write(payload)
+				handle.flush()
+				os.fsync(handle.fileno())
+			os.chmod(tmp_name, 0o644)
+			try:
+				os.link(tmp_name, self.path)
+			except FileExistsError:
+				return False
+		finally:
+			os.unlink(tmp_name)
+		return True
+
 	def acquire(self) -> None:
 		self.path.parent.mkdir(parents=True, exist_ok=True)
+		payload = json.dumps({"pid": os.getpid(), "started": time.time()}).encode("utf-8")
 		for _ in range(2):
-			try:
-				fd = os.open(self.path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
-			except FileExistsError:
-				owner = self._read_owner()
-				if pid_is_alive(owner) and owner != os.getpid():
+			if not self._claim(payload):
+				if self._is_live():
+					owner = self._read_owner()
 					raise LockError(
 						f"another mutation run (pid {owner}) is using this working tree. "
 						f"Wait for it, or remove {self.path} if you are sure it is dead."
-					) from None
-				# Stale lock from a crashed run: its pid is gone, so reclaim it.
+					)
+				# Stale lock from a crashed run: nobody holds it any more, so reclaim it.
 				try:
 					self.path.unlink()
 				except FileNotFoundError:
 					pass
 				continue
-			with os.fdopen(fd, "w") as handle:
-				json.dump({"pid": os.getpid(), "started": time.time()}, handle)
+			# Held for as long as this process lives, so a SIGKILL leaves a lock file
+			# that the next run can prove is stale rather than merely guess about.
+			# Blocking, because the only descriptor that can be contending here is
+			# another process's liveness probe, which holds it for an instant.
+			self._fd = os.open(self.path, os.O_RDONLY)
+			fcntl.flock(self._fd, fcntl.LOCK_EX)
 			self._held = True
 			return
 		raise LockError(f"could not acquire {self.path}")
@@ -161,6 +229,9 @@ class CampaignLock:
 				self.path.unlink()
 			except FileNotFoundError:
 				pass
+		if self._fd is not None:
+			os.close(self._fd)
+			self._fd = None
 		self._held = False
 
 	def __enter__(self) -> CampaignLock:
@@ -207,13 +278,66 @@ class FileGuard:
 		write_atomic(self.manifest_path, json.dumps(manifest, indent=2).encode("utf-8"))
 
 	def install_backup(self) -> None:
-		"""Persist the pristine copy before the first mutation of this file."""
+		"""Persist the pristine copy before the first mutation of this file.
+
+		A backup already sitting at our slug is never a leftover to overwrite: the slug
+		is derived from the target path alone, so it is the pristine copy an earlier run
+		took of *this* file and never put back. Overwriting it with what is on disk now
+		would promote that run's mutant to "the original", and every later restore would
+		then faithfully write the mutant back.
+		"""
 		if self._backed_up:
 			return
 		BACKUP_DIR.mkdir(parents=True, exist_ok=True)
+		if self.backup_path.exists():
+			self._adopt_existing_backup()
+			return
 		write_atomic(self.backup_path, self.original_bytes)
 		self._write_manifest(None)
 		self._backed_up = True
+
+	def _adopt_existing_backup(self) -> None:
+		"""Take over an unreleased backup, undoing the crashed run's mutation first."""
+		if _manifest_owned_by_other_live_process(self.manifest_path):
+			raise LockError(
+				f"{self.backup_path} belongs to a mutation run that is still alive "
+				f"(pid {_read_json(self.manifest_path).get('pid')}). Wait for it to finish."
+			)
+		pristine = self.backup_path.read_bytes()
+		pristine_sha = sha256_bytes(pristine)
+		manifest = _read_json(self.manifest_path)
+		recorded_sha = manifest.get("sha256")
+		if recorded_sha and recorded_sha != pristine_sha:
+			raise RestoreError(
+				f"backup {self.backup_path} is itself corrupt: its sha256 {pristine_sha} does not "
+				f"match the {recorded_sha} recorded in {self.manifest_path}. Resolve it by hand."
+			)
+
+		if pristine_sha != self.original_sha:
+			# The bytes we read at construction are a previous run's mutant, not the
+			# original. Only the mutant it recorded may be overwritten; anything else is
+			# an edit made since the crash and may be the only copy in existence.
+			if manifest.get("mutated_sha256") != self.original_sha:
+				raise RestoreError(
+					f"{self.path} matches neither the pristine backup {self.backup_path} nor the "
+					f"mutant recorded in {self.manifest_path}, so it has been edited since an "
+					f"earlier run crashed. Inspect it, then either copy the backup over it or "
+					f"delete the backup to keep what is on disk."
+				)
+			write_atomic(self.path, pristine)
+			current = sha256_bytes(self.path.read_bytes())
+			if current != pristine_sha:
+				raise RestoreError(f"failed to restore {self.path} from {self.backup_path}")
+			self.original_bytes = pristine
+			self.original_sha = pristine_sha
+			print(
+				f"[mutation] recovered {self.path} from {self.backup_path}: "
+				f"a previous run left a mutant on disk.",
+				file=sys.stderr,
+			)
+
+		self._backed_up = True
+		self._write_manifest(None)
 
 	def apply(self, mutated_source: str) -> None:
 		data = mutated_source.encode("utf-8")
@@ -233,7 +357,10 @@ class FileGuard:
 				f"failed to restore {self.path}: sha256 {current} != expected {self.original_sha}. "
 				f"Pristine copy is at {self.backup_path}"
 			)
-		if self._backed_up:
+		# Stamping our pid on a manifest another live process owns would erase the only
+		# record that its backup is not ours to delete - and that record is exactly what
+		# release() reads a moment later.
+		if self._backed_up and not _manifest_owned_by_other_live_process(self.manifest_path):
 			self._write_manifest(None)
 
 	def release(self) -> None:
@@ -256,11 +383,7 @@ class FileGuard:
 
 
 def _manifest_owned_by_other_live_process(manifest_path: Path) -> bool:
-	try:
-		manifest = json.loads(manifest_path.read_text())
-	except (OSError, ValueError):
-		return False
-	pid = manifest.get("pid")
+	pid = _read_json(manifest_path).get("pid")
 	return pid != os.getpid() and pid_is_alive(pid)
 
 
@@ -385,9 +508,8 @@ def find_orphaned_backups() -> list[dict]:
 		return []
 	orphans = []
 	for manifest_path in sorted(BACKUP_DIR.glob("*.json")):
-		try:
-			manifest = json.loads(manifest_path.read_text())
-		except (OSError, ValueError):
+		manifest = _read_json(manifest_path)
+		if not manifest.get("path"):
 			continue
 		orig_path = manifest_path.with_suffix(".orig")
 		if not orig_path.exists():
@@ -487,9 +609,17 @@ def git_is_clean(rel_paths: list[str]) -> tuple[bool, list[str]]:
 
 	A clean tree is the escape hatch of last resort: if the process is SIGKILLed and
 	the sidecar backup is also lost, ``git checkout -- <file>`` still recovers it.
+
+	"Clean" therefore has to mean *recoverable*, not merely "git diff is silent". A file
+	git does not track, or one flagged assume-unchanged/skip-worktree, produces no diff
+	at all while having no committed copy to check out - the promise in the paragraph
+	above would be false for it, so it counts as dirty.
 	"""
 	dirty: list[str] = []
 	for rel in rel_paths:
+		if not _git_has_recoverable_copy(rel):
+			dirty.append(rel)
+			continue
 		for args in (["diff", "--quiet", "--"], ["diff", "--cached", "--quiet", "--"]):
 			result = subprocess.run(
 				["git", *args, rel],
@@ -500,3 +630,21 @@ def git_is_clean(rel_paths: list[str]) -> tuple[bool, list[str]]:
 				dirty.append(rel)
 				break
 	return (not dirty), dirty
+
+
+def _git_has_recoverable_copy(rel: str) -> bool:
+	"""True if ``git checkout -- rel`` would actually restore the file's committed bytes."""
+	result = subprocess.run(
+		["git", "ls-files", "-v", "--error-unmatch", "--", rel],
+		cwd=APP_ROOT,
+		capture_output=True,
+		text=True,
+	)
+	if result.returncode != 0:
+		# Untracked, or not a git repository at all.
+		return False
+	# ``ls-files -v`` prefixes each path with its index tag. "H" is an ordinary cached
+	# entry; lowercase means assume-unchanged and "S" means skip-worktree, both of which
+	# make git ignore the working-tree copy on diff *and* on checkout.
+	tag = result.stdout[:1]
+	return tag == "H"

--- a/gameplan/tests/mutation/scope.py
+++ b/gameplan/tests/mutation/scope.py
@@ -1,0 +1,401 @@
+"""What one mutation run attempts, and when it stops.
+
+The decisions live here as functions of their arguments - no site, no network, no wall
+clock except the one you inject, and no filesystem beyond reading files you name. That is
+deliberate: they are the logic CI depends on, and CI is the one place we cannot debug
+interactively.
+
+* :class:`Budget` - the nightly runs for a fixed wall-clock slice, not to completion.
+* :func:`round_robin_order` - which module that slice is spent on, so a week of budgeted
+  nights covers the corpus instead of grinding the first module forever.
+* :func:`changed_targets` - which targets a pull request's diff implicates.
+* :func:`test_fingerprint` - when a settled verdict stops describing the current suite.
+
+IMPORT CONSTRAINT: this module must import nothing but the standard library at module
+level, and nothing from its own package. ``gameplan/tests/__init__.py`` imports frappe,
+so `import gameplan.tests.mutation.scope` needs a provisioned bench. The CI job that
+answers "does this PR touch any mutation target at all?" has to run *before* a bench
+exists - otherwise every frontend-only PR pays ten minutes of provisioning to be told
+"nothing to do". It therefore runs this file as a script:
+
+    python gameplan/tests/mutation/scope.py --changed-files-from changed.txt
+
+which puts the file's own directory on sys.path and never executes a parent package's
+``__init__``. A single relative import at module level would break that.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import hashlib
+import sys
+import time
+from collections.abc import Callable, Collection, Iterable, Mapping, Sequence
+from pathlib import Path
+
+# The package that holds this app's shared test infrastructure. Everything a mapped test
+# module transitively imports from under here is part of what its assertions MEAN, so it
+# belongs in the fingerprint; see _support_closure.
+TEST_PACKAGE = "gameplan.tests"
+
+
+class Budget:
+	"""A wall-clock allowance, checked *between* units of work.
+
+	The nightly cannot run the full corpus in one go, so it runs for a slice and resumes
+	tomorrow. The slice has to be enforced in here rather than by killing the job: the
+	harness edits source files in place, and a process killed between ``apply`` and
+	``restore`` leaves a mutant on disk in a real working tree. So nothing in this class
+	can interrupt anything - it only ever answers "should the caller start another one?",
+	and the caller asks that question at points where no file is mutated.
+
+	``clock`` is injected so the whole thing is testable without sleeping.
+	"""
+
+	def __init__(self, seconds: float | None, clock: Callable[[], float] = time.monotonic) -> None:
+		if seconds is not None and seconds < 0:
+			raise ValueError(f"budget must not be negative: {seconds!r}")
+		self.seconds = seconds
+		self._clock = clock
+		self._started = clock()
+
+	@property
+	def unlimited(self) -> bool:
+		return self.seconds is None
+
+	@property
+	def elapsed(self) -> float:
+		return self._clock() - self._started
+
+	@property
+	def remaining(self) -> float:
+		"""Seconds left, clamped at 0. ``inf`` when there is no budget."""
+		if self.seconds is None:
+			return float("inf")
+		return max(0.0, self.seconds - self.elapsed)
+
+	@property
+	def expired(self) -> bool:
+		"""True once the allowance is used up.
+
+		A zero budget is expired from the outset. That mirrors ``--limit 0``: an explicit
+		request to evaluate nothing, which the exit-code rules treat as success rather
+		than as a run that failed to measure anything.
+		"""
+		if self.seconds is None:
+			return False
+		return self.elapsed >= self.seconds
+
+	def describe(self) -> str:
+		if self.seconds is None:
+			return "no budget"
+		return f"{self.elapsed:.0f}s of {self.seconds:.0f}s used, {self.remaining:.0f}s left"
+
+
+def last_measured_positions(
+	records: Iterable[Mapping[str, object]], ignore_statuses: Collection[str] = ()
+) -> dict[str, int]:
+	"""Map each module to the position of its most recent journal record.
+
+	The journal is append-only and survives between nightly runs (it is restored from the
+	Actions cache), so position in the file *is* recency: the further down a module's last
+	record sits, the more recently it was worked on.
+
+	``ignore_statuses`` exists for the module-skip records. A skip is the opposite of a
+	measurement, and counting it as one is actively harmful: the skip lands at the very end
+	of the journal, so the broken module sorts LAST in the rotation - the one module the
+	gate is demanding be re-measured becomes the one a budget will not reach, and the
+	nightly stays red for a full rotation after the cause is fixed. Skips therefore leave a
+	module's recency exactly where it was, so it is retried at its normal turn or sooner.
+	"""
+	positions: dict[str, int] = {}
+	for position, record in enumerate(records):
+		if record.get("status") in ignore_statuses:
+			continue
+		module = record.get("module") or record.get("file")
+		if isinstance(module, str) and module:
+			positions[module] = position
+	return positions
+
+
+def _module_path(dotted: str, root: Path) -> Path | None:
+	"""Resolve a dotted module to a file under ``root``: a module, or a package's init."""
+	base = root / dotted.replace(".", "/")
+	module = base.with_suffix(".py")
+	if module.is_file():
+		return module
+	package = base / "__init__.py"
+	if package.is_file():
+		return package
+	return None
+
+
+def _imported_support_modules(path: Path, dotted: str) -> list[str]:
+	"""Dotted names under ``TEST_PACKAGE`` that ``path`` imports.
+
+	Read from the AST rather than by importing anything: this runs on a bare checkout with
+	no bench, and importing ``gameplan.tests`` needs frappe (see the module docstring).
+	"""
+	try:
+		tree = ast.parse(path.read_bytes())
+	except (OSError, SyntaxError, ValueError):
+		# A test file we cannot parse still contributes its bytes to the fingerprint; only
+		# the edges out of it are lost, and guessing them would be worse.
+		return []
+	candidates: list[str] = []
+	for node in ast.walk(tree):
+		if isinstance(node, ast.Import):
+			candidates += [alias.name for alias in node.names]
+		elif isinstance(node, ast.ImportFrom):
+			if node.level:
+				# "from . import x" inside a module: the base is the module's package.
+				parts = dotted.split(".")[: -node.level]
+				if not parts:
+					continue
+				module = ".".join(parts + ([node.module] if node.module else []))
+			else:
+				module = node.module or ""
+			if not module:
+				continue
+			candidates.append(module)
+			# "from gameplan.tests import base" names the submodule in the alias, not the
+			# module, so both spellings have to be tried.
+			candidates += [f"{module}.{alias.name}" for alias in node.names]
+	return [m for m in candidates if m == TEST_PACKAGE or m.startswith(f"{TEST_PACKAGE}.")]
+
+
+def _support_closure(test_modules: Iterable[str], root: Path) -> list[str]:
+	"""The mapped test modules plus the shared test code they transitively import.
+
+	WHY THE CLOSURE AND NOT JUST THE MAPPED FILES
+	---------------------------------------------
+	The mapped modules are not where the assertions live. ``assert_allowed`` and
+	``assert_not_allowed`` are in ``gameplan/tests/base.py``; the personas and
+	``create_space``/``create_community`` are in ``gameplan/tests/fixtures.py``. Gut one of
+	those and every permission test still passes while asserting nothing - and not one
+	mapped file's bytes changed, so a fingerprint over the mapped files alone does not
+	move, every verdict stays settled for ever, and the nightly republishes yesterday's
+	score having run nothing. That is precisely the failure the fingerprint exists to
+	prevent, one file away from where it was fixed.
+
+	WHERE THE BOUNDARY IS, AND WHY THERE
+	------------------------------------
+	Only ``gameplan.tests.*``. Test code decides what is ASSERTED, and nothing else
+	fingerprints it. Production code is the thing being measured: a change to it re-keys
+	the mutation sites it contains, and the corpus rotation re-measures the rest. Pulling
+	all first-party imports in instead would put most of the app behind every verdict, and
+	a nightly whose entire corpus goes stale on any source edit never settles and therefore
+	never measures anything at all.
+
+	Package ``__init__`` files on the way to each module are included: importing a test
+	module executes them, and ``gameplan/tests/__init__.py`` in particular installs
+	setup that every test in this app runs under.
+
+	THE COST, ACCEPTED DELIBERATELY: an edit to ``base.py`` invalidates EVERY target's
+	verdicts - the whole ~1100-mutant corpus, several budgeted nights of re-measurement.
+	That is the right trade, because the alternative is that the one edit which can make
+	every suite in the repo vacuous is the one edit nothing re-measures. A cheaper grain
+	(hash only the functions a test calls) would claim a precision the measurement does not
+	have: a mutation verdict depends on the whole module's tests running, fixtures and
+	imports included.
+	"""
+	seen: set[str] = set()
+	queue: list[str] = []
+	for dotted in test_modules:
+		if dotted not in seen:
+			seen.add(dotted)
+			queue.append(dotted)
+	while queue:
+		dotted = queue.pop()
+		path = _module_path(dotted, root)
+		if path is None:
+			continue
+		parts = dotted.split(".")
+		# Ancestor packages, as far up as the test package itself.
+		ancestors = [".".join(parts[:i]) for i in range(1, len(parts))]
+		neighbours = [a for a in ancestors if a == TEST_PACKAGE or a.startswith(f"{TEST_PACKAGE}.")]
+		neighbours += _imported_support_modules(path, dotted)
+		for candidate in neighbours:
+			if candidate not in seen and _module_path(candidate, root) is not None:
+				seen.add(candidate)
+				queue.append(candidate)
+	return sorted(seen)
+
+
+def test_fingerprint(test_modules: Iterable[str], root: Path) -> str:
+	"""Fingerprint the test files that decide a module's mutation verdicts.
+
+	WHY A VERDICT NEEDS THIS
+	------------------------
+	A mutant key is derived purely from the source AST, so nothing about the test suite
+	enters it. Without a fingerprint the resume logic treats "killed" as settled for ever:
+	delete an assertion, and the mutant it used to kill is never re-measured. The nightly
+	then cannot detect the one regression it exists to catch, and - because the journal is
+	carried between nights - it looks greener and does less work every night, for ever.
+
+	Storing this beside each verdict makes the verdict's provenance explicit: it says
+	"this kill was produced by THESE test files, at these exact bytes". When the bytes
+	change the verdict is stale, not wrong, and gets re-measured.
+
+	WHAT IT COVERS
+	--------------
+	The mapped test files AND the shared test code they transitively import - see
+	:func:`_support_closure`, which also documents where that boundary is drawn and what
+	the width of it costs.
+
+	THE COST, DECIDED DELIBERATELY
+	------------------------------
+	The fingerprint covers a whole module's test closure, so editing one line of
+	``test_email_digest.py`` invalidates all of ``email_digest.py``'s verdicts - the
+	largest target at 431 mutants, about 49 minutes at the measured 6.8s mean, i.e. more
+	than one whole nightly budget - and editing ``base.py`` invalidates the entire corpus.
+	That is the intended trade: the alternative on offer is never re-measuring at all, and
+	a nightly that cannot notice a deleted assertion is theatre. A finer grain (per test
+	function, or per mutant x killing-test) was rejected - a mutation verdict depends on the
+	whole module's tests running, including which fixtures and which imports they set up,
+	so anything narrower would claim a precision the measurement does not have.
+
+	A missing test file hashes as a distinct constant rather than raising: config.py can
+	name a module that has been renamed away, and that has to invalidate verdicts (and
+	show up as a red baseline) rather than crash the campaign.
+	"""
+	digest = hashlib.sha256()
+	for dotted in _support_closure(sorted(set(test_modules)), root):
+		path = _module_path(dotted, root)
+		try:
+			body = path.read_bytes() if path is not None else b"\x00<missing>"
+		except OSError:
+			body = b"\x00<missing>"
+		digest.update(dotted.encode("utf-8"))
+		digest.update(b"\x00")
+		digest.update(hashlib.sha256(body).hexdigest().encode("ascii"))
+		digest.update(b"\x00")
+	return digest.hexdigest()
+
+
+def round_robin_order(modules: Sequence[str], last_measured: Mapping[str, int]) -> list[str]:
+	"""Order modules least-recently-measured first.
+
+	Without this, a budgeted nightly is worthless: every night starts at the top of the
+	target map, so the first module absorbs the entire budget and the last module is never
+	measured at all. Ordering by "when did we last touch this" makes consecutive nights
+	pick up where the previous one stopped, and the corpus rotates.
+
+	Modules with no journal record at all sort first (a brand-new target should not wait a
+	full rotation), and ties keep the declared order so the result is deterministic.
+	"""
+	declared = {module: index for index, module in enumerate(modules)}
+	return sorted(modules, key=lambda m: (last_measured.get(m, -1), declared[m]))
+
+
+def normalise_path(raw: str) -> str:
+	"""Repo-relative POSIX form of a path from a diff, or "" if it is not one."""
+	path = raw.strip().replace("\\", "/")
+	while path.startswith("./"):
+		path = path[2:]
+	return path.lstrip("/")
+
+
+def _test_module_path(dotted: str) -> str:
+	"""``gameplan.tests.features.test_polls`` -> ``gameplan/tests/features/test_polls.py``."""
+	return dotted.replace(".", "/") + ".py"
+
+
+def changed_targets(
+	changed_paths: Iterable[str], targets: Mapping[str, Sequence[str]], root: Path | None = None
+) -> dict[str, list[str]]:
+	"""Restrict ``targets`` to the ones a diff implicates, keeping the declared order.
+
+	Three kinds of changed file select a target:
+
+	* the target source itself - the obvious case;
+	* one of its mapped *test* modules - editing a test changes what that module's mutation
+	score means, and a PR that deletes an assertion is exactly the change this job exists
+	to catch. Skipping those would leave the one edit that can silently drop a module's
+	score unmeasured.
+	* any shared test file those modules import (``base.py``, ``fixtures.py``, ...). Same
+	argument, and a stronger one: weakening ``assert_not_allowed`` makes every permission
+	test in the repo vacuous while touching no mapped file at all. This mirrors exactly
+	what :func:`test_fingerprint` invalidates, so the pull-request job measures what the
+	nightly would re-measure. ``root`` is where those imports are resolved from; the
+	default is this app's root, which is also the checkout in CI.
+
+	Anything else - frontend, docs, an unmapped Python file - selects nothing, and an
+	empty result is a legitimate answer meaning "this PR has nothing to measure", not an
+	error. Inputs are expected repo-relative, as ``git diff --name-only`` emits them.
+	"""
+	root = root if root is not None else Path(__file__).resolve().parents[3]
+	wanted: set[str] = set()
+	by_test_file: dict[str, list[str]] = {}
+	for source, test_modules in targets.items():
+		# The declared modules first and unconditionally: a mapped test file selects its
+		# target whether or not it exists on disk to be resolved.
+		for dotted in list(test_modules) + _support_closure(test_modules, root):
+			by_test_file.setdefault(_test_module_path(dotted), []).append(source)
+			resolved = _module_path(dotted, root)
+			if resolved is not None:
+				try:
+					relative = resolved.resolve().relative_to(root.resolve()).as_posix()
+				except ValueError:  # pragma: no cover - a module outside the app root
+					continue
+				by_test_file.setdefault(relative, []).append(source)
+
+	for raw in changed_paths:
+		path = normalise_path(raw)
+		if not path:
+			continue
+		if path in targets:
+			wanted.add(path)
+		wanted.update(by_test_file.get(path, ()))
+
+	return {source: list(tests) for source, tests in targets.items() if source in wanted}
+
+
+def _target_map_from_disk(tier: str = "all") -> dict[str, list[str]]:
+	"""Load the target map without importing the ``gameplan`` package.
+
+	See the import constraint in the module docstring: ``gameplan.tests`` pulls in frappe,
+	which does not exist on a bare checkout. ``config.py`` next door is pure stdlib, so it
+	can be loaded straight off disk by path.
+	"""
+	import importlib.util
+
+	config_path = Path(__file__).resolve().with_name("config.py")
+	spec = importlib.util.spec_from_file_location("_gameplan_mutation_config", config_path)
+	if spec is None or spec.loader is None:  # pragma: no cover - unreachable for a real file
+		raise RuntimeError(f"could not load {config_path}")
+	module = importlib.util.module_from_spec(spec)
+	spec.loader.exec_module(module)
+	return module.target_map(tier)
+
+
+def read_changed_paths(source: str) -> list[str]:
+	"""Read a newline-delimited path list from a file, or from stdin for "-"."""
+	text = sys.stdin.read() if source == "-" else Path(source).read_text(encoding="utf-8")
+	return [line for line in (line.strip() for line in text.splitlines()) if line]
+
+
+def main(argv: list[str] | None = None) -> int:
+	"""Print the mutation targets a diff implicates, one repo-relative path per line.
+
+	Exits 0 whether or not anything matched - "this PR touches no mutation target" is an
+	answer, not a failure. The caller distinguishes the two by whether stdout is empty,
+	which is why nothing else is ever printed to it.
+	"""
+	parser = argparse.ArgumentParser(
+		prog="scope.py",
+		description="Map a list of changed files to mutation targets.",
+	)
+	parser.add_argument("--changed-files-from", required=True, metavar="PATH", help='file list, or "-"')
+	parser.add_argument("--tier", choices=["1", "2", "all"], default="all")
+	args = parser.parse_args(argv)
+
+	selected = changed_targets(read_changed_paths(args.changed_files_from), _target_map_from_disk(args.tier))
+	for source in selected:
+		print(source)
+	return 0
+
+
+if __name__ == "__main__":
+	sys.exit(main())

--- a/gameplan/tests/permissions/test_content_access.py
+++ b/gameplan/tests/permissions/test_content_access.py
@@ -21,6 +21,7 @@ from gameplan.gameplan.doctype.gp_discussion.gp_discussion import (
 )
 from gameplan.gameplan.doctype.gp_page.gp_page import has_permission as page_has_permission
 from gameplan.gameplan.doctype.gp_task.gp_task import has_permission as task_has_permission
+from gameplan.permissions import users_who_can_view_content
 from gameplan.tests.base import GameplanTestCase
 from gameplan.tests.fixtures import (
 	create_community,
@@ -44,6 +45,46 @@ class TestPersonalContent(GameplanTestCase):
 		# In a space: visibility is the space's, not the owner's.
 		self.assert_allowed(space_page, "read", self.member)
 		self.assert_not_allowed(space_page, "read", self.second_member)
+
+	def test_a_global_admin_can_still_moderate_personal_content(self):
+		"""Owner-only stops at the global admin, who has to be able to moderate anything.
+
+		Space-less content is the one shape with no space to inherit that from, so the
+		admin exemption has to be spelled out in can_view_content itself.
+		"""
+		page = create_page("Moderated Private Page", owner=self.member)
+
+		for action in ("read", "write", "delete"):
+			with self.subTest(action=action):
+				self.assert_allowed(page, action, self.admin)
+				self.assert_not_allowed(page, action, self.second_member)
+
+
+class TestContentAudience(GameplanTestCase):
+	"""users_who_can_view_content resolves a whole audience in one pass — the @everyone
+	fan-out and the digest audience. Its answer has to be can_view_content's answer: a
+	user in it gets a notification carrying the content's title and a link to it, so
+	anyone who lands in it wrongly is handed something they cannot open.
+	"""
+
+	def test_a_public_space_audience_reaches_beyond_the_community_membership(self):
+		"""A public space in a public community is open to every member of the site.
+
+		Only guests are the exception: their access is a per-space grant, never the
+		"public" default.
+		"""
+		community = create_community("Audience Community", members=[self.member])
+		space = create_space("Audience Space", community)
+		discussion = create_discussion("Audience thread", space, owner=self.member)
+
+		audience = users_who_can_view_content(
+			# second_member is in no community at all; the duplicate and the ungranted
+			# guest are the docstring's other two contracts.
+			[self.member.name, self.second_member.name, self.member.name, self.guest.name],
+			discussion,
+		)
+
+		self.assertEqual(audience, [self.member.name, self.second_member.name])
 
 
 class TestUnsavedContent(GameplanTestCase):

--- a/gameplan/tests/permissions/test_guest_access.py
+++ b/gameplan/tests/permissions/test_guest_access.py
@@ -13,7 +13,13 @@ import frappe
 from gameplan.extends.client import get_list as get_client_list
 from gameplan.gameplan.doctype.gp_discussion.api import get_discussions
 from gameplan.tests.base import GameplanTestCase
-from gameplan.tests.fixtures import create_community, create_discussion, create_space, grant_guest_access
+from gameplan.tests.fixtures import (
+	create_community,
+	create_discussion,
+	create_guest,
+	create_space,
+	grant_guest_access,
+)
 
 
 class TestGuestAccess(GameplanTestCase):
@@ -49,6 +55,37 @@ class TestGuestAccess(GameplanTestCase):
 		self.assertIn(str(self.granted_space.name), listed)
 		self.assertNotIn(str(self.public_space.name), listed)
 		self.assertEqual(team_titles[str(self.granted_space.name)], self.community.title)
+
+	def test_guest_community_list_contains_only_communities_holding_a_granted_space(self):
+		"""A guest joins no community, so their community list is derived entirely from
+		their space grants. Unfiltered, this hands a guest the title of every community
+		on the site — the one thing a per-space grant is supposed to keep from them."""
+		ungranted_community = create_community("Guest Ungranted Community")
+		create_space("Guest Ungranted Space", ungranted_community)
+
+		with self.as_user(self.guest):
+			communities = frappe.get_list("GP Team", pluck="name", limit_page_length=0)
+
+		self.assertIn(self.community.name, communities)
+		self.assertNotIn(ungranted_community.name, communities)
+
+	def test_one_guests_community_list_does_not_leak_another_guests_community(self):
+		"""The grant is per guest, not per site: holding a grant somewhere must not put
+		every other guest's community in your list."""
+		other_guest = create_guest("second_guest@example.com", "Second Guest")
+		other_community = create_community("Second Guest Community")
+		other_space = create_space("Second Guest Space", other_community, is_private=1)
+		grant_guest_access(other_guest, other_space)
+
+		with self.as_user(self.guest):
+			communities = frappe.get_list("GP Team", pluck="name", limit_page_length=0)
+		with self.as_user(other_guest):
+			other_communities = frappe.get_list("GP Team", pluck="name", limit_page_length=0)
+
+		self.assertIn(self.community.name, communities)
+		self.assertNotIn(other_community.name, communities)
+		self.assertIn(other_community.name, other_communities)
+		self.assertNotIn(self.community.name, other_communities)
 
 	def test_guest_discussion_feed_contains_only_posts_in_granted_spaces(self):
 		"""What the guest clicks through to: the feed must drop posts from spaces they

--- a/gameplan/tests/permissions/test_list_scoping.py
+++ b/gameplan/tests/permissions/test_list_scoping.py
@@ -1,0 +1,165 @@
+# Copyright (c) 2026, Frappe Technologies Pvt Ltd and Contributors
+# See license.txt
+
+"""List filters, asserted from both sides.
+
+Every filter in this file answers an enumeration with "your rows only". A test that
+asserts nothing but "I can see mine" passes just as happily against a filter that hands
+back everybody's rows, so each case below also names a row belonging to somebody else
+and asserts it is absent. That second half is the one that tests the filter.
+
+Enumeration goes through `frappe.get_list` — the generic list API the SPA reaches over
+/api/v2, and the path `permission_query_conditions` guards. It is a separate door from
+the per-document `has_permission` checks the permission matrix walks: a doctype can
+refuse to hand over a document by name and still list it.
+"""
+
+import frappe
+
+from gameplan.tests.base import GameplanTestCase
+from gameplan.tests.fixtures import (
+	create_comment,
+	create_community,
+	create_discussion,
+	create_page,
+	create_poll,
+	create_space,
+	create_task,
+	set_owner,
+)
+
+
+class ListScopingTestCase(GameplanTestCase):
+	def assert_listed_for(self, doctype, user, *, visible, hidden):
+		"""Assert `user` enumerating `doctype` gets `visible` and not `hidden`."""
+		with self.as_user(user):
+			listed = {str(name) for name in frappe.get_list(doctype, pluck="name", limit_page_length=0)}
+
+		self.assertIn(str(visible.name), listed, f"{user.name} should see {doctype} {visible.name}")
+		self.assertNotIn(str(hidden.name), listed, f"{user.name} must not see {doctype} {hidden.name}")
+
+
+class TestPersonalRowListScoping(ListScopingTestCase):
+	"""Rows that belong to exactly one user.
+
+	A space-less page and a discussion-less poll have no space to inherit visibility
+	from, and a draft or a bookmark never had one: for all four the owner is the whole
+	audience, so enumeration must stop at them.
+	"""
+
+	def setUp(self):
+		super().setUp()
+		self.community = create_community("Personal Row Community", members=[self.member, self.second_member])
+		self.space = create_space("Personal Row Space", self.community)
+		self.discussion = create_discussion("Personal Row Discussion", self.space, owner=self.member)
+
+	def create_draft(self, title, owner):
+		draft = frappe.get_doc(doctype="GP Draft", title=title, content="Draft content").insert(
+			ignore_permissions=True
+		)
+		return set_owner(draft, owner)
+
+	def create_bookmark(self, user):
+		return frappe.get_doc(doctype="GP Bookmark", user=user.name, discussion=self.discussion.name).insert(
+			ignore_permissions=True
+		)
+
+	def test_a_space_less_page_is_listed_only_for_its_owner(self):
+		mine = create_page("My Personal Page", owner=self.member)
+		theirs = create_page("Their Personal Page", owner=self.second_member)
+
+		self.assert_listed_for("GP Page", self.member, visible=mine, hidden=theirs)
+
+	def test_a_discussion_less_poll_is_listed_only_for_its_owner(self):
+		mine = create_poll("My Loose Poll", None, owner=self.member)
+		theirs = create_poll("Their Loose Poll", None, owner=self.second_member)
+
+		self.assert_listed_for("GP Poll", self.member, visible=mine, hidden=theirs)
+
+	def test_a_draft_is_listed_only_for_its_owner(self):
+		mine = self.create_draft("My Draft", self.member)
+		theirs = self.create_draft("Their Draft", self.second_member)
+
+		self.assert_listed_for("GP Draft", self.member, visible=mine, hidden=theirs)
+
+	def test_a_bookmark_is_listed_only_for_the_user_it_belongs_to(self):
+		# A bookmark is scoped by its `user` field rather than by `owner`: it is the
+		# reading list of the user it names, whoever created the row.
+		mine = self.create_bookmark(self.member)
+		theirs = self.create_bookmark(self.second_member)
+
+		self.assert_listed_for("GP Bookmark", self.member, visible=mine, hidden=theirs)
+
+
+class TestCommentListScoping(ListScopingTestCase):
+	"""A comment is listed from the space of whatever it hangs off.
+
+	Discussions and tasks are two separate branches of the filter, and a comment reaches
+	the list through exactly one of them, so both are asserted: a filter that lost the
+	task branch would still look correct measured on discussion comments alone.
+	"""
+
+	def setUp(self):
+		super().setUp()
+		self.community = create_community(
+			"Comment Scope Community", members=[self.member, self.second_member]
+		)
+		self.visible_space = create_space("Comment Visible Space", self.community)
+		self.hidden_space = create_space(
+			"Comment Hidden Space", self.community, is_private=1, members=[self.second_member]
+		)
+
+	def comment_on_task(self, task, owner):
+		comment = frappe.get_doc(
+			doctype="GP Comment",
+			reference_doctype="GP Task",
+			reference_name=task.name,
+			content="Task comment",
+		).insert(ignore_permissions=True)
+		return set_owner(comment, owner)
+
+	def test_a_discussion_comment_is_listed_only_from_a_space_the_user_can_see(self):
+		visible = create_comment(
+			create_discussion("Visible Comment Thread", self.visible_space, owner=self.member),
+			owner=self.member,
+		)
+		hidden = create_comment(
+			create_discussion("Hidden Comment Thread", self.hidden_space, owner=self.second_member),
+			owner=self.second_member,
+		)
+
+		self.assert_listed_for("GP Comment", self.member, visible=visible, hidden=hidden)
+
+	def test_a_task_comment_is_listed_only_from_a_space_the_user_can_see(self):
+		visible = self.comment_on_task(
+			create_task("Visible Comment Task", self.visible_space, owner=self.member), self.member
+		)
+		hidden = self.comment_on_task(
+			create_task("Hidden Comment Task", self.hidden_space, owner=self.second_member),
+			self.second_member,
+		)
+
+		self.assert_listed_for("GP Comment", self.member, visible=visible, hidden=hidden)
+
+
+class TestMembershipListScoping(ListScopingTestCase):
+	"""Membership is what puts a private community or space in your list.
+
+	Communities and spaces keep their members in the same child table, told apart only
+	by `parenttype`, so each list has to be asserted against a private container the
+	user belongs to as well as one they do not: a membership lookup that stopped
+	distinguishing the two would empty the user's own list rather than fill it.
+	"""
+
+	def test_a_private_community_is_listed_only_for_its_own_members(self):
+		mine = create_community("My Private Community", is_private=1, members=[self.member])
+		theirs = create_community("Their Private Community", is_private=1, members=[self.second_member])
+
+		self.assert_listed_for("GP Team", self.member, visible=mine, hidden=theirs)
+
+	def test_a_private_space_is_listed_only_for_its_own_members(self):
+		community = create_community("Space Membership Community", members=[self.member, self.second_member])
+		mine = create_space("My Private Space", community, is_private=1, members=[self.member])
+		theirs = create_space("Their Private Space", community, is_private=1, members=[self.second_member])
+
+		self.assert_listed_for("GP Project", self.member, visible=mine, hidden=theirs)

--- a/gameplan/tests/permissions/test_permission_defaults.py
+++ b/gameplan/tests/permissions/test_permission_defaults.py
@@ -1,0 +1,176 @@
+# Copyright (c) 2026, Frappe Technologies Pvt Ltd and Contributors
+# See license.txt
+
+"""The defaults in permissions.py that look dead but are not.
+
+Mutation testing flagged four branches as survivors — no test changed its answer when
+they were flipped — and they read like dead code:
+
+  - `content_has_permission`'s trailing `return True`
+  - `can_interact_with_content`'s global-admin short circuit
+  - `can_interact_with_content`'s owner check for space-less content
+  - `can_delete_content`'s explicit deny for space-less content
+
+They are defaults in the security core, so "no test covers it" is the wrong reason to
+delete one: removing a default converts a future *denied* into a future *allowed* (or,
+for the deferring `return True`, breaks every desk permission read today). This module
+pins what each one is actually for, so the next person deleting a survivor gets a red
+test instead of a silent permission change.
+
+Only the first three are pinned by tests that go red when the branch changes. The fourth
+(TestPersonalContentHasNoModerators) cannot be — that branch is unreachable through the
+public function, so its mutant stays alive with this module green. Read that class's
+docstring before treating a passing run as cover for editing those lines.
+
+The same trailing `return True` also ends `team_has_permission` (permissions.py:34) and
+`project_has_permission` (L43) — load-bearing there too, but for a stronger reason, not
+the same one. Unlike content_has_permission, neither hook decides `create` at all, so
+ptype="create" falls through to their trailing default on every Space and Community
+insert: an ordinary user action, not only the ptype=None dict read. Dropping either to
+False would stop members creating spaces outright. Both are already pinned by
+test_visibility.py::TestContainerManagement::
+test_a_member_may_create_a_space_in_a_community_they_can_see (L207), which is why this
+module does not re-test them.
+"""
+
+import frappe
+from frappe.utils import cint
+
+from gameplan.permissions import (
+	can_delete_content,
+	can_interact_with_content,
+	can_view_content,
+	content_has_permission,
+)
+from gameplan.tests.base import GameplanTestCase
+from gameplan.tests.fixtures import (
+	create_community,
+	create_discussion,
+	create_member,
+	create_page,
+	create_space,
+)
+
+# Permission types frappe knows about that content_has_permission does not decide, plus
+# the `None` that frappe.permissions.get_doc_permissions passes when it wants the whole
+# evaluated dict rather than one answer. Every one of them lands on the trailing default.
+UNGOVERNED_PTYPES = (None, "submit", "cancel", "amend", "import", "set_user_permissions")
+
+
+class TestUngovernedPermissionTypes(GameplanTestCase):
+	"""content_has_permission's trailing `return True` is "no opinion", not "allowed".
+
+	A `has_permission` hook can only ever deny (frappe.permissions.has_controller_
+	permissions: "Controllers can only deny permission, they can not explicitly grant any
+	permission that wasn't already present"), so the honest answer for a permission type
+	Gameplan does not model is True — defer to the doctype's role permissions.
+	"""
+
+	def setUp(self):
+		super().setUp()
+		self.community = create_community("Defaults Community", members=[self.member])
+		self.space = create_space("Defaults Space", self.community)
+		self.discussion = create_discussion("Defaults thread", self.space, owner=self.member)
+
+	def test_the_content_hook_defers_on_permission_types_it_does_not_govern(self):
+		for ptype in UNGOVERNED_PTYPES:
+			with self.subTest(ptype=ptype):
+				self.assertIs(content_has_permission(self.discussion, ptype, self.member.name), True)
+
+	def test_deferring_is_a_blanket_answer_and_not_a_hole(self):
+		"""Even for a user who cannot read the content, the answer is defer, not deny.
+
+		That is safe precisely because the hook cannot grant: `submit` on a GP Discussion
+		stays impossible because the doctype is not submittable and the role layer says so.
+		If the trailing default were dropped to False instead, the hook would start
+		denying permission types it was never asked to have an opinion on.
+		"""
+		self.assertIs(content_has_permission(self.discussion, "submit", self.outsider.name), True)
+		# cint, because meta flags arrive as 0/"0"/False depending on how the doctype was
+		# loaded, and only the truthiness is the contract here.
+		self.assertFalse(cint(frappe.get_meta("GP Discussion").is_submittable))
+		self.assertIs(
+			frappe.has_permission(
+				"GP Discussion", "submit", doc=self.discussion.name, user=self.outsider.name
+			),
+			False,
+		)
+
+	def test_the_evaluated_permission_dict_survives_the_content_hook(self):
+		"""frappe.permissions.get_doc_permissions calls the hook with ptype=None.
+
+		It is reachable over HTTP (frappe.client.get_doc_permissions, and desk form load),
+		and a falsy answer there collapses the whole dict to `{None: 0}` — the document
+		reads as having no permissions at all. This is the live caller that makes the
+		trailing default load-bearing today, not just a guard for a future ptype.
+		"""
+		permissions = frappe.permissions.get_doc_permissions(self.discussion, user=self.member.name)
+
+		self.assertTrue(permissions.get("read"))
+		self.assertTrue(permissions.get("write"))
+
+
+class TestInteractionFloor(GameplanTestCase):
+	"""can_interact_with_content is the floor under the `write` permission.
+
+	Its only caller (can_write_content) reaches it after can_edit_content has already
+	said False, which is why two of its branches never fire from there: a global admin
+	and the owner of space-less content are both editors. The branches still have to
+	state the rule for the function itself — it is a named predicate about who may reach
+	content to participate, and a global admin who could not is a wrong answer.
+	"""
+
+	def setUp(self):
+		super().setUp()
+		self.personal_page = create_page("Interaction Personal Page", owner=self.member)
+
+	def test_a_global_admin_can_interact_with_personal_content_they_do_not_own(self):
+		self.assertIs(can_interact_with_content(self.admin.name, self.personal_page), True)
+
+	def test_the_owner_can_interact_with_their_own_personal_content(self):
+		self.assertIs(can_interact_with_content(self.member.name, self.personal_page), True)
+
+	def test_a_stranger_cannot_interact_with_personal_content(self):
+		self.assertIs(can_interact_with_content(self.second_member.name, self.personal_page), False)
+
+
+class TestPersonalContentHasNoModerators(GameplanTestCase):
+	"""Space-less content answers to its owner and the global admin, nobody else.
+
+	NOT a regression guard for can_delete_content's space-less `return False`. That branch
+	is unreachable through the public function — a non-owner who is not a global admin is
+	already denied by the can_view_content check above it — so flipping it to True leaves
+	every test here green, and no test written against can_delete_content can turn red on
+	it. A passing run is not cover for editing those lines.
+
+	What these tests do pin is the rule the branch states, reached by the paths that DO
+	produce an answer: moderation stops at the edge of a space, and space-less content
+	stays deletable by its owner and the global admin. The last test pins the
+	unreachability itself, so that if can_view_content's space-less rule ever loosens the
+	branch starts firing and something here has to be revisited.
+	"""
+
+	def setUp(self):
+		super().setUp()
+		self.community_admin = create_member("defaults_community_admin@example.com", "Community Admin")
+		self.community = create_community(
+			"Moderation Community", members=[self.member], admins=[self.community_admin]
+		)
+		self.personal_page = create_page("Unmoderated Personal Page", owner=self.member)
+
+	def test_a_community_admin_cannot_delete_personal_content(self):
+		self.assertIs(can_delete_content(self.community_admin.name, self.personal_page), False)
+
+	def test_the_owner_and_the_global_admin_can(self):
+		self.assertIs(can_delete_content(self.member.name, self.personal_page), True)
+		self.assertIs(can_delete_content(self.admin.name, self.personal_page), True)
+
+	def test_nobody_else_can_even_view_personal_content(self):
+		"""The precondition that makes the space-less deny unreachable, asserted.
+
+		can_delete_content only reaches that branch for a user who got past
+		can_view_content without being the owner or a global admin, which for space-less
+		content cannot happen. When this test goes red the branch is live again.
+		"""
+		self.assertIs(can_view_content(self.community_admin.name, self.personal_page), False)
+		self.assertIs(can_view_content(self.second_member.name, self.personal_page), False)

--- a/gameplan/tests/permissions/test_visibility.py
+++ b/gameplan/tests/permissions/test_visibility.py
@@ -13,9 +13,38 @@ import frappe
 
 from gameplan.extends.client import get_list as get_client_list
 from gameplan.gameplan.doctype.gp_discussion.api import get_discussions
+from gameplan.gameplan.doctype.gp_team.gp_team import GPTeam
+from gameplan.permissions import (
+	apply_accessible_project_filter,
+	bookmark_has_permission,
+	bookmark_query_conditions,
+	comment_query_conditions,
+	discussion_query_conditions,
+	draft_query_conditions,
+	page_query_conditions,
+	poll_query_conditions,
+	project_query_conditions,
+	task_query_conditions,
+	team_query_conditions,
+)
 from gameplan.search_sqlite import GameplanSearch
 from gameplan.tests.base import GameplanTestCase
-from gameplan.tests.fixtures import create_community, create_discussion, create_space
+from gameplan.tests.fixtures import create_community, create_discussion, create_member, create_space
+
+# Shared content: a global admin sees everything, so these hand back "no condition".
+ADMIN_EXEMPT_CONDITIONS = (
+	team_query_conditions,
+	project_query_conditions,
+	discussion_query_conditions,
+	task_query_conditions,
+	page_query_conditions,
+	comment_query_conditions,
+	poll_query_conditions,
+)
+
+# Personal rows: scoped to their owner with no global-admin exception (see
+# bookmark_query_conditions' "Decision 4").
+PERSONAL_ROW_CONDITIONS = (draft_query_conditions, bookmark_query_conditions)
 
 
 class TestCommunityVisibility(GameplanTestCase):
@@ -120,3 +149,166 @@ class TestPermissionAwareQueries(GameplanTestCase):
 			accessible_projects = GameplanSearch()._get_accessible_projects()
 
 		self.assertNotIn(str(space.name), accessible_projects)
+
+
+class TestContainerManagement(GameplanTestCase):
+	"""Who may EDIT or DELETE a community/space, as opposed to merely see it.
+
+	The rest of this file (and the permission matrix) asks who can *read* what. This asks
+	who can destroy it, which is where a regression costs the most: deleting a community
+	takes every space, discussion and comment under it along with it.
+	"""
+
+	def setUp(self):
+		super().setUp()
+		self.community_admin = create_member("container_admin@example.com", "Container Admin")
+		self.community = create_community(
+			"Container Community",
+			members=[self.member, self.second_member],
+			admins=[self.community_admin],
+		)
+		self.public_space = create_space("Container Public Space", self.community)
+		self.private_space = create_space(
+			"Container Private Space", self.community, is_private=1, members=[self.member]
+		)
+
+	def assert_managed_by(self, doc, *, managers, others):
+		for action in ("write", "delete"):
+			for user in managers:
+				with self.subTest(action=action, user=user.name, expected=True):
+					self.assert_allowed(doc, action, user)
+			for user in others:
+				with self.subTest(action=action, user=user.name, expected=False):
+					self.assert_not_allowed(doc, action, user)
+
+	def test_only_community_admins_may_edit_or_delete_a_community(self):
+		self.assert_managed_by(
+			self.community,
+			managers=[self.admin, self.community_admin],
+			others=[self.member, self.second_member, self.outsider],
+		)
+
+	def test_a_public_space_is_managed_by_its_community_admins(self):
+		self.assert_managed_by(
+			self.public_space,
+			managers=[self.admin, self.community_admin],
+			others=[self.member, self.second_member, self.outsider],
+		)
+
+	def test_a_private_space_is_managed_by_its_own_members(self):
+		# Space membership REPLACES the community-admin rule here rather than adding to
+		# it: the community admin is not in this space, so it is not theirs to manage.
+		self.assert_managed_by(
+			self.private_space,
+			managers=[self.admin, self.member],
+			others=[self.community_admin, self.second_member, self.outsider],
+		)
+
+	def test_a_member_may_create_a_space_in_a_community_they_can_see(self):
+		"""Creating a space is not managing one — any member may start one.
+
+		Asserted through a real insert because that is the only path that runs the
+		create branch of project_has_permission.
+		"""
+		with self.as_user(self.member):
+			space = frappe.get_doc(
+				doctype="GP Project", title="Member Created Space", team=self.community.name
+			).insert()
+
+		self.assertTrue(space.name)
+
+
+class TestPermissionQueriesUseTheGivenUser(GameplanTestCase):
+	"""Permission filters must answer for the user they are HANDED, not the session user.
+
+	Every list and feed in the app runs inside the session of the user being served, so a
+	filter that quietly fell back to `frappe.session.user` would still look correct there.
+	What breaks is the code that serves one user from another's session: the weekly digest
+	builds each recipient's query while the scheduler runs as Administrator
+	(email_digest.get_unread_discussions). There the fallback does not merely pick the
+	wrong user — it picks a global admin, and a global admin is exempt from every content
+	filter, so the recipient's digest would be built from the whole site.
+
+	Every test here therefore stays in the Administrator session on purpose.
+	"""
+
+	def setUp(self):
+		super().setUp()
+		self.open_community = create_community("Open Query Community", members=[self.second_member])
+		self.open_space = create_space("Open Query Space", self.open_community)
+		self.visible_discussion = create_discussion(
+			"Visible Query Discussion", self.open_space, owner=self.second_member
+		)
+		self.closed_community = create_community(
+			"Closed Query Community", is_private=1, members=[self.member]
+		)
+		self.closed_space = create_space("Closed Query Space", self.closed_community)
+		self.hidden_discussion = create_discussion(
+			"Hidden Query Discussion", self.closed_space, owner=self.member
+		)
+
+	def discussion_names_for(self, user):
+		"""The digest's query shape: built for `user` from someone else's session."""
+		Discussion = frappe.qb.DocType("GP Discussion")
+		query = apply_accessible_project_filter(
+			frappe.qb.from_(Discussion).select(Discussion.name), Discussion.project, user
+		)
+		return {str(row[0]) for row in query.run()}
+
+	def test_a_query_built_for_another_user_uses_that_users_access(self):
+		self.assertEqual(frappe.session.user, "Administrator", "the session must not be the served user")
+
+		names = self.discussion_names_for(self.second_member.name)
+
+		self.assertIn(str(self.visible_discussion.name), names)
+		self.assertNotIn(str(self.hidden_discussion.name), names)
+
+	def test_a_query_built_for_a_global_admin_is_handed_back_unfiltered(self):
+		names = self.discussion_names_for(self.admin.name)
+
+		self.assertIn(str(self.hidden_discussion.name), names)
+
+	def test_permission_query_conditions_answer_for_the_user_they_are_given(self):
+		for condition in ADMIN_EXEMPT_CONDITIONS + PERSONAL_ROW_CONDITIONS:
+			with self.subTest(condition=condition.__name__):
+				self.assertIsNotNone(
+					condition(user=self.member.name),
+					"a non-admin must always be filtered, whoever holds the session",
+				)
+
+	def test_a_global_admin_is_exempt_from_the_shared_content_filters(self):
+		for condition in ADMIN_EXEMPT_CONDITIONS:
+			with self.subTest(condition=condition.__name__):
+				self.assertIsNone(condition(user=self.admin.name))
+
+	def test_personal_rows_stay_scoped_to_their_owner_even_for_a_global_admin(self):
+		for condition in PERSONAL_ROW_CONDITIONS:
+			with self.subTest(condition=condition.__name__):
+				self.assertIn(self.member.name, condition(user=self.member.name))
+				self.assertNotIn("Administrator", condition(user=self.member.name))
+				self.assertIn(self.admin.name, condition(user=self.admin.name))
+
+	def test_bookmark_permission_answers_for_the_user_it_is_given(self):
+		bookmark = frappe.get_doc(
+			doctype="GP Bookmark",
+			user=self.member.name,
+			discussion=self.visible_discussion.name,
+		).insert(ignore_permissions=True)
+
+		self.assertIs(bookmark_has_permission(bookmark, "read", self.member.name), True)
+		self.assertIs(bookmark_has_permission(bookmark, "read", self.second_member.name), False)
+		self.assertIs(bookmark_has_permission(bookmark, "read", self.admin.name), False)
+
+	def test_the_community_list_query_filter_hides_private_communities(self):
+		Team = frappe.qb.DocType("GP Team")
+
+		def listed_for(user):
+			with self.as_user(user):
+				query = GPTeam.get_list_query(frappe.qb.from_(Team).select(Team.name))
+				return {str(row[0]) for row in query.run()}
+
+		self.assertIn(self.open_community.name, listed_for(self.second_member))
+		self.assertNotIn(self.closed_community.name, listed_for(self.second_member))
+		# A global admin has no criterion at all: the filter must hand the query back
+		# untouched rather than filter on nothing.
+		self.assertIn(self.closed_community.name, listed_for(self.admin))

--- a/gameplan/tests/platform/test_api_endpoints.py
+++ b/gameplan/tests/platform/test_api_endpoints.py
@@ -3,14 +3,27 @@
 
 """Contracts and access guards for Gameplan's cross-cutting API endpoints."""
 
-import frappe
+import json
+from unittest.mock import patch
 
-from gameplan.api import can_access_gameplan, get_search_filter_options, onboarding
+import frappe
+from frappe.utils import add_days, now
+
+from gameplan.api import (
+	can_access_gameplan,
+	get_search_filter_options,
+	get_user_info,
+	invite_by_email,
+	onboarding,
+	search_sqlite,
+)
 from gameplan.search_sqlite import GameplanSearch
 from gameplan.tests.base import GameplanTestCase
 from gameplan.tests.fixtures import (
+	create_comment,
 	create_community,
 	create_discussion,
+	create_member,
 	create_space,
 	create_user,
 	declared_http_methods,
@@ -61,6 +74,19 @@ class TestOnboardingEndpoint(APIEndpointTestCase):
 		self.assertEqual(space.team, community.name)
 		self.assertEqual(space.icon, "lucide-users")
 		self.assertEqual(space.is_private, 1)
+
+	def test_the_first_space_is_public_unless_the_signup_asks_for_privacy(self):
+		"""Signup omits is_private, and the default decides whether a brand-new
+		community's first space is visible to the teammates invited alongside it."""
+		with self.as_user(self.member):
+			result = onboarding(
+				community="API Default Privacy Community",
+				space="API Default Privacy Space",
+				icon="lucide-users",
+				emails="[]",
+			)
+
+		self.assertEqual(frappe.db.get_value("GP Project", result["space"], "is_private"), 0)
 
 	def test_anonymous_caller_is_denied(self):
 		self.assert_anonymous_denied(onboarding)
@@ -193,3 +219,157 @@ class TestCanAccessGameplan(APIEndpointTestCase):
 			result = can_access_gameplan()
 
 		self.assertIs(result, False)
+
+
+class TestGetUserInfoEndpoint(APIEndpointTestCase):
+	"""The member directory the SPA boots from: who exists, who "I" am, and how active.
+
+	The email-visibility split (guests never see other members' addresses) lives in
+	`test_members.py`; this class owns the shape of a row.
+	"""
+
+	def user_info(self, caller, target):
+		with self.as_user(caller):
+			rows = get_user_info(target.name)
+		self.assertEqual([row.name for row in rows], [target.name])
+		return rows[0]
+
+	def test_an_anonymous_caller_reaches_the_endpoint_and_is_told_to_authenticate(self):
+		"""Deliberately guest-reachable: the SPA needs the 401 that AuthenticationError
+		produces to send the visitor to log in. Closing the whitelist to guests would
+		return 403 instead, which the frontend treats as "logged in, but forbidden"."""
+		with self.as_user("Guest"):
+			frappe.is_whitelisted(get_user_info)
+
+			with self.assertRaises(frappe.AuthenticationError):
+				get_user_info()
+
+	def test_reports_the_session_user_and_their_highest_gameplan_role(self):
+		info = self.user_info(self.member, self.member)
+
+		self.assertIs(info.session_user, True)
+		self.assertEqual(info.role, "Gameplan Member")
+
+	def test_another_member_is_not_reported_as_the_session_user(self):
+		info = self.user_info(self.member, self.second_member)
+
+		self.assertNotIn("session_user", info)
+		self.assertEqual(info.role, "Gameplan Member")
+
+	def test_a_user_holding_two_gameplan_roles_appears_once_at_the_higher_role(self):
+		"""The role filter joins Has Role, so a member later promoted to admin matches
+		twice; without deduplication the directory lists them twice."""
+		promoted = create_member("api-promoted@example.com", "Promoted Member")
+		promoted.add_roles("Gameplan Admin")
+
+		with self.as_user(self.member):
+			rows = get_user_info()
+
+		matches = [row for row in rows if row.name == promoted.name]
+		self.assertEqual(len(matches), 1)
+		self.assertEqual(matches[0].role, "Gameplan Admin")
+
+	def test_counts_the_authors_own_discussions_and_comments(self):
+		author = create_member("api-counts-author@example.com", "Counts Author")
+		space = create_space("API Counts Space", create_community("API Counts Community"))
+		discussion = create_discussion("Counted discussion", space, owner=author)
+		create_comment(discussion, owner=author)
+
+		info = self.user_info(self.member, author)
+
+		self.assertEqual(info.discussions_count_3m, 1)
+		self.assertEqual(info.comments_count_3m, 1)
+
+	def test_a_user_with_no_activity_counts_zero(self):
+		quiet = create_member("api-counts-quiet@example.com", "Quiet Member")
+
+		info = self.user_info(self.member, quiet)
+
+		self.assertEqual(info.discussions_count_3m, 0)
+		self.assertEqual(info.comments_count_3m, 0)
+
+	def test_activity_older_than_three_months_is_left_out(self):
+		"""The two counts are labelled "3m" in the profile; widening the window silently
+		would restate a dormant account as an active one."""
+		author = create_member("api-counts-stale@example.com", "Stale Author")
+		space = create_space("API Stale Space", create_community("API Stale Community"))
+		discussion = create_discussion("Stale discussion", space, owner=author)
+		comment = create_comment(discussion, owner=author)
+		# 100 days is outside a 3-month window but inside a 4-month one, so an off-by-one
+		# on the window boundary changes both counts.
+		long_ago = add_days(now(), -100)
+		frappe.db.set_value("GP Discussion", discussion.name, "creation", long_ago, update_modified=False)
+		frappe.db.set_value("GP Comment", comment.name, "creation", long_ago, update_modified=False)
+
+		info = self.user_info(self.member, author)
+
+		self.assertEqual(info.discussions_count_3m, 0)
+		self.assertEqual(info.comments_count_3m, 0)
+
+
+class TestInviteByEmailEndpoint(APIEndpointTestCase):
+	"""The admin gate and role allowlist are covered in `test_members.py`, and the
+	de-duplication rules in `test_invitations.py`; what is left — and what nothing else
+	asserts — is that an authorized invite actually creates the invitations."""
+
+	def setUp(self):
+		super().setUp()
+		# GP Invitation.after_insert emails the invitee; a bare dev site has no outgoing
+		# account and raises, so mute the send for the whole case.
+		sendmail = patch("frappe.sendmail")
+		sendmail.start()
+		self.addCleanup(sendmail.stop)
+
+	def test_an_admin_invite_creates_an_invitation_per_address(self):
+		emails = ["api-invitee-one@example.com", "api-invitee-two@example.com"]
+
+		with self.as_user(self.admin):
+			invite_by_email(", ".join(emails), role="Gameplan Member")
+
+		for email in emails:
+			with self.subTest(email=email):
+				self.assertTrue(
+					frappe.db.exists("GP Invitation", {"email": email, "role": "Gameplan Member"})
+				)
+
+	def test_an_unparseable_address_is_dropped_instead_of_failing_the_whole_invite(self):
+		"""Admins paste address lists; one typo must not discard the other invites."""
+		with self.as_user(self.admin):
+			invite_by_email("api-invitee-valid@example.com, not-an-email", role="Gameplan Member")
+
+		self.assertTrue(frappe.db.exists("GP Invitation", {"email": "api-invitee-valid@example.com"}))
+		self.assertFalse(frappe.db.exists("GP Invitation", {"email": "not-an-email"}))
+
+
+class TestSearchEndpoint(IsolatedSearchIndex, APIEndpointTestCase):
+	INDEX_NAME = "test_gameplan_search_api_endpoint.db"
+
+	def setUp(self):
+		super().setUp()
+		# Must happen before the first indexable document: the doc_event hook builds a
+		# fresh GameplanSearch, which resolves db_path from INDEX_NAME at construction.
+		self.isolate_search_index()
+		self.search = GameplanSearch()
+		self.search.drop_index()
+
+	def test_filters_are_accepted_as_json_and_as_an_already_parsed_object(self):
+		"""Both call shapes are real: a query-string caller sends the filters as a JSON
+		string, while a JSON request body arrives already parsed as a dict."""
+		community = create_community("API Search Community")
+		space = create_space("API Search Space", community)
+		create_discussion("Search endpoint coverage", space, content="apisearchneedle", owner=self.member)
+		self.search.build_index()
+		filters = {"project": [str(space.name)]}
+
+		with self.as_user(self.member):
+			from_object = search_sqlite("apisearchneedle", filters=filters)
+			from_json = search_sqlite("apisearchneedle", filters=json.dumps(filters))
+
+		self.assertTrue(from_object["results"])
+		self.assertEqual(
+			[result["id"] for result in from_object["results"]],
+			[result["id"] for result in from_json["results"]],
+		)
+
+	def test_anonymous_caller_is_denied(self):
+		self.assert_anonymous_denied(search_sqlite)

--- a/gameplan/tests/platform/test_mutation_ci.py
+++ b/gameplan/tests/platform/test_mutation_ci.py
@@ -1,0 +1,2036 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# MIT License. See license.txt
+
+"""Unit tests for the logic the mutation CI jobs are built on.
+
+The two jobs in ``.github/workflows/mutation-*.yml`` cannot be run here, so everything
+they depend on is pushed into pure functions and pinned below. The properties, each one a
+way the jobs would silently rot:
+
+* the budget stops the campaign BETWEEN mutants and never inside one - a stop mid-mutant
+  leaves a mutated source file on disk, which is the single failure the safety layer
+  exists to prevent, and a nightly is exactly the unattended context where nobody notices;
+* "stopped on budget" has an exit code of its own - shared with success it hides a nightly
+  that is falling behind, shared with failure it pages someone every night forever;
+* round-robin ordering actually rotates - a budgeted nightly that restarts at the same
+  module every night measures the first module and nothing else, for ever;
+* diff scope maps changed paths to targets, including the two boring cases (a pull request
+  that touches no target, and one that touches a non-target file) that decide whether the
+  pull-request job is fast or wrong;
+* WHAT THE CACHE MAY CARRY. The journal is the only transferable state. Caching the
+  directory it lives in transplants crash sidecars and the campaign lock onto the next
+  runner and wedges the nightly permanently, re-poisoning itself every night;
+* WHEN A VERDICT GOES STALE. Mutant keys come from the source AST alone, so without the
+  test fingerprint a "killed" is settled for ever and deleting an assertion is invisible
+  to the one job whose purpose is to notice it;
+* EVERY SKIP IS VISIBLE. A module that drops out of the corpus has to say so in the
+  journal, in the report and in the gate - otherwise it goes unmeasured for ever while its
+  stale verdicts keep counting toward the published score.
+
+No bench, no site, no network: a synthetic app tree in a tempdir and an injected clock.
+The two workflow files are read as YAML and asserted against directly, because the
+properties above live half in Python and half in twelve lines of shell.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import yaml
+
+from gameplan.tests.mutation import campaign, cli, config, mutators, safety, scope
+from gameplan.tests.mutation import journal as journal_mod
+from gameplan.tests.mutation import report as report_mod
+
+# The campaign-loop fixture (synthetic app tree, patched git/orphan/backup plumbing) is
+# reused rather than copied: these tests exercise the same loop from a different angle,
+# and two divergent copies of that setup would be a bug factory. It defines no test
+# methods of its own, so importing it does not re-run anything.
+from gameplan.tests.platform.test_mutation_cli import ORIGINAL, CampaignLoopTestCase
+
+# A synthetic target map. Deliberately not the real one: these tests are about the
+# mapping logic, and pinning them to the real map would make every legitimate edit to
+# config.TIER1/TIER2 fail an unrelated test.
+TARGETS = {
+	"pkg/alpha.py": ["tests.test_alpha"],
+	"pkg/beta.py": ["tests.test_beta", "tests.test_beta_extra"],
+	"pkg/gamma.py": ["tests.test_gamma"],
+}
+
+
+def mutant_records(records: list[dict]) -> list[dict]:
+	"""Just the mutant verdicts. A campaign also journals statements about MODULES.
+
+	Those statements ("no current score", "score is current") are keyed per module rather
+	than per mutation site, and counting them as measurements is the mistake the report
+	used to make - see ModuleCurrencyIsDataTest.
+	"""
+	return [record for record in records if record.get("status") not in config.MODULE_STATUSES]
+
+
+WORKFLOW_DIR = Path(config.APP_ROOT) / ".github" / "workflows"
+NIGHTLY_WORKFLOW = WORKFLOW_DIR / "mutation-nightly.yml"
+PR_WORKFLOW = WORKFLOW_DIR / "mutation-pr.yml"
+
+
+class FakeClock:
+	"""A monotonic clock that only moves when the test says so."""
+
+	def __init__(self) -> None:
+		self.now = 0.0
+
+	def __call__(self) -> float:
+		return self.now
+
+	def advance(self, seconds: float) -> None:
+		self.now += seconds
+
+
+class BudgetTest(unittest.TestCase):
+	"""The allowance itself: it must be an honest wall clock and never negative."""
+
+	def test_no_budget_never_expires(self):
+		clock = FakeClock()
+		budget = scope.Budget(None, clock=clock)
+		clock.advance(10_000)
+		self.assertFalse(budget.expired)
+		self.assertTrue(budget.unlimited)
+		self.assertEqual(budget.remaining, float("inf"))
+
+	def test_it_expires_when_the_allowance_is_used(self):
+		clock = FakeClock()
+		budget = scope.Budget(60, clock=clock)
+		clock.advance(59.9)
+		self.assertFalse(budget.expired)
+		clock.advance(0.1)
+		self.assertTrue(budget.expired)
+
+	def test_remaining_counts_down_and_clamps_at_zero(self):
+		clock = FakeClock()
+		budget = scope.Budget(60, clock=clock)
+		clock.advance(20)
+		self.assertAlmostEqual(budget.remaining, 40)
+		clock.advance(100)
+		self.assertEqual(budget.remaining, 0.0)
+
+	def test_a_zero_budget_is_expired_from_the_start(self):
+		"""Mirrors --limit 0: an explicit request to evaluate nothing."""
+		self.assertTrue(scope.Budget(0, clock=FakeClock()).expired)
+
+	def test_a_negative_budget_is_rejected(self):
+		with self.assertRaises(ValueError):
+			scope.Budget(-1)
+
+	def test_the_clock_starts_at_construction_not_at_first_check(self):
+		"""Setup spends the budget too, or "45 minutes" is not a wall-clock number."""
+		clock = FakeClock()
+		budget = scope.Budget(30, clock=clock)
+		clock.advance(31)
+		self.assertTrue(budget.expired)
+
+
+class BudgetStopsBetweenMutantsTest(CampaignLoopTestCase):
+	"""The load-bearing one: where the budget is allowed to interrupt the loop."""
+
+	def run_budgeted(
+		self,
+		targets: dict[str, list[str]],
+		budget_seconds: float,
+		cost_per_mutant: float,
+		clock: FakeClock | None = None,
+	) -> tuple[int, list[bool]]:
+		"""Run the loop with a fake clock that only advances while a mutant is evaluated.
+
+		Returns the exit code and, for each mutant that was evaluated, whether the budget
+		was already expired at the moment evaluation started.
+		"""
+		clock = clock or FakeClock()
+		expired_on_entry: list[bool] = []
+		budget = scope.Budget(budget_seconds, clock=clock)
+
+		def fake_evaluate(_guard, mutated_source, *_args, **_kwargs):
+			expired_on_entry.append(budget.expired)
+			self.evaluated_sources.append(mutated_source)
+			clock.advance(cost_per_mutant)
+			return config.STATUS_KILLED, "tests.some_module", cost_per_mutant
+
+		self.evaluated_sources = []
+		with mock.patch.object(campaign, "_baseline_ok", return_value=(True, "")):
+			with mock.patch.object(campaign, "_evaluate_mutant", fake_evaluate):
+				with contextlib.redirect_stdout(io.StringIO()) as out:
+					code = campaign._run_campaign_locked(
+						targets=targets,
+						site="unused.test",
+						timeout=1,
+						limit=None,
+						mutate_strings=False,
+						assume_yes=True,
+						journal_path=self.journal,
+						budget=budget,
+					)
+		self.output = out.getvalue()
+		return code, expired_on_entry
+
+	def test_no_mutant_is_started_after_the_budget_is_gone(self):
+		self.write_target("pkg/alpha.py", ORIGINAL)
+		_code, expired_on_entry = self.run_budgeted(
+			{"pkg/alpha.py": ["tests.test_alpha"]}, budget_seconds=10, cost_per_mutant=4
+		)
+		self.assertTrue(expired_on_entry, "expected at least one mutant to be evaluated")
+		self.assertNotIn(True, expired_on_entry)
+
+	def test_it_stops_partway_through_a_module_rather_than_finishing_it(self):
+		path = self.write_target("pkg/alpha.py", ORIGINAL)
+		total = len(mutators.collect_sites(path.read_text(), "pkg/alpha.py"))
+		self.assertGreater(total, 2, "fixture must have enough mutants to stop partway")
+
+		_code, expired_on_entry = self.run_budgeted(
+			{"pkg/alpha.py": ["tests.test_alpha"]}, budget_seconds=2, cost_per_mutant=1
+		)
+		self.assertLess(len(expired_on_entry), total)
+
+	def test_the_source_file_is_unmutated_after_a_budget_stop(self):
+		"""A stop that abandoned a mutant on disk would be worse than no budget at all."""
+		path = self.write_target("pkg/alpha.py", ORIGINAL)
+		self.run_budgeted({"pkg/alpha.py": ["tests.test_alpha"]}, budget_seconds=2, cost_per_mutant=1)
+		self.assertEqual(path.read_text(), ORIGINAL)
+
+	def test_no_backup_is_left_behind_after_a_budget_stop(self):
+		"""A stranded sidecar backup makes the next run refuse to start as an orphan."""
+		self.write_target("pkg/alpha.py", ORIGINAL)
+		self.run_budgeted({"pkg/alpha.py": ["tests.test_alpha"]}, budget_seconds=2, cost_per_mutant=1)
+		self.assertEqual(list(self.backup_dir.iterdir()), [])
+
+	def test_everything_it_did_evaluate_is_journalled(self):
+		"""The journal is the resume point; work done outside it is work done twice."""
+		self.write_target("pkg/alpha.py", ORIGINAL)
+		_code, expired_on_entry = self.run_budgeted(
+			{"pkg/alpha.py": ["tests.test_alpha"]}, budget_seconds=2, cost_per_mutant=1
+		)
+		self.assertEqual(len(mutant_records(self.journal_records())), len(expired_on_entry))
+
+	def test_a_budget_stop_does_not_start_the_next_module(self):
+		"""The check sits before the module too: a baseline pass costs minutes."""
+		self.write_target("pkg/alpha.py", ORIGINAL)
+		self.write_target("pkg/beta.py", ORIGINAL)
+		self.run_budgeted(
+			{"pkg/alpha.py": ["tests.test_alpha"], "pkg/beta.py": ["tests.test_beta"]},
+			budget_seconds=2,
+			cost_per_mutant=1,
+		)
+		measured = {record["module"] for record in self.journal_records()}
+		self.assertEqual(measured, {"pkg/alpha.py"})
+
+	def test_a_budget_stop_exits_with_the_budget_code(self):
+		self.write_target("pkg/alpha.py", ORIGINAL)
+		code, _ = self.run_budgeted(
+			{"pkg/alpha.py": ["tests.test_alpha"]}, budget_seconds=2, cost_per_mutant=1
+		)
+		self.assertEqual(code, campaign.EXIT_BUDGET_EXHAUSTED)
+		self.assertIn("STOPPED ON BUDGET", self.output)
+
+	def test_a_budget_that_outlasts_the_work_exits_zero(self):
+		"""Finishing the corpus inside the allowance is a plain success, not a budget stop."""
+		self.write_target("pkg/alpha.py", ORIGINAL)
+		code, _ = self.run_budgeted(
+			{"pkg/alpha.py": ["tests.test_alpha"]}, budget_seconds=10_000, cost_per_mutant=1
+		)
+		self.assertEqual(code, campaign.EXIT_OK)
+
+
+class BudgetExitCodeTest(unittest.TestCase):
+	"""``_campaign_exit_code`` again, now with the budget in the mix."""
+
+	def test_stopping_on_budget_is_neither_success_nor_failure(self):
+		code = campaign._campaign_exit_code(
+			targeted=3, skipped=0, pending=50, evaluated=12, aborted=False, budget_stopped=True
+		)
+		self.assertEqual(code, campaign.EXIT_BUDGET_EXHAUSTED)
+		for other in (
+			campaign.EXIT_OK,
+			campaign.EXIT_ABORTED,
+			campaign.EXIT_USAGE,
+			campaign.EXIT_NOTHING_MEASURED,
+		):
+			self.assertNotEqual(code, other)
+
+	def test_an_abort_outranks_the_budget(self):
+		"""The circuit breaker fired: nothing this run produced is credible."""
+		code = campaign._campaign_exit_code(
+			targeted=3, skipped=0, pending=50, evaluated=12, aborted=True, budget_stopped=True
+		)
+		self.assertEqual(code, campaign.EXIT_ABORTED)
+
+	def test_a_budget_that_measured_nothing_is_still_a_failure(self):
+		"""45 minutes and not one verdict is a broken site, not a budget doing its job."""
+		code = campaign._campaign_exit_code(
+			targeted=3, skipped=0, pending=50, evaluated=0, aborted=False, budget_stopped=True
+		)
+		self.assertEqual(code, campaign.EXIT_NOTHING_MEASURED)
+
+	def test_every_module_skipped_outranks_the_budget(self):
+		code = campaign._campaign_exit_code(
+			targeted=2, skipped=2, pending=0, evaluated=0, aborted=False, budget_stopped=True
+		)
+		self.assertEqual(code, campaign.EXIT_NOTHING_MEASURED)
+
+	def test_a_zero_budget_is_an_explicit_request_to_measure_nothing(self):
+		code = campaign._campaign_exit_code(
+			targeted=1,
+			skipped=0,
+			pending=9,
+			evaluated=0,
+			aborted=False,
+			budget_stopped=True,
+			budget_seconds=0,
+		)
+		self.assertEqual(code, campaign.EXIT_BUDGET_EXHAUSTED)
+
+	def test_an_unbudgeted_run_is_unaffected(self):
+		code = campaign._campaign_exit_code(
+			targeted=1, skipped=0, pending=9, evaluated=9, aborted=False, budget_stopped=False
+		)
+		self.assertEqual(code, campaign.EXIT_OK)
+
+
+class RoundRobinOrderTest(unittest.TestCase):
+	"""Ordering is pure: modules in, modules out."""
+
+	MODULES = ["a.py", "b.py", "c.py"]
+
+	def test_an_empty_journal_keeps_the_declared_order(self):
+		self.assertEqual(scope.round_robin_order(self.MODULES, {}), self.MODULES)
+
+	def test_the_least_recently_measured_module_goes_first(self):
+		order = scope.round_robin_order(self.MODULES, {"a.py": 10, "b.py": 2, "c.py": 7})
+		self.assertEqual(order, ["b.py", "c.py", "a.py"])
+
+	def test_never_measured_modules_outrank_measured_ones(self):
+		"""A newly added target must not wait a full rotation to be looked at."""
+		order = scope.round_robin_order(self.MODULES, {"a.py": 0, "c.py": 1})
+		self.assertEqual(order, ["b.py", "a.py", "c.py"])
+
+	def test_ties_keep_the_declared_order(self):
+		order = scope.round_robin_order(self.MODULES, {"a.py": 5, "b.py": 5, "c.py": 5})
+		self.assertEqual(order, self.MODULES)
+
+	def test_it_rotates_rather_than_restarting_at_the_same_module(self):
+		"""Simulate three budgeted nights, each measuring only whatever came first."""
+		positions: dict[str, int] = {}
+		clock = 0
+		first_each_night = []
+		for _night in range(4):
+			order = scope.round_robin_order(self.MODULES, positions)
+			first_each_night.append(order[0])
+			clock += 1
+			positions[order[0]] = clock
+		self.assertEqual(first_each_night, ["a.py", "b.py", "c.py", "a.py"])
+
+	def test_last_measured_positions_uses_the_most_recent_record(self):
+		records = [
+			{"module": "a.py"},
+			{"module": "b.py"},
+			{"module": "a.py"},
+		]
+		self.assertEqual(scope.last_measured_positions(records), {"a.py": 2, "b.py": 1})
+
+	def test_last_measured_positions_falls_back_to_the_file_field(self):
+		"""Older journal records predate the "module" field."""
+		self.assertEqual(scope.last_measured_positions([{"file": "a.py"}]), {"a.py": 0})
+
+	def test_records_without_a_module_are_ignored(self):
+		self.assertEqual(scope.last_measured_positions([{"status": "killed"}, {"module": ""}]), {})
+
+
+class RoundRobinInTheLoopTest(CampaignLoopTestCase):
+	"""Consecutive budgeted runs over one journal must move through the corpus."""
+
+	def night(self, targets: dict[str, list[str]]) -> str | None:
+		"""One budgeted run that can afford exactly one mutant. Returns the module it hit."""
+		clock = FakeClock()
+		budget = scope.Budget(1, clock=clock)
+
+		def fake_evaluate(*_args, **_kwargs):
+			clock.advance(100)
+			return config.STATUS_KILLED, "tests.some_module", 100.0
+
+		before = len(self.journal_records())
+		with mock.patch.object(campaign, "_baseline_ok", return_value=(True, "")):
+			with mock.patch.object(campaign, "_evaluate_mutant", fake_evaluate):
+				with contextlib.redirect_stdout(io.StringIO()):
+					campaign._run_campaign_locked(
+						targets=targets,
+						site="unused.test",
+						timeout=1,
+						limit=None,
+						mutate_strings=False,
+						assume_yes=True,
+						journal_path=self.journal,
+						budget=budget,
+					)
+		added = self.journal_records()[before:]
+		return added[0]["module"] if added else None
+
+	def test_three_nights_cover_three_modules(self):
+		targets = {}
+		for name in ("alpha", "beta", "gamma"):
+			self.write_target(f"pkg/{name}.py", ORIGINAL)
+			targets[f"pkg/{name}.py"] = [f"tests.test_{name}"]
+
+		nights = [self.night(targets) for _ in range(3)]
+
+		self.assertEqual(nights, ["pkg/alpha.py", "pkg/beta.py", "pkg/gamma.py"])
+
+	def test_the_fourth_night_wraps_back_to_the_first_module(self):
+		targets = {}
+		for name in ("alpha", "beta"):
+			self.write_target(f"pkg/{name}.py", ORIGINAL)
+			targets[f"pkg/{name}.py"] = [f"tests.test_{name}"]
+
+		nights = [self.night(targets) for _ in range(4)]
+
+		self.assertEqual(nights, ["pkg/alpha.py", "pkg/beta.py", "pkg/alpha.py", "pkg/beta.py"])
+
+	def test_a_finished_module_costs_no_baseline_run(self):
+		"""Otherwise a mostly-finished corpus spends its whole budget re-proving itself."""
+		self.write_target("pkg/alpha.py", ORIGINAL)
+		targets = {"pkg/alpha.py": ["tests.test_alpha"]}
+		with mock.patch.object(campaign, "_baseline_ok", return_value=(True, "")) as baseline:
+			with mock.patch.object(
+				campaign, "_evaluate_mutant", lambda *_a, **_k: (config.STATUS_KILLED, "t", 0.0)
+			):
+				with contextlib.redirect_stdout(io.StringIO()):
+					for _ in range(2):
+						campaign._run_campaign_locked(
+							targets=targets,
+							site="unused.test",
+							timeout=1,
+							limit=None,
+							mutate_strings=False,
+							assume_yes=True,
+							journal_path=self.journal,
+						)
+		self.assertEqual(baseline.call_count, 1)
+
+
+class ChangedTargetsTest(unittest.TestCase):
+	"""Diff scope: which targets a pull request implicates."""
+
+	def test_a_changed_target_source_selects_itself(self):
+		selected = scope.changed_targets(["pkg/beta.py"], TARGETS)
+		self.assertEqual(selected, {"pkg/beta.py": ["tests.test_beta", "tests.test_beta_extra"]})
+
+	def test_a_changed_test_module_selects_the_source_it_covers(self):
+		"""Deleting an assertion is exactly the change this job exists to catch."""
+		selected = scope.changed_targets(["tests/test_beta_extra.py"], TARGETS)
+		self.assertEqual(list(selected), ["pkg/beta.py"])
+
+	def test_a_pull_request_that_touches_no_target_selects_nothing(self):
+		selected = scope.changed_targets(["frontend/src/pages/Discussion.vue", "README.md"], TARGETS)
+		self.assertEqual(selected, {})
+
+	def test_a_non_target_python_file_selects_nothing(self):
+		"""Being Python is not the same as being mapped to tests."""
+		self.assertEqual(scope.changed_targets(["pkg/untested.py"], TARGETS), {})
+
+	def test_an_empty_diff_selects_nothing(self):
+		self.assertEqual(scope.changed_targets([], TARGETS), {})
+
+	def test_several_changed_files_select_several_targets_in_declared_order(self):
+		selected = scope.changed_targets(["pkg/gamma.py", "pkg/alpha.py"], TARGETS)
+		self.assertEqual(list(selected), ["pkg/alpha.py", "pkg/gamma.py"])
+
+	def test_a_source_and_its_test_do_not_select_it_twice(self):
+		selected = scope.changed_targets(["pkg/alpha.py", "tests/test_alpha.py"], TARGETS)
+		self.assertEqual(list(selected), ["pkg/alpha.py"])
+
+	def test_paths_are_normalised(self):
+		for raw in ("./pkg/alpha.py", "  pkg/alpha.py  ", "pkg\\alpha.py"):
+			with self.subTest(raw=raw):
+				self.assertEqual(list(scope.changed_targets([raw], TARGETS)), ["pkg/alpha.py"])
+
+	def test_blank_lines_in_a_diff_list_are_ignored(self):
+		self.assertEqual(scope.changed_targets(["", "   "], TARGETS), {})
+
+	def test_the_result_is_a_subset_of_the_map_it_was_given(self):
+		"""--tier narrows the map first, so scope must never widen it back."""
+		tier2 = config.target_map("2")
+		selected = scope.changed_targets(list(config.TIER1) + list(tier2), tier2)
+		self.assertEqual(list(selected), list(tier2))
+
+	def test_it_works_against_the_real_target_map(self):
+		"""One check against reality, so a renamed target is noticed here."""
+		real = config.target_map("all")
+		source = next(iter(real))
+		self.assertEqual(list(scope.changed_targets([source], real)), [source])
+
+
+class ChangedTargetsWiringTest(unittest.TestCase):
+	"""The diff list has to reach ``changed_targets`` from the command line."""
+
+	def setUp(self) -> None:
+		self._tmp = tempfile.TemporaryDirectory()
+		self.addCleanup(self._tmp.cleanup)
+		self.tmp = Path(self._tmp.name)
+
+	def write_list(self, paths: list[str]) -> Path:
+		path = self.tmp / "changed.txt"
+		path.write_text("\n".join(paths) + "\n", encoding="utf-8")
+		return path
+
+	def test_the_diff_list_is_read_and_passed_through(self):
+		listing = self.write_list(["gameplan/api.py", "frontend/src/main.ts"])
+		with mock.patch.object(campaign, "run_campaign", return_value=0) as stub:
+			with contextlib.redirect_stdout(io.StringIO()):
+				cli.main(["run", "--changed-files-from", str(listing)])
+		self.assertEqual(stub.call_args.kwargs["changed_files"], ["gameplan/api.py", "frontend/src/main.ts"])
+
+	def test_no_diff_list_means_no_scoping(self):
+		with mock.patch.object(campaign, "run_campaign", return_value=0) as stub:
+			with contextlib.redirect_stdout(io.StringIO()):
+				cli.main(["run"])
+		self.assertIsNone(stub.call_args.kwargs["changed_files"])
+
+	def test_a_missing_diff_list_is_a_usage_error(self):
+		"""Not "nothing measured": we were told to scope to a diff we cannot see."""
+		with contextlib.redirect_stdout(io.StringIO()):
+			code = cli.main(["run", "--changed-files-from", str(self.tmp / "gone.txt")])
+		self.assertEqual(code, campaign.EXIT_USAGE)
+
+	def test_the_budget_is_passed_through(self):
+		with mock.patch.object(campaign, "run_campaign", return_value=0) as stub:
+			with contextlib.redirect_stdout(io.StringIO()):
+				cli.main(["run", "--budget-seconds", "2700"])
+		self.assertEqual(stub.call_args.kwargs["budget_seconds"], 2700.0)
+
+	def test_the_budget_exit_code_reaches_the_shell(self):
+		with mock.patch.object(campaign, "run_campaign", return_value=campaign.EXIT_BUDGET_EXHAUSTED):
+			with contextlib.redirect_stdout(io.StringIO()):
+				code = cli.main(["run"])
+		self.assertEqual(code, campaign.EXIT_BUDGET_EXHAUSTED)
+
+	def test_the_budget_exit_code_is_documented_in_the_help(self):
+		help_text = io.StringIO()
+		with contextlib.redirect_stdout(help_text):
+			with self.assertRaises(SystemExit):
+				cli.build_parser().parse_args(["run", "--help"])
+		text = help_text.getvalue()
+		self.assertIn("--budget-seconds", text)
+		self.assertIn(f"  {campaign.EXIT_BUDGET_EXHAUSTED}  ", text)
+
+	def test_a_diff_with_no_targets_succeeds_without_touching_the_working_tree(self):
+		"""The common frontend-only pull request: fast, green, and explicit about why."""
+		with mock.patch.object(campaign.safety, "CampaignLock") as lock:
+			with contextlib.redirect_stdout(io.StringIO()) as out:
+				code = campaign.run_campaign(
+					tier="all", changed_files=["frontend/src/main.ts"], journal_path=self.tmp / "j.jsonl"
+				)
+		self.assertEqual(code, campaign.EXIT_OK)
+		lock.assert_not_called()
+		self.assertIn("nothing to measure", out.getvalue())
+
+	def test_module_and_diff_scoping_together_are_a_usage_error(self):
+		with contextlib.redirect_stdout(io.StringIO()):
+			code = campaign.run_campaign(only_module="gameplan/api.py", changed_files=["gameplan/api.py"])
+		self.assertEqual(code, campaign.EXIT_USAGE)
+
+
+class ScopeScriptTest(unittest.TestCase):
+	"""``scope.py`` must run as a bare script, with no bench and no frappe.
+
+	The pull-request job asks "does this diff touch a mutation target?" before it decides
+	whether to spend ten minutes provisioning a bench. ``gameplan/tests/__init__.py``
+	imports frappe, so that question cannot be asked through the package. A relative
+	import added to scope.py at module level would break this and the only symptom would
+	be a red job on every pull request.
+	"""
+
+	def setUp(self) -> None:
+		self._tmp = tempfile.TemporaryDirectory()
+		self.addCleanup(self._tmp.cleanup)
+		self.tmp = Path(self._tmp.name)
+		self.script = Path(scope.__file__).resolve()
+
+	def run_script(self, paths: list[str]) -> subprocess.CompletedProcess:
+		listing = self.tmp / "changed.txt"
+		listing.write_text("\n".join(paths) + "\n", encoding="utf-8")
+		# -I isolates the interpreter (no PYTHONPATH, no user site), and the cwd is a
+		# tempdir, so nothing in this repo is importable as a package.
+		return subprocess.run(
+			[sys.executable, "-I", str(self.script), "--changed-files-from", str(listing)],
+			cwd=str(self.tmp),
+			capture_output=True,
+			text=True,
+			timeout=60,
+			env={"PATH": os.environ.get("PATH", "")},
+		)
+
+	def test_it_prints_the_targets_a_diff_implicates(self):
+		source = next(iter(config.target_map("all")))
+		result = self.run_script([source, "frontend/src/main.ts"])
+		self.assertEqual(result.returncode, 0, result.stderr)
+		self.assertEqual(result.stdout.split(), [source])
+
+	def test_it_prints_nothing_and_succeeds_when_no_target_is_touched(self):
+		"""Empty stdout is the "skip the heavy job" signal, so it must stay exit 0."""
+		result = self.run_script(["frontend/src/main.ts", "README.md"])
+		self.assertEqual(result.returncode, 0, result.stderr)
+		self.assertEqual(result.stdout.strip(), "")
+
+
+class NewSinceTest(unittest.TestCase):
+	"""``report --new-since``: what THIS run added, not what the corpus looks like."""
+
+	def setUp(self) -> None:
+		self._tmp = tempfile.TemporaryDirectory()
+		self.addCleanup(self._tmp.cleanup)
+		self.tmp = Path(self._tmp.name)
+
+	def write_journal(self, name: str, keys: list[str], status: str = "killed") -> Path:
+		path = self.tmp / name
+		with open(path, "w", encoding="utf-8") as handle:
+			for key in keys:
+				handle.write(json.dumps({"key": key, "module": "pkg/a.py", "status": status}) + "\n")
+		return path
+
+	def test_mutants_already_settled_with_the_same_verdict_are_dropped(self):
+		baseline = self.write_journal("before.jsonl", ["old1", "old2"])
+		records = [
+			{"key": "old1", "status": "killed"},
+			{"key": "new1", "status": "killed"},
+		]
+		self.assertEqual(report_mod.only_new_since(records, baseline), [{"key": "new1", "status": "killed"}])
+
+	def test_a_verdict_that_changed_is_kept_even_though_the_key_is_old(self):
+		"""Killed yesterday, surviving today: the regression the nightly exists to catch.
+
+		Filtering on the key alone hides it among 500 cumulative survivors - and now that a
+		test edit re-measures settled keys, that is the common case rather than a corner.
+		"""
+		baseline = self.write_journal("before.jsonl", ["old1"], status="killed")
+		records = [{"key": "old1", "status": "survived"}]
+		self.assertEqual(report_mod.only_new_since(records, baseline), records)
+
+	def test_a_module_skip_is_never_filtered_out(self):
+		"""Its key is fixed per module, so "already seen" says nothing about this run.
+
+		Dropping it deletes the only evidence that a changed file was never measured.
+		"""
+		baseline = self.write_journal("before.jsonl", ["baseline:pkg/a.py"], status="baseline-skip")
+		records = [{"key": "baseline:pkg/a.py", "status": "baseline-skip"}]
+		self.assertEqual(report_mod.only_new_since(records, baseline), records)
+
+	def test_a_missing_baseline_filters_nothing(self):
+		"""A cold or evicted cache must degrade to "report everything", not to silence."""
+		records = [{"key": "a"}, {"key": "b"}]
+		self.assertEqual(report_mod.only_new_since(records, self.tmp / "absent.jsonl"), records)
+		self.assertEqual(report_mod.only_new_since(records, None), records)
+
+	def test_the_report_scores_only_the_new_mutants(self):
+		baseline = self.write_journal("before.jsonl", ["old"])
+		journal = self.tmp / "journal.jsonl"
+		with open(journal, "w", encoding="utf-8") as handle:
+			for key, status in (("old", "killed"), ("new", "survived")):
+				handle.write(json.dumps({"key": key, "module": "pkg/a.py", "status": status}) + "\n")
+
+		with contextlib.redirect_stderr(io.StringIO()):
+			with contextlib.redirect_stdout(io.StringIO()) as out:
+				code = report_mod.report(journal_path=journal, fmt="json", new_since=baseline)
+
+		# Parsed whole: the "N of M are new" notice belongs on stderr, or this is a job
+		# that pipes a report into json.load and crashes.
+		summary = json.loads(out.getvalue())
+		self.assertEqual(code, report_mod.EXIT_OK)
+		self.assertEqual(
+			summary["overall"], {"total": 1, "scored": 1, "unscored": 0, "killed": 0, "score": 0.0}
+		)
+
+	def test_nothing_new_is_reported_as_nothing_to_report(self):
+		"""No new mutants means no score to report - never a fabricated 0%."""
+		baseline = self.write_journal("before.jsonl", ["old"])
+		journal = self.write_journal("journal.jsonl", ["old"])
+		with contextlib.redirect_stderr(io.StringIO()):
+			with contextlib.redirect_stdout(io.StringIO()):
+				code = report_mod.report(journal_path=journal, new_since=baseline)
+		self.assertEqual(code, report_mod.EXIT_NOTHING_TO_REPORT)
+		self.assertNotEqual(code, report_mod.EXIT_OK)
+		self.assertNotEqual(code, report_mod.EXIT_NOTHING_MEASURED)
+
+
+def _workflow(path: Path) -> dict:
+	return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _steps(workflow: dict) -> list[dict]:
+	return [step for job in workflow["jobs"].values() for step in job["steps"]]
+
+
+def _cache_steps(workflow: dict) -> list[dict]:
+	return [step for step in _steps(workflow) if "actions/cache" in step.get("uses", "")]
+
+
+def _mutation_cache_steps(workflow: dict) -> list[dict]:
+	return [step for step in _cache_steps(workflow) if ".mutation" in step["with"]["path"]]
+
+
+def _cached_entries(step: dict) -> list[str]:
+	"""The individual paths a cache step names, as written in the workflow."""
+	return [line.strip() for line in step["with"]["path"].strip().splitlines() if line.strip()]
+
+
+class CachedStateTest(unittest.TestCase):
+	"""What the Actions cache is allowed to carry between runners.
+
+	This is the defect that made the nightly self-poisoning. ``.mutation/`` holds three
+	kinds of thing: the journals (append-only records of completed work, meaningful
+	anywhere), the crash sidecars in ``backup/`` (bound to one working tree and one
+	process), and ``campaign.lock`` (bound to one pid on one machine). Caching the
+	DIRECTORY carried all three. A nightly killed mid-mutant - job cancel, timeout, OOM -
+	left sidecars behind, the ``if: always()`` save cached them, and the next night's fresh
+	clone at a different commit found a backup matching neither the file nor the recorded
+	mutant. The harness then correctly refused to touch it, ``--yes`` could not override
+	that, the campaign exited 1 with a gate message blaming the circuit breaker, and the
+	poisoned directory was re-cached every night. It also failed every pull request, and
+	nothing self-healed it.
+
+	So: only journal files may be cached, asserted against config.py rather than against
+	string literals, so moving the sidecars somewhere else cannot quietly re-open it.
+	"""
+
+	def setUp(self) -> None:
+		self.nightly = _workflow(NIGHTLY_WORKFLOW)
+		self.pr = _workflow(PR_WORKFLOW)
+
+	def cacheable_names(self) -> set[str]:
+		return {config.JOURNAL_PATH.name, config.VERIFY_PATH.name}
+
+	def test_both_workflows_cache_journal_files_and_nothing_else(self):
+		for name, workflow in (("nightly", self.nightly), ("pr", self.pr)):
+			steps = _mutation_cache_steps(workflow)
+			self.assertTrue(steps, f"{name} caches no journal at all")
+			for step in steps:
+				for entry in _cached_entries(step):
+					with self.subTest(workflow=name, step=step.get("name"), entry=entry):
+						self.assertIn(Path(entry).name, self.cacheable_names())
+
+	def test_the_directory_itself_is_never_cached(self):
+		"""Caching the directory is how the sidecars and the lock got in."""
+		for workflow in (self.nightly, self.pr):
+			for step in _mutation_cache_steps(workflow):
+				for entry in _cached_entries(step):
+					self.assertNotEqual(Path(entry).name, config.MUTATION_DIR.name)
+
+	def test_no_cached_path_can_contain_a_crash_sidecar_or_the_lock(self):
+		"""The property, stated the way it actually matters: could this payload hold one?"""
+		forbidden = {config.BACKUP_DIR.name, config.LOCK_PATH.name}
+		for workflow in (self.nightly, self.pr):
+			for step in _mutation_cache_steps(workflow):
+				for entry in _cached_entries(step):
+					parts = set(Path(entry).parts)
+					self.assertEqual(parts & forbidden, set(), entry)
+					# A file path cannot contain anything; a directory could.
+					self.assertTrue(Path(entry).suffix, f"{entry} is not a file")
+
+	def test_the_backup_directory_and_lock_really_do_live_under_the_mutation_directory(self):
+		"""Fixes the test to reality: without this the assertions above prove nothing."""
+		self.assertEqual(config.BACKUP_DIR.parent, config.MUTATION_DIR)
+		self.assertEqual(config.LOCK_PATH.parent, config.MUTATION_DIR)
+		self.assertEqual(config.JOURNAL_PATH.parent, config.MUTATION_DIR)
+
+	def test_the_nightly_saves_exactly_what_it_restores(self):
+		steps = _mutation_cache_steps(self.nightly)
+		restore = [s for s in steps if "restore" in s["uses"]]
+		save = [s for s in steps if "save" in s["uses"]]
+		self.assertEqual(len(restore), 1)
+		self.assertEqual(len(save), 1)
+		self.assertEqual(_cached_entries(restore[0]), _cached_entries(save[0]))
+		# The rolling key: save writes the key the restore could not possibly have hit,
+		# which is what makes the prefix match return last night's cache instead of a hit
+		# that skips the save.
+		self.assertEqual(restore[0]["with"]["key"], save[0]["with"]["key"])
+		self.assertIn("run_id", restore[0]["with"]["key"])
+
+	def test_a_pull_request_never_writes_the_nightly_cache(self):
+		saves = [s for s in _cache_steps(self.pr) if "save" in s["uses"]]
+		self.assertEqual(saves, [])
+
+	def test_the_pull_request_lookup_key_is_outside_the_nightly_prefix(self):
+		"""Or adding a save step here later silently hands PR journals to the nightly."""
+		prefix = self.nightly["env"]["JOURNAL_CACHE_PREFIX"]
+		self.assertEqual(prefix, self.pr["env"]["JOURNAL_CACHE_PREFIX"])
+		for step in _mutation_cache_steps(self.pr):
+			self.assertNotIn(prefix, step["with"]["key"])
+			self.assertNotIn("JOURNAL_CACHE_PREFIX", step["with"]["key"])
+			# ...while still READING the nightly's lineage.
+			self.assertIn("JOURNAL_CACHE_PREFIX", step["with"]["restore-keys"])
+
+	def test_the_cache_lineage_was_abandoned_rather_than_inherited(self):
+		"""v1 caches may hold sidecars from before this fix; they must never be restored."""
+		self.assertNotIn("v1", self.nightly["env"]["JOURNAL_CACHE_PREFIX"])
+
+
+class SignalRestoreDropsTheSidecarTest(unittest.TestCase):
+	"""``restore_all`` is what a cancelled job runs, and it must leave nothing behind.
+
+	The sidecar exists to undo a mutation nobody else can undo. Once ``restore`` has put
+	the file back and proved it byte for byte, that job is done - and a leftover manifest
+	is then indistinguishable from a real crash to the next run, which is what wedged the
+	nightly. If the restore FAILS, the sidecar is still the only copy of the original and
+	is kept.
+	"""
+
+	def setUp(self) -> None:
+		self._tmp = tempfile.TemporaryDirectory()
+		self.addCleanup(self._tmp.cleanup)
+		self.tmp = Path(self._tmp.name)
+		self.backup_dir = self.tmp / "backup"
+		self.backup_dir.mkdir()
+		patcher = mock.patch.object(safety, "BACKUP_DIR", self.backup_dir)
+		patcher.start()
+		self.addCleanup(patcher.stop)
+		self.source = self.tmp / "target.py"
+		self.source.write_text(ORIGINAL, encoding="utf-8")
+
+	def mutated_guard(self) -> safety.FileGuard:
+		guard = safety.FileGuard(self.source)
+		guard.install_backup()
+		guard.apply(ORIGINAL.replace(">", ">="))
+		safety.register(guard)
+		self.addCleanup(safety.unregister, guard)
+		return guard
+
+	def test_it_restores_the_file(self):
+		self.mutated_guard()
+		with contextlib.redirect_stderr(io.StringIO()):
+			safety.restore_all()
+		self.assertEqual(self.source.read_text(), ORIGINAL)
+
+	def test_it_leaves_no_sidecar_for_the_next_run_to_trip_over(self):
+		self.mutated_guard()
+		with contextlib.redirect_stderr(io.StringIO()):
+			safety.restore_all()
+		self.assertEqual(list(self.backup_dir.iterdir()), [])
+		self.assertEqual(safety.find_orphaned_backups(), [])
+
+	def test_a_later_edit_to_the_file_no_longer_wedges_anything(self):
+		"""The exact scenario: interrupted run, then the source moves on (a new commit).
+
+		With the sidecar still on disk this is what ``check_orphans`` classifies "unknown"
+		and refuses - permanently, and with ``--yes`` powerless to override it.
+		"""
+		self.mutated_guard()
+		with contextlib.redirect_stderr(io.StringIO()):
+			safety.restore_all()
+		self.source.write_text(ORIGINAL + "\n# a later commit\n", encoding="utf-8")
+
+		with contextlib.redirect_stdout(io.StringIO()) as out:
+			self.assertTrue(campaign.check_orphans(assume_yes=True))
+		self.assertNotIn("refusing", out.getvalue())
+
+	def test_a_failed_restore_keeps_the_sidecar(self):
+		"""The one case where the backup is still the only copy of the original."""
+		guard = self.mutated_guard()
+		with mock.patch.object(safety.FileGuard, "restore", side_effect=safety.RestoreError("disk is full")):
+			with contextlib.redirect_stderr(io.StringIO()) as err:
+				safety.restore_all()
+		self.assertIn("CRITICAL", err.getvalue())
+		self.assertTrue(guard.backup_path.exists())
+		self.assertTrue(guard.manifest_path.exists())
+
+
+class TestFingerprintTest(unittest.TestCase):
+	"""``scope.test_fingerprint``: the provenance stamped on every verdict."""
+
+	def setUp(self) -> None:
+		self._tmp = tempfile.TemporaryDirectory()
+		self.addCleanup(self._tmp.cleanup)
+		self.root = Path(self._tmp.name)
+		self.write("tests.test_alpha", "def test_a():\n\tassert True\n")
+		self.write("tests.test_beta", "def test_b():\n\tassert True\n")
+
+	def write(self, dotted: str, body: str) -> Path:
+		path = self.root / (dotted.replace(".", "/") + ".py")
+		path.parent.mkdir(parents=True, exist_ok=True)
+		path.write_text(body, encoding="utf-8")
+		return path
+
+	def test_it_is_stable_for_unchanged_files(self):
+		first = scope.test_fingerprint(["tests.test_alpha"], self.root)
+		self.assertEqual(first, scope.test_fingerprint(["tests.test_alpha"], self.root))
+
+	def test_editing_a_mapped_test_changes_it(self):
+		before = scope.test_fingerprint(["tests.test_alpha"], self.root)
+		self.write("tests.test_alpha", "def test_a():\n\tpass\n")
+		self.assertNotEqual(before, scope.test_fingerprint(["tests.test_alpha"], self.root))
+
+	def test_editing_an_unmapped_test_does_not(self):
+		before = scope.test_fingerprint(["tests.test_alpha"], self.root)
+		self.write("tests.test_beta", "def test_b():\n\tpass\n")
+		self.assertEqual(before, scope.test_fingerprint(["tests.test_alpha"], self.root))
+
+	def test_two_modules_with_different_tests_differ(self):
+		self.assertNotEqual(
+			scope.test_fingerprint(["tests.test_alpha"], self.root),
+			scope.test_fingerprint(["tests.test_beta"], self.root),
+		)
+
+	def test_it_covers_every_mapped_module_not_just_the_first(self):
+		before = scope.test_fingerprint(["tests.test_alpha", "tests.test_beta"], self.root)
+		self.write("tests.test_beta", "def test_b():\n\tpass\n")
+		self.assertNotEqual(
+			before, scope.test_fingerprint(["tests.test_alpha", "tests.test_beta"], self.root)
+		)
+
+	def test_order_does_not_matter(self):
+		self.assertEqual(
+			scope.test_fingerprint(["tests.test_alpha", "tests.test_beta"], self.root),
+			scope.test_fingerprint(["tests.test_beta", "tests.test_alpha"], self.root),
+		)
+
+	def test_a_missing_test_module_hashes_rather_than_raising(self):
+		"""config.py can name a module that was renamed away; that invalidates, not crashes."""
+		digest = scope.test_fingerprint(["tests.test_gone"], self.root)
+		self.assertNotEqual(digest, scope.test_fingerprint(["tests.test_alpha"], self.root))
+
+
+class SettledVerdictStalenessTest(unittest.TestCase):
+	"""``completed_keys`` only calls a verdict done while its tests are unchanged."""
+
+	def setUp(self) -> None:
+		self._tmp = tempfile.TemporaryDirectory()
+		self.addCleanup(self._tmp.cleanup)
+		self.journal = Path(self._tmp.name) / "journal.jsonl"
+
+	def write(self, records: list[dict]) -> None:
+		with open(self.journal, "w", encoding="utf-8") as handle:
+			for record in records:
+				handle.write(json.dumps(record, sort_keys=True) + "\n")
+
+	def test_a_matching_fingerprint_is_settled(self):
+		self.write([{"key": "k1", "module": "pkg/a.py", "status": "killed", "tests_sha": "aaa"}])
+		self.assertEqual(journal_mod.completed_keys(self.journal, fingerprints={"pkg/a.py": "aaa"}), {"k1"})
+
+	def test_a_changed_fingerprint_is_stale(self):
+		self.write([{"key": "k1", "module": "pkg/a.py", "status": "killed", "tests_sha": "aaa"}])
+		self.assertEqual(journal_mod.completed_keys(self.journal, fingerprints={"pkg/a.py": "bbb"}), set())
+
+	def test_a_record_without_provenance_is_stale(self):
+		"""Written before verdicts carried their provenance: we cannot show what produced it."""
+		self.write([{"key": "k1", "module": "pkg/a.py", "status": "killed"}])
+		self.assertEqual(journal_mod.completed_keys(self.journal, fingerprints={"pkg/a.py": "aaa"}), set())
+
+	def test_only_the_module_whose_tests_changed_is_invalidated(self):
+		self.write(
+			[
+				{"key": "a1", "module": "pkg/a.py", "status": "killed", "tests_sha": "aaa"},
+				{"key": "b1", "module": "pkg/b.py", "status": "killed", "tests_sha": "bbb"},
+			]
+		)
+		done = journal_mod.completed_keys(
+			self.journal, fingerprints={"pkg/a.py": "CHANGED", "pkg/b.py": "bbb"}
+		)
+		self.assertEqual(done, {"b1"})
+
+	def test_a_module_outside_the_run_is_left_alone(self):
+		"""No current fingerprint for it means no evidence it is stale."""
+		self.write([{"key": "k1", "module": "pkg/other.py", "status": "killed"}])
+		self.assertEqual(journal_mod.completed_keys(self.journal, fingerprints={"pkg/a.py": "aaa"}), {"k1"})
+
+	def test_without_fingerprints_nothing_is_invalidated(self):
+		"""The verify stage runs the full suite, so a per-module fingerprint means nothing."""
+		self.write([{"key": "k1", "module": "pkg/a.py", "status": "killed"}])
+		self.assertEqual(journal_mod.completed_keys(self.journal), {"k1"})
+
+	def test_a_retryable_status_is_still_retried_regardless(self):
+		self.write([{"key": "k1", "module": "pkg/a.py", "status": "timeout", "tests_sha": "aaa"}])
+		self.assertEqual(
+			journal_mod.completed_keys(
+				self.journal,
+				exclude_statuses=config.RETRYABLE_STATUSES,
+				fingerprints={"pkg/a.py": "aaa"},
+			),
+			set(),
+		)
+
+
+class TestEditReMeasuresTheRightModuleTest(CampaignLoopTestCase):
+	"""End to end: edit one test file, and exactly that module is measured again.
+
+	Without this the nightly is theatre. Mutant keys come from the source AST, so deleting
+	an assertion changes no key: every "killed" stays settled for ever, the module
+	short-circuits before its baseline, and the job republishes yesterday's score having
+	run nothing - looking greener and doing less work every night.
+	"""
+
+	def setUp(self) -> None:
+		super().setUp()
+		self.targets = {}
+		for name in ("alpha", "beta"):
+			self.write_target(f"pkg/{name}.py", ORIGINAL)
+			self.write_test_module(f"tests.test_{name}", "def test_x():\n\tassert True\n")
+			self.targets[f"pkg/{name}.py"] = [f"tests.test_{name}"]
+
+	def write_test_module(self, dotted: str, body: str) -> Path:
+		path = self.app_root / (dotted.replace(".", "/") + ".py")
+		path.parent.mkdir(parents=True, exist_ok=True)
+		path.write_text(body, encoding="utf-8")
+		return path
+
+	def modules_measured(self, before: int) -> list[str]:
+		return [record["module"] for record in mutant_records(self.journal_records()[before:])]
+
+	def test_a_settled_corpus_measures_nothing_when_nothing_changed(self):
+		self.run_campaign(self.targets)
+		self.run_campaign(self.targets)
+		self.assertEqual(self.evaluated_sources, [])
+
+	def test_deleting_an_assertion_re_measures_that_module(self):
+		self.run_campaign(self.targets)
+		mark = len(self.journal_records())
+
+		self.write_test_module("tests.test_alpha", "def test_x():\n\tpass\n")
+		self.run_campaign(self.targets)
+
+		self.assertTrue(self.evaluated_sources, "the edited module was not re-measured")
+		self.assertEqual(set(self.modules_measured(mark)), {"pkg/alpha.py"})
+
+	def test_the_other_module_is_not_re_measured(self):
+		"""The cost is bounded: one module's tests, one module's verdicts."""
+		self.run_campaign(self.targets)
+		mark = len(self.journal_records())
+
+		self.write_test_module("tests.test_alpha", "def test_x():\n\tpass\n")
+		self.run_campaign(self.targets)
+
+		self.assertNotIn("pkg/beta.py", self.modules_measured(mark))
+
+	def test_every_mutant_of_the_edited_module_is_re_measured(self):
+		self.run_campaign(self.targets)
+		mark = len(self.journal_records())
+		expected = len(mutators.collect_sites(ORIGINAL, "pkg/alpha.py"))
+
+		self.write_test_module("tests.test_alpha", "def test_x():\n\tpass\n")
+		self.run_campaign(self.targets)
+
+		self.assertEqual(len(self.modules_measured(mark)), expected)
+
+	def test_re_measuring_pays_for_the_baseline_again(self):
+		"""A verdict is only as good as the baseline behind it, so it must be re-proven."""
+		self.run_campaign(self.targets)
+		self.write_test_module("tests.test_alpha", "def test_x():\n\tpass\n")
+		with mock.patch.object(campaign, "_baseline_ok", return_value=(True, "")) as baseline:
+			with mock.patch.object(
+				campaign, "_evaluate_mutant", lambda *_a, **_k: (config.STATUS_KILLED, "t", 0.0)
+			):
+				with contextlib.redirect_stdout(io.StringIO()):
+					campaign._run_campaign_locked(
+						targets=self.targets,
+						site="unused.test",
+						timeout=1,
+						limit=None,
+						mutate_strings=False,
+						assume_yes=True,
+						journal_path=self.journal,
+					)
+		self.assertEqual(baseline.call_count, 1)
+
+	def test_the_verdict_carries_the_fingerprint_that_produced_it(self):
+		self.run_campaign(self.targets)
+		expected = scope.test_fingerprint(["tests.test_alpha"], self.app_root)
+		alpha = [r for r in self.journal_records() if r["module"] == "pkg/alpha.py"]
+		self.assertTrue(alpha)
+		for record in alpha:
+			self.assertEqual(record["tests_sha"], expected)
+
+
+class SkippedModuleVisibilityTest(CampaignLoopTestCase):
+	"""Every way a module can drop out has to be visible in the journal AND the report.
+
+	The exit code cannot carry this: it only fails when EVERY module was skipped, so a
+	renamed target sits there unmeasured for ever - green job, stale verdicts still
+	counting toward the published score, one line of stdout nobody reads.
+	"""
+
+	def summary(self) -> dict:
+		return report_mod.summarise(report_mod.load_results(self.journal))
+
+	def test_a_missing_source_file_is_journalled(self):
+		self.run_campaign({"pkg/gone.py": ["tests.test_gone"]})
+		records = self.journal_records()
+		self.assertEqual([r["status"] for r in records], [config.STATUS_MODULE_SKIP])
+		self.assertIn("does not exist", records[0]["reason"])
+
+	def test_a_missing_source_file_reaches_the_report(self):
+		self.run_campaign({"pkg/gone.py": ["tests.test_gone"]})
+		skipped = self.summary()["skipped_modules"]
+		self.assertIn("pkg/gone.py", skipped)
+		self.assertEqual(skipped["pkg/gone.py"]["kind"], "not measurable")
+
+	def test_a_guard_failure_is_journalled_and_reported(self):
+		self.write_target("pkg/alpha.py", ORIGINAL)
+		with mock.patch.object(campaign, "_guard_for", side_effect=OSError("permission denied")):
+			self.run_campaign({"pkg/alpha.py": ["tests.test_alpha"]})
+		self.assertIn("pkg/alpha.py", self.summary()["skipped_modules"])
+		self.assertIn("permission denied", self.journal_records()[0]["reason"])
+
+	def test_a_red_baseline_is_reported_as_a_red_baseline(self):
+		"""The three causes stay distinguishable; only "measured nothing" is shared."""
+		self.write_target("pkg/alpha.py", ORIGINAL)
+		self.run_campaign({"pkg/alpha.py": ["tests.test_alpha"]}, baseline=(False, "site is down"))
+		skipped = self.summary()["skipped_modules"]
+		self.assertEqual(skipped["pkg/alpha.py"]["kind"], "red baseline")
+		self.assertIn("site is down", skipped["pkg/alpha.py"]["reason"])
+
+	def test_a_partially_skipped_run_is_green_but_the_report_is_not_silent(self):
+		"""Exactly the hole: exit 0, and the only trace used to be a line of stdout."""
+		self.write_target("pkg/alpha.py", ORIGINAL)
+		code = self.run_campaign({"pkg/alpha.py": ["tests.test_alpha"], "pkg/gone.py": ["tests.test_gone"]})
+		self.assertEqual(code, campaign.EXIT_OK)
+		self.assertEqual(list(self.summary()["skipped_modules"]), ["pkg/gone.py"])
+
+	def test_the_skip_names_the_module_and_the_reason_on_stdout_too(self):
+		self.run_campaign({"pkg/gone.py": ["tests.test_gone"]})
+		self.assertIn("pkg/gone.py", self.output)
+		self.assertIn("without updating config.py", self.output)
+
+	def test_a_skip_never_becomes_a_module_with_a_score(self):
+		"""It is not a mutant and must never render as one, not even as "n/a"."""
+		self.run_campaign({"pkg/gone.py": ["tests.test_gone"]})
+		self.assertEqual(self.summary()["modules"], {})
+
+	def test_measuring_the_module_again_clears_the_skip(self):
+		"""Or the gate stays red for ever after the cause is fixed."""
+		self.run_campaign({"pkg/alpha.py": ["tests.test_alpha"]}, baseline=(False, "site is down"))
+		self.write_target("pkg/alpha.py", ORIGINAL)
+		self.run_campaign({"pkg/alpha.py": ["tests.test_alpha"]})
+		self.assertEqual(self.summary()["skipped_modules"], {})
+
+	def test_a_skipped_module_is_not_pushed_to_the_back_of_the_rotation(self):
+		"""The skip record must not read as "recently measured"; it is the opposite."""
+		records = [
+			{"module": "a.py", "status": config.STATUS_KILLED},
+			{"module": "b.py", "status": config.STATUS_KILLED},
+			{"module": "a.py", "status": config.STATUS_BASELINE_SKIP},
+		]
+		positions = scope.last_measured_positions(records, ignore_statuses=config.SKIP_STATUSES)
+		self.assertEqual(scope.round_robin_order(["a.py", "b.py"], positions), ["a.py", "b.py"])
+
+
+class StaleCorpusTest(unittest.TestCase):
+	"""Verdicts about code that no longer exists must not stay in the published score."""
+
+	SOURCE = "def f(a, b):\n\treturn a > b\n"
+
+	def setUp(self) -> None:
+		self._tmp = tempfile.TemporaryDirectory()
+		self.addCleanup(self._tmp.cleanup)
+		self.root = Path(self._tmp.name)
+		(self.root / "pkg").mkdir()
+		(self.root / "pkg" / "a.py").write_text(self.SOURCE, encoding="utf-8")
+		self.sites = mutators.collect_sites(self.SOURCE, "pkg/a.py", mutate_strings=True)
+
+	def record(self, key: str, status: str = "killed") -> dict:
+		return {"key": key, "module": "pkg/a.py", "file": "pkg/a.py", "status": status}
+
+	def test_a_live_site_is_kept(self):
+		kept, dropped = report_mod.drop_stale_sites([self.record(self.sites[0].key)], self.root)
+		self.assertEqual(len(kept), 1)
+		self.assertEqual(dropped, 0)
+
+	def test_a_key_that_matches_no_current_site_is_dropped(self):
+		kept, dropped = report_mod.drop_stale_sites([self.record("nolongerexists")], self.root)
+		self.assertEqual(kept, [])
+		self.assertEqual(dropped, 1)
+
+	def test_a_file_that_cannot_be_read_keeps_all_of_its_records(self):
+		""" "I could not check" must never be resolved into "these results are stale"."""
+		record = dict(self.record("whatever"), file="pkg/missing.py", module="pkg/missing.py")
+		kept, dropped = report_mod.drop_stale_sites([record], self.root)
+		self.assertEqual(kept, [record])
+		self.assertEqual(dropped, 0)
+
+	def test_an_unparseable_file_keeps_all_of_its_records(self):
+		(self.root / "pkg" / "broken.py").write_text("def (:\n", encoding="utf-8")
+		record = dict(self.record("whatever"), file="pkg/broken.py", module="pkg/broken.py")
+		kept, _dropped = report_mod.drop_stale_sites([record], self.root)
+		self.assertEqual(kept, [record])
+
+	def test_module_skips_are_always_kept(self):
+		record = self.record("baseline:pkg/a.py", status=config.STATUS_MODULE_SKIP)
+		kept, _dropped = report_mod.drop_stale_sites([record], self.root)
+		self.assertEqual(kept, [record])
+
+	def test_pruning_changes_the_published_score(self):
+		"""The point of it: a stale kill inflates the number a human reads."""
+		records = [
+			self.record(self.sites[0].key, status="survived"),
+			self.record("deleted-code-that-was-killed", status="killed"),
+		]
+		self.assertEqual(report_mod.summarise(records)["overall"]["score"], 0.5)
+		kept, _ = report_mod.drop_stale_sites(records, self.root)
+		self.assertEqual(report_mod.summarise(kept)["overall"]["score"], 0.0)
+
+
+class BudgetSpentBeforeAnythingWasMeasuredTest(CampaignLoopTestCase):
+	"""A whole allowance burned without one verdict is a broken site, not a budget stop."""
+
+	def run_with_expired_budget(self, targets: dict[str, list[str]], budget_seconds: float) -> int:
+		clock = FakeClock()
+		budget = scope.Budget(budget_seconds, clock=clock)
+		# Setup (orphan recovery, the git check, a slow provisioning step) ate the lot
+		# before the loop ever looked at a module.
+		clock.advance(budget_seconds + 1)
+		with mock.patch.object(campaign, "_baseline_ok", return_value=(True, "")):
+			with contextlib.redirect_stdout(io.StringIO()) as out:
+				code = campaign._run_campaign_locked(
+					targets=targets,
+					site="unused.test",
+					timeout=1,
+					limit=None,
+					mutate_strings=False,
+					assume_yes=True,
+					journal_path=self.journal,
+					budget=budget,
+				)
+		self.output = out.getvalue()
+		return code
+
+	def test_it_does_not_report_a_healthy_budget_stop(self):
+		"""``pending`` is 0 only because the loop never reached a module to count one."""
+		self.write_target("pkg/alpha.py", ORIGINAL)
+		code = self.run_with_expired_budget({"pkg/alpha.py": ["tests.test_alpha"]}, 2700)
+		self.assertEqual(code, campaign.EXIT_NOTHING_MEASURED)
+		self.assertNotEqual(code, campaign.EXIT_BUDGET_EXHAUSTED)
+		self.assertEqual(self.journal_records(), [])
+
+	def test_an_explicit_zero_budget_is_still_an_explicit_request_to_do_nothing(self):
+		self.write_target("pkg/alpha.py", ORIGINAL)
+		code = self.run_with_expired_budget({"pkg/alpha.py": ["tests.test_alpha"]}, 0)
+		self.assertEqual(code, campaign.EXIT_BUDGET_EXHAUSTED)
+
+
+class PullRequestJobClaimsTest(unittest.TestCase):
+	"""The pull-request job must not turn "I measured nothing" into a fact about the code.
+
+	``report`` returns non-zero for three different reasons and the job used to answer all
+	three with "the pull request did not change any mutable behaviour in them". Two of
+	those are false: exit 3 means every new mutant produced a NON-verdict (one hung mutant
+	used to eat the entire budget, since --timeout equalled --budget-seconds), and a
+	crashed report means nothing was measured at all.
+	"""
+
+	def setUp(self) -> None:
+		self.pr = _workflow(PR_WORKFLOW)
+		self.report_step = next(step for step in _steps(self.pr) if step.get("name") == "Publish the report")
+		self.gate_step = next(
+			step for step in _steps(self.pr) if step.get("name") == "Gate on the mutation signal"
+		)
+
+	def case_arm(self, script: str, label: str) -> str:
+		"""The body of one `case` arm, from its label to the `;;` that closes it."""
+		head = script.index(f"{label})")
+		return script[head : script.index(";;", head)]
+
+	def test_the_three_outcomes_have_three_separate_arms(self):
+		script = self.report_step["run"]
+		for label in ("0", "5", "3", "*"):
+			self.assertIn(f"{label})", script)
+
+	def test_no_arm_claims_anything_about_mutants_that_were_not_evaluated(self):
+		"""The empty-result arm used to generalise from a sample to the whole diff.
+
+		A pull request that edits a mapped test module invalidates every verdict of the
+		module behind it; the run then re-measures as many as its 10-minute budget allows -
+		20 of 273, say - and if they all agree with the journal the report is empty. The old
+		text answered that with "the pull request did not change any mutable behaviour in
+		them", a claim over 273 mutants earned on 20, printed directly above the note saying
+		the run was cut off by its budget.
+		"""
+		script = self.report_step["run"]
+		self.assertNotIn("did not change any mutable behaviour", script)
+		self.assertIn("every mutant this run reached", self.case_arm(script, "5"))
+
+	def test_the_summary_says_what_the_run_actually_did(self):
+		"""Without it, "no new verdicts" and "the campaign never ran" render identically."""
+		script = self.report_step["run"]
+		self.assertIn("mutation work", script)
+		self.assertIn('echo "${work}"', script)
+
+	def test_the_no_verdict_case_says_so(self):
+		self.assertIn("No verdict", self.case_arm(self.report_step["run"], "3"))
+
+	def test_the_crashed_report_case_says_so(self):
+		arm = self.case_arm(self.report_step["run"], "*")
+		self.assertIn("report itself failed", arm)
+
+	def test_the_exit_codes_the_workflow_branches_on_are_the_ones_report_returns(self):
+		"""Pins the shell to the Python: renumbering either alone breaks this."""
+		self.assertEqual(report_mod.EXIT_NOTHING_TO_REPORT, 5)
+		self.assertEqual(report_mod.EXIT_NOTHING_MEASURED, 3)
+		self.assertEqual(report_mod.EXIT_OK, 0)
+
+	def test_the_pull_request_job_gates_on_skipped_modules(self):
+		"""The nightly had this gate and the pull-request job did not."""
+		self.assertIn("skipped_modules", self.gate_step["run"])
+
+	def test_the_budget_is_comfortably_larger_than_one_mutant_timeout(self):
+		"""Equal values mean one hung module consumes the whole allowance by construction."""
+		script = next(
+			step["run"] for step in _steps(self.pr) if step.get("name") == "Mutate the changed targets"
+		)
+		timeout = int(script.split("--timeout")[1].split()[0])
+		budget = int(script.split("--budget-seconds")[1].split()[0])
+		self.assertLess(timeout * 2, budget)
+
+
+class NightlyGateHonestyTest(unittest.TestCase):
+	"""The nightly's gate may not diagnose a cause it has not established."""
+
+	def setUp(self) -> None:
+		self.nightly = _workflow(NIGHTLY_WORKFLOW)
+		self.gate = next(
+			step["run"] for step in _steps(self.nightly) if step.get("name") == "Gate on the mutation signal"
+		)
+
+	def test_exit_one_does_not_blame_the_circuit_breaker_alone(self):
+		"""Exit 1 is also an orphaned backup, a held lock, or a dirty target file."""
+		arm = self.gate[self.gate.index("1)") : self.gate.index(";;", self.gate.index("1)"))]
+		self.assertIn("aborted or refused to start", arm)
+		for cause in ("circuit breaker", "orphaned backup", "lock", "uncommitted changes"):
+			self.assertIn(cause, arm)
+
+	def test_it_gates_on_every_kind_of_skip(self):
+		self.assertIn("skipped_modules", self.gate)
+
+	def test_the_summary_states_the_budget_it_actually_used(self):
+		"""A manually dispatched short run must not read like a normal night."""
+		publish = next(
+			step["run"] for step in _steps(self.nightly) if step.get("name") == "Publish the report"
+		)
+		self.assertIn("Budget:", publish)
+
+	def test_the_summary_shows_what_changed_rather_than_the_whole_corpus(self):
+		publish = next(
+			step["run"] for step in _steps(self.nightly) if step.get("name") == "Publish the report"
+		)
+		self.assertIn("--new-since", publish)
+		self.assertIn("Decided tonight", publish)
+
+
+class ModuleCurrencyIsDataTest(unittest.TestCase):
+	"""A skip is reported IF AND ONLY IF it describes the module as it is now.
+
+	Under any filtering. That "under any filtering" is the whole test class, because the
+	defect it pins was not in what the report decided but in WHERE it decided it. Currency
+	used to be inferred from journal position - "a mutant record further down means this
+	skip is old" - and every caller is free to filter the list that position is measured
+	over. ``--new-since`` keeps skips (deliberately: they are the evidence a changed file
+	was never measured) and drops settled mutants, i.e. it removes exactly the evidence
+	that ages a skip out. So one red baseline anywhere in the nightly journal made every
+	pull request red, for a module the pull request never touched, with a reason from weeks
+	ago - while the nightly's own cumulative report insisted nothing was skipped, so
+	nothing pointed at the cause. Nothing could clear it either: the key is fixed per
+	module, so the record is immortal.
+
+	The fix is that currency is now a FACT in the journal - a module that has a current
+	score says so under the skip's own key - settled once against the complete journal and
+	only read thereafter. These tests pin the property, not the mechanism: cumulative and
+	filtered views must agree, whatever the filter.
+	"""
+
+	def setUp(self) -> None:
+		self._tmp = tempfile.TemporaryDirectory()
+		self.addCleanup(self._tmp.cleanup)
+		self.tmp = Path(self._tmp.name)
+		self.journal = self.tmp / "journal.jsonl"
+
+	def skip_record(self, module: str = "pkg/a.py", reason: str = "tests were red") -> dict:
+		return {
+			"key": f"baseline:{module}",
+			"module": module,
+			"file": module,
+			"status": config.STATUS_BASELINE_SKIP,
+			"reason": reason,
+		}
+
+	def current_record(self, module: str = "pkg/a.py") -> dict:
+		return {
+			"key": f"baseline:{module}",
+			"module": module,
+			"file": module,
+			"status": config.STATUS_MODULE_CURRENT,
+			"reason": "baseline green",
+		}
+
+	def mutant(self, key: str, module: str = "pkg/a.py", status: str = config.STATUS_KILLED) -> dict:
+		return {"key": key, "module": module, "file": module, "status": status}
+
+	def write(self, records: list[dict], name: str = "journal.jsonl") -> Path:
+		path = self.tmp / name
+		with open(path, "w", encoding="utf-8") as handle:
+			for record in records:
+				handle.write(json.dumps(record, sort_keys=True) + "\n")
+		return path
+
+	def skipped(self, records: list[dict]) -> dict:
+		return report_mod.summarise(records)["skipped_modules"]
+
+	def test_a_measurement_after_the_skip_retires_it(self):
+		journal = self.write([self.skip_record(), self.mutant("k1"), self.mutant("k2")])
+		self.assertEqual(self.skipped(report_mod.load_results(journal)), {})
+
+	def test_the_filtered_view_agrees_with_the_cumulative_one(self):
+		"""The defect, stated as the property it broke. Both views, one answer."""
+		journal = self.write([self.skip_record(), self.mutant("k1"), self.mutant("k2")])
+		before = self.write([self.skip_record(), self.mutant("k1"), self.mutant("k2")], "before.jsonl")
+
+		cumulative = report_mod.load_results(journal)
+		filtered = report_mod.only_new_since(cumulative, before)
+
+		self.assertEqual(self.skipped(cumulative), {})
+		self.assertEqual(self.skipped(filtered), {})
+
+	def test_a_skip_that_is_still_current_survives_both_views(self):
+		"""The other half: retiring a live skip would hide an unmeasured module."""
+		journal = self.write([self.mutant("k1"), self.skip_record()])
+		before = self.write([self.mutant("k1"), self.skip_record()], "before.jsonl")
+
+		cumulative = report_mod.load_results(journal)
+		filtered = report_mod.only_new_since(cumulative, before)
+
+		self.assertEqual(list(self.skipped(cumulative)), ["pkg/a.py"])
+		self.assertEqual(self.skipped(cumulative), self.skipped(filtered))
+
+	def test_a_current_score_record_retires_the_skip_by_key(self):
+		"""The forward mechanism: one key per module, last record wins, no ordering guess."""
+		journal = self.write([self.skip_record(), self.current_record()])
+		records = report_mod.load_results(journal)
+		self.assertEqual(self.skipped(records), {})
+		self.assertEqual([r["status"] for r in records], [config.STATUS_MODULE_CURRENT])
+
+	def test_a_skip_after_a_current_score_record_still_wins(self):
+		"""Same key, and the later record is the module's state. Order matters HERE only."""
+		journal = self.write([self.current_record(), self.skip_record()])
+		self.assertEqual(list(self.skipped(report_mod.load_results(journal))), ["pkg/a.py"])
+
+	def test_pruning_every_mutant_record_cannot_resurrect_a_skip(self):
+		"""N2: --prune-stale over a rewritten module used to delete the retiring evidence."""
+		source_root = self.tmp / "app"
+		(source_root / "pkg").mkdir(parents=True)
+		(source_root / "pkg" / "a.py").write_text("def f(a, b):\n\treturn a > b\n", encoding="utf-8")
+		journal = self.write(
+			[self.skip_record(), self.mutant("gone-1"), self.mutant("gone-2"), self.current_record()]
+		)
+
+		records = report_mod.load_results(journal)
+		pruned, dropped = report_mod.drop_stale_sites(records, source_root)
+
+		self.assertEqual(dropped, 2, "the module was rewritten; its old verdicts are stale")
+		self.assertEqual(self.skipped(pruned), {})
+
+	def test_summarise_does_not_read_currency_out_of_the_list_it_is_given(self):
+		"""Handed a skip and nothing else, it reports it; the ordering logic is gone."""
+		self.assertEqual(list(self.skipped([self.skip_record()])), ["pkg/a.py"])
+		self.assertEqual(self.skipped([self.current_record()]), {})
+
+	def test_a_skip_never_becomes_a_scored_module(self):
+		summary = report_mod.summarise([self.skip_record(), self.current_record("pkg/b.py")])
+		self.assertEqual(summary["modules"], {})
+		self.assertEqual(summary["overall"]["total"], 0)
+
+	def test_the_verify_stage_cannot_retire_a_skip(self):
+		"""Stage 2 re-runs old survivors; it says nothing about today's baseline."""
+		journal = self.write([self.mutant("k1"), self.skip_record()])
+		verify = self.write([self.mutant("k1", status=config.STATUS_KILLED_BY_OTHER_SUITE)], "v.jsonl")
+		records = report_mod.load_results(journal, verify)
+		self.assertEqual(list(self.skipped(records)), ["pkg/a.py"])
+
+
+class ModuleCurrencyInTheLoopTest(CampaignLoopTestCase):
+	"""The campaign has to WRITE the fact that a module's score is current.
+
+	Every path that leaves a module measurable must say so under the skip's own key, or a
+	skip journalled once is a skip for ever - and the gate reads skips.
+	"""
+
+	def module_records(self, module: str) -> list[dict]:
+		return [
+			record
+			for record in self.journal_records()
+			if record["module"] == module and record["status"] in config.MODULE_STATUSES
+		]
+
+	def summary(self) -> dict:
+		return report_mod.summarise(report_mod.load_results(self.journal))
+
+	def test_a_green_baseline_records_that_the_module_has_a_current_score(self):
+		self.write_target("pkg/alpha.py", ORIGINAL)
+		self.run_campaign({"pkg/alpha.py": ["tests.test_alpha"]})
+		self.assertEqual(
+			[r["status"] for r in self.module_records("pkg/alpha.py")], [config.STATUS_MODULE_CURRENT]
+		)
+
+	def test_a_module_with_nothing_pending_records_it_too(self):
+		"""The one that closes the loop: a settled module never runs a baseline again.
+
+		Without a record here, a module that was skipped once and then has every mutant
+		settled short-circuits before the baseline for ever, so nothing can ever clear the
+		skip and the gate is red until a human deletes the journal.
+		"""
+		self.write_target("pkg/alpha.py", ORIGINAL)
+		self.run_campaign({"pkg/alpha.py": ["tests.test_alpha"]})
+		self.run_campaign({"pkg/alpha.py": ["tests.test_alpha"]})
+		self.assertEqual(self.evaluated_sources, [], "nothing should have been re-measured")
+		self.assertEqual(len(self.module_records("pkg/alpha.py")), 2)
+		self.assertEqual(self.module_records("pkg/alpha.py")[-1]["status"], config.STATUS_MODULE_CURRENT)
+
+	def test_a_skip_clears_even_when_there_is_nothing_left_to_measure(self):
+		"""The self-sustaining case, end to end: settled module, skip, fix, still cleared.
+
+		A module whose every mutant is settled never runs a baseline again, so the skip
+		journalled while its source was missing has no later mutant record to age it out.
+		Only the "score is current" record can retire it, and this is the run that writes
+		one.
+		"""
+		path = self.write_target("pkg/alpha.py", ORIGINAL)
+		targets = {"pkg/alpha.py": ["tests.test_alpha"]}
+		self.run_campaign(targets)  # settles every mutant
+
+		path.unlink()  # a rename config.py did not follow
+		self.run_campaign(targets)
+		self.assertEqual(list(self.summary()["skipped_modules"]), ["pkg/alpha.py"])
+
+		self.write_target("pkg/alpha.py", ORIGINAL)  # put back; nothing is pending
+		self.run_campaign(targets)
+
+		self.assertEqual(self.evaluated_sources, [], "nothing was pending, so nothing ran")
+		self.assertEqual(self.summary()["skipped_modules"], {})
+
+	def test_the_cleared_skip_stays_cleared_in_a_filtered_report(self):
+		"""What a pull request seeded from this journal sees. Same answer, or it is red."""
+		self.write_target("pkg/alpha.py", ORIGINAL)
+		targets = {"pkg/alpha.py": ["tests.test_alpha"]}
+		self.run_campaign(targets, baseline=(False, "site is down"))
+		self.run_campaign(targets)
+
+		records = report_mod.load_results(self.journal)
+		filtered = report_mod.only_new_since(records, self.journal)
+
+		self.assertEqual(report_mod.summarise(records)["skipped_modules"], {})
+		self.assertEqual(report_mod.summarise(filtered)["skipped_modules"], {})
+
+	def test_a_module_record_does_not_push_the_module_down_the_rotation(self):
+		"""It is a statement, not a measurement: a budget stop must not cost a rotation."""
+		records = [
+			{"module": "a.py", "status": config.STATUS_KILLED},
+			{"module": "b.py", "status": config.STATUS_KILLED},
+			{"module": "a.py", "status": config.STATUS_MODULE_CURRENT},
+		]
+		positions = scope.last_measured_positions(records, ignore_statuses=config.MODULE_STATUSES)
+		self.assertEqual(scope.round_robin_order(["a.py", "b.py"], positions), ["a.py", "b.py"])
+
+
+class QuietNightIsNotADegradedNightTest(unittest.TestCase):
+	"""Exit 3 means "we measured and got no verdict". Nothing else may borrow it."""
+
+	def setUp(self) -> None:
+		self._tmp = tempfile.TemporaryDirectory()
+		self.addCleanup(self._tmp.cleanup)
+		self.tmp = Path(self._tmp.name)
+
+	def write(self, records: list[dict], name: str) -> Path:
+		path = self.tmp / name
+		with open(path, "w", encoding="utf-8") as handle:
+			for record in records:
+				handle.write(json.dumps(record, sort_keys=True) + "\n")
+		return path
+
+	def report(self, journal: Path, **kwargs) -> tuple[int, str]:
+		with contextlib.redirect_stderr(io.StringIO()):
+			with contextlib.redirect_stdout(io.StringIO()) as out:
+				code = report_mod.report(journal_path=journal, fmt="json", **kwargs)
+		return code, out.getvalue()
+
+	def test_a_view_holding_only_a_skip_is_not_reported_as_degraded(self):
+		"""It used to exit 3, which the nightly renders as "a degraded run, not a result"."""
+		journal = self.write(
+			[{"key": "baseline:pkg/a.py", "module": "pkg/a.py", "status": config.STATUS_BASELINE_SKIP}],
+			"journal.jsonl",
+		)
+		code, _stdout = self.report(journal)
+		self.assertEqual(code, report_mod.EXIT_NOTHING_TO_REPORT)
+		self.assertNotEqual(code, report_mod.EXIT_NOTHING_MEASURED)
+
+	def test_a_view_where_mutants_ran_and_none_scored_is_still_degraded(self):
+		"""The distinction has to cut both ways or exit 3 stops meaning anything."""
+		journal = self.write(
+			[{"key": "k1", "module": "pkg/a.py", "status": config.STATUS_TIMEOUT}], "journal.jsonl"
+		)
+		code, _stdout = self.report(journal)
+		self.assertEqual(code, report_mod.EXIT_NOTHING_MEASURED)
+
+	def test_the_summary_is_rendered_even_when_there_is_nothing_to_report(self):
+		"""Both gates parse this JSON; a step that prints nothing makes them guess."""
+		journal = self.write([], "empty.jsonl")
+		code, stdout = self.report(journal)
+		self.assertEqual(code, report_mod.EXIT_NOTHING_TO_REPORT)
+		self.assertEqual(json.loads(stdout)["skipped_modules"], {})
+
+	def test_a_skip_only_view_still_names_the_module_in_the_json(self):
+		"""Exit 5 must not mean "silent": the pull-request gate reads skips out of this."""
+		journal = self.write(
+			[
+				{
+					"key": "baseline:pkg/a.py",
+					"module": "pkg/a.py",
+					"status": config.STATUS_MODULE_SKIP,
+					"reason": "renamed away",
+				}
+			],
+			"journal.jsonl",
+		)
+		_code, stdout = self.report(journal)
+		self.assertEqual(list(json.loads(stdout)["skipped_modules"]), ["pkg/a.py"])
+
+	def test_an_empty_render_says_so_rather_than_printing_zeros(self):
+		summary = report_mod.summarise([])
+		self.assertIn("Nothing to report", report_mod.render_markdown(summary))
+		self.assertIn("Nothing to report", report_mod.render_text(summary))
+		self.assertNotIn("NOTHING MEASURED", report_mod.render_text(summary))
+
+
+class WorkDoneTest(unittest.TestCase):
+	"""What a run DID, which a report of what it DECIDED cannot express.
+
+	A night that re-measures 431 mutants because one test file was touched, and confirms
+	every verdict, decides nothing: ``--new-since`` filters all of it and the summary says
+	"nothing new". So does a night whose campaign died in provisioning. Truthful about
+	verdicts, useless about work - and the second one is the one somebody has to act on.
+	"""
+
+	def setUp(self) -> None:
+		self._tmp = tempfile.TemporaryDirectory()
+		self.addCleanup(self._tmp.cleanup)
+		self.tmp = Path(self._tmp.name)
+
+	def write(self, name: str, records: list[dict]) -> Path:
+		path = self.tmp / name
+		with open(path, "w", encoding="utf-8") as handle:
+			for record in records:
+				handle.write(json.dumps(record, sort_keys=True) + "\n")
+		return path
+
+	def mutant(self, key: str, module: str) -> dict:
+		return {"key": key, "module": module, "status": config.STATUS_KILLED}
+
+	def test_it_counts_the_mutants_a_run_appended(self):
+		before = self.write("before.jsonl", [self.mutant("k0", "pkg/a.py")])
+		journal = self.write(
+			"journal.jsonl",
+			[self.mutant("k0", "pkg/a.py"), self.mutant("k1", "pkg/a.py"), self.mutant("k2", "pkg/b.py")],
+		)
+		work = report_mod.work_done(journal, before)
+		self.assertEqual(work["evaluated"], 2)
+		self.assertEqual(work["modules"], ["pkg/a.py", "pkg/b.py"])
+
+	def test_a_re_measured_verdict_that_did_not_change_still_counts_as_work(self):
+		"""The exact case: 431 mutants re-measured, every verdict identical, report empty."""
+		records = [self.mutant("k1", "pkg/a.py")]
+		before = self.write("before.jsonl", records)
+		journal = self.write("journal.jsonl", records + records)
+
+		self.assertEqual(report_mod.only_new_since(report_mod.load_results(journal), before), [])
+		self.assertEqual(report_mod.work_done(journal, before)["evaluated"], 1)
+
+	def test_module_level_records_are_not_counted_as_mutants(self):
+		before = self.write("before.jsonl", [])
+		journal = self.write(
+			"journal.jsonl",
+			[{"key": "baseline:pkg/a.py", "module": "pkg/a.py", "status": config.STATUS_MODULE_CURRENT}],
+		)
+		work = report_mod.work_done(journal, before)
+		self.assertEqual(work["evaluated"], 0)
+		self.assertEqual(work["modules"], [])
+
+	def test_a_skipped_module_is_named(self):
+		before = self.write("before.jsonl", [])
+		journal = self.write(
+			"journal.jsonl",
+			[{"key": "baseline:pkg/a.py", "module": "pkg/a.py", "status": config.STATUS_BASELINE_SKIP}],
+		)
+		self.assertEqual(report_mod.work_done(journal, before)["skipped"], ["pkg/a.py"])
+
+	def test_a_replaced_journal_is_reported_as_unknown_rather_than_guessed(self):
+		before = self.write("before.jsonl", [self.mutant("k1", "pkg/a.py")] * 3)
+		journal = self.write("journal.jsonl", [self.mutant("k1", "pkg/a.py")])
+		self.assertTrue(report_mod.work_done(journal, before)["unknown"])
+		self.assertIn("unknown", report_mod.render_work(report_mod.work_done(journal, before)))
+
+	def test_a_run_that_evaluated_nothing_says_so_in_words(self):
+		before = self.write("before.jsonl", [])
+		journal = self.write("journal.jsonl", [])
+		self.assertIn(
+			"no mutant was evaluated", report_mod.render_work(report_mod.work_done(journal, before))
+		)
+
+	def test_the_line_names_the_modules_it_covered(self):
+		before = self.write("before.jsonl", [])
+		journal = self.write("journal.jsonl", [self.mutant("k1", "pkg/a.py")])
+		line = report_mod.render_work(report_mod.work_done(journal, before))
+		self.assertIn("1 mutant(s) evaluated", line)
+		self.assertIn("pkg/a.py", line)
+
+	def test_the_cli_prints_it_and_never_gates_on_it(self):
+		before = self.write("before.jsonl", [])
+		journal = self.write("journal.jsonl", [self.mutant("k1", "pkg/a.py")])
+		with contextlib.redirect_stdout(io.StringIO()) as out:
+			code = cli.main(["work", "--journal", str(journal), "--since", str(before)])
+		self.assertEqual(code, 0)
+		self.assertIn("1 mutant(s) evaluated", out.getvalue())
+
+
+class StaleProvenanceIsMarkedTest(unittest.TestCase):
+	"""A score computed from verdicts whose tests have moved has to SAY so.
+
+	Invalidation drives re-measurement but did not reach the report. A test edit invalidates
+	a whole module at once and a big one takes several budgeted nights to work through, so
+	for those nights the published headline is computed entirely from verdicts the harness
+	has itself flagged as describing a suite that no longer exists - with no marker, while
+	a red baseline gets an explicit "STALE:".
+	"""
+
+	def records(self, sha: str | None) -> list[dict]:
+		record = {"key": "k1", "module": "pkg/a.py", "file": "pkg/a.py", "status": config.STATUS_KILLED}
+		if sha is not None:
+			record["tests_sha"] = sha
+		return [record]
+
+	def test_verdicts_from_the_current_tests_are_not_marked(self):
+		summary = report_mod.summarise(self.records("aaa"), fingerprints={"pkg/a.py": "aaa"})
+		self.assertEqual(summary["modules"]["pkg/a.py"]["provenance"], "current")
+		self.assertEqual(summary["stale_test_modules"], [])
+
+	def test_verdicts_from_edited_tests_are_marked_stale(self):
+		summary = report_mod.summarise(self.records("aaa"), fingerprints={"pkg/a.py": "CHANGED"})
+		self.assertEqual(summary["modules"]["pkg/a.py"]["provenance"], "stale")
+		self.assertEqual(summary["stale_test_modules"], ["pkg/a.py"])
+
+	def test_verdicts_with_no_provenance_at_all_are_marked_too(self):
+		"""A pre-fingerprint journal cannot show what produced its numbers."""
+		summary = report_mod.summarise(self.records(None), fingerprints={"pkg/a.py": "aaa"})
+		self.assertEqual(summary["modules"]["pkg/a.py"]["provenance"], "unknown")
+
+	def test_a_partially_re_measured_module_is_still_stale(self):
+		records = self.records("aaa") + [
+			{"key": "k2", "module": "pkg/a.py", "status": config.STATUS_KILLED, "tests_sha": "NEW"}
+		]
+		summary = report_mod.summarise(records, fingerprints={"pkg/a.py": "NEW"})
+		self.assertEqual(summary["modules"]["pkg/a.py"]["provenance"], "stale")
+
+	def test_without_fingerprints_no_claim_is_made_either_way(self):
+		summary = report_mod.summarise(self.records("aaa"))
+		self.assertNotIn("provenance", summary["modules"]["pkg/a.py"])
+		self.assertEqual(summary["stale_test_modules"], [])
+
+	def test_both_renderers_show_the_marker(self):
+		summary = report_mod.summarise(self.records("aaa"), fingerprints={"pkg/a.py": "CHANGED"})
+		self.assertIn("STALE", report_mod.render_text(summary))
+		self.assertIn("stale: tests changed", report_mod.render_markdown(summary))
+
+	def test_the_two_kinds_of_staleness_do_not_share_a_sentence(self):
+		""" "edited since this was measured" and "nothing says what measured it" differ."""
+		edited = report_mod.provenance_note("stale")
+		unknown = report_mod.provenance_note("unknown")
+		self.assertNotEqual(edited, unknown)
+		self.assertIn("tests changed", edited)
+		self.assertIn("no record", unknown)
+
+	def test_the_score_itself_is_unchanged_by_the_marker(self):
+		"""It annotates the number; suppressing it would be worse than publishing it."""
+		summary = report_mod.summarise(self.records("aaa"), fingerprints={"pkg/a.py": "CHANGED"})
+		self.assertEqual(summary["overall"]["score"], 1.0)
+
+	def test_a_tree_it_cannot_fingerprint_degrades_to_no_marker(self):
+		with mock.patch.object(scope, "test_fingerprint", side_effect=OSError("no tree")):
+			self.assertEqual(report_mod.current_fingerprints(), {})
+
+	def test_the_real_target_map_is_what_gets_fingerprinted(self):
+		fingerprints = report_mod.current_fingerprints()
+		self.assertEqual(set(fingerprints), set(config.target_map("all")))
+
+
+class SharedTestInfrastructureTest(unittest.TestCase):
+	"""The fingerprint has to cover the files the mapped tests get their assertions from.
+
+	``assert_allowed``/``assert_not_allowed`` live in ``gameplan/tests/base.py`` and the
+	personas in ``gameplan/tests/fixtures.py``. Gut one of those and every permission test
+	still passes, asserting nothing - while no mapped test file's bytes moved, so a
+	fingerprint over the mapped files alone does not move either, every verdict stays
+	settled, the module short-circuits before its baseline and the nightly republishes
+	yesterday's score having run nothing. That is the failure the fingerprint exists to
+	prevent, reachable one import away from where it was fixed.
+	"""
+
+	def setUp(self) -> None:
+		self._tmp = tempfile.TemporaryDirectory()
+		self.addCleanup(self._tmp.cleanup)
+		self.root = Path(self._tmp.name)
+		self.write("gameplan/tests/__init__.py", "")
+		self.write("gameplan/tests/base.py", "def assert_not_allowed(x):\n\tassert not x\n")
+		self.write("gameplan/tests/fixtures.py", "def create_space():\n\treturn 1\n")
+		self.write(
+			"gameplan/tests/features/__init__.py",
+			"",
+		)
+		self.write(
+			"gameplan/tests/features/test_alpha.py",
+			"from gameplan.tests.base import assert_not_allowed\n"
+			"from gameplan.tests.fixtures import create_space\n",
+		)
+		self.mapped = ["gameplan.tests.features.test_alpha"]
+
+	def write(self, relative: str, body: str) -> Path:
+		path = self.root / relative
+		path.parent.mkdir(parents=True, exist_ok=True)
+		path.write_text(body, encoding="utf-8")
+		return path
+
+	def test_weakening_a_shared_assertion_helper_moves_the_fingerprint(self):
+		before = scope.test_fingerprint(self.mapped, self.root)
+		self.write("gameplan/tests/base.py", "def assert_not_allowed(x):\n\tpass\n")
+		self.assertNotEqual(before, scope.test_fingerprint(self.mapped, self.root))
+
+	def test_changing_a_shared_fixture_moves_it_too(self):
+		before = scope.test_fingerprint(self.mapped, self.root)
+		self.write("gameplan/tests/fixtures.py", "def create_space():\n\treturn 2\n")
+		self.assertNotEqual(before, scope.test_fingerprint(self.mapped, self.root))
+
+	def test_package_level_setup_is_covered(self):
+		"""Importing a test module executes it, so it decides what the tests do."""
+		before = scope.test_fingerprint(self.mapped, self.root)
+		self.write("gameplan/tests/__init__.py", "# search isolation disabled\n")
+		self.assertNotEqual(before, scope.test_fingerprint(self.mapped, self.root))
+
+	def test_it_follows_imports_transitively(self):
+		self.write(
+			"gameplan/tests/base.py",
+			"from gameplan.tests.search_isolation import guard\n\n"
+			"def assert_not_allowed(x):\n\tassert not x\n",
+		)
+		self.write("gameplan/tests/search_isolation.py", "def guard():\n\treturn 1\n")
+		before = scope.test_fingerprint(self.mapped, self.root)
+		self.write("gameplan/tests/search_isolation.py", "def guard():\n\treturn 2\n")
+		self.assertNotEqual(before, scope.test_fingerprint(self.mapped, self.root))
+
+	def test_production_code_is_not_in_the_fingerprint(self):
+		"""The boundary, and it is load-bearing: a corpus that goes stale on any source
+		edit is never settled long enough to be measured at all."""
+		self.write("gameplan/permissions.py", "def check():\n\treturn 1\n")
+		self.write(
+			"gameplan/tests/features/test_alpha.py",
+			"from gameplan.permissions import check\nfrom gameplan.tests.base import assert_not_allowed\n",
+		)
+		before = scope.test_fingerprint(self.mapped, self.root)
+		self.write("gameplan/permissions.py", "def check():\n\treturn 2\n")
+		self.assertEqual(before, scope.test_fingerprint(self.mapped, self.root))
+
+	def test_an_unrelated_test_module_is_not_in_the_fingerprint(self):
+		self.write("gameplan/tests/features/test_other.py", "x = 1\n")
+		before = scope.test_fingerprint(self.mapped, self.root)
+		self.write("gameplan/tests/features/test_other.py", "x = 2\n")
+		self.assertEqual(before, scope.test_fingerprint(self.mapped, self.root))
+
+	def test_a_diff_touching_a_shared_helper_selects_the_targets_it_invalidates(self):
+		"""Or the pull-request job maps the one edit that matters to zero targets."""
+		targets = {"pkg/alpha.py": self.mapped}
+		selected = scope.changed_targets(["gameplan/tests/base.py"], targets, self.root)
+		self.assertEqual(list(selected), ["pkg/alpha.py"])
+
+	def test_scope_and_fingerprint_agree_against_the_real_tree(self):
+		"""One check against reality: base.py really is shared by every real target."""
+		real = config.target_map("all")
+		selected = scope.changed_targets(["gameplan/tests/base.py"], real, Path(config.APP_ROOT))
+		self.assertEqual(list(selected), list(real), "base.py must invalidate every target")
+
+	def test_the_real_closure_includes_the_assertion_helpers(self):
+		closure = scope._support_closure(
+			["gameplan.tests.permissions.test_visibility"], Path(config.APP_ROOT)
+		)
+		self.assertIn("gameplan.tests.base", closure)
+		self.assertIn("gameplan.tests.fixtures", closure)
+		self.assertIn("gameplan.tests", closure)
+
+
+class PruneAgainstAMutatedTreeTest(unittest.TestCase):
+	"""Pruning asks the source "does this site still exist?"; a mutant makes it lie.
+
+	Mutant keys carry a fingerprint of their enclosing scope, so ONE applied mutant re-keys
+	every site in that function. If a run is SIGKILLed with a mutant on disk, the
+	``if: always()`` report step prunes against that tree and silently deletes real
+	verdicts - measured at 12 of 72 keys for one mutant in reactions.py - describing them
+	as "sites that no longer exist".
+	"""
+
+	SOURCE = "def f(a, b):\n\treturn a > b\n"
+
+	def setUp(self) -> None:
+		self._tmp = tempfile.TemporaryDirectory()
+		self.addCleanup(self._tmp.cleanup)
+		self.root = Path(self._tmp.name)
+		(self.root / "pkg").mkdir()
+		(self.root / "pkg" / "a.py").write_text(self.SOURCE, encoding="utf-8")
+
+	def test_records_of_a_file_left_mutated_are_kept(self):
+		record = {"key": "a-key-from-the-unmutated-file", "module": "pkg/a.py", "file": "pkg/a.py"}
+		kept, dropped = report_mod.drop_stale_sites([record], self.root, unreadable_files={"pkg/a.py"})
+		self.assertEqual(kept, [record])
+		self.assertEqual(dropped, 0)
+
+	def test_other_files_are_still_pruned(self):
+		"""Refusing to prune anything at all would let a real refactor inflate the score."""
+		(self.root / "pkg" / "b.py").write_text(self.SOURCE, encoding="utf-8")
+		record = {"key": "stale", "module": "pkg/b.py", "file": "pkg/b.py"}
+		kept, dropped = report_mod.drop_stale_sites([record], self.root, unreadable_files={"pkg/a.py"})
+		self.assertEqual(kept, [])
+		self.assertEqual(dropped, 1)
+
+	def test_a_clean_tree_names_no_unreadable_file(self):
+		with mock.patch.object(safety, "find_orphaned_backups", return_value=[]):
+			self.assertEqual(report_mod.mutated_files(self.root), set())
+
+	def test_a_crashed_run_names_the_file_it_left_mutated(self):
+		manifest = {"path": str(self.root / "pkg" / "a.py")}
+		with mock.patch.object(safety, "find_orphaned_backups", return_value=[manifest]):
+			with mock.patch.object(safety, "orphan_state", return_value="mutated"):
+				self.assertEqual(report_mod.mutated_files(self.root), {"pkg/a.py"})
+
+	def test_an_already_restored_backup_does_not_block_pruning(self):
+		manifest = {"path": str(self.root / "pkg" / "a.py")}
+		with mock.patch.object(safety, "find_orphaned_backups", return_value=[manifest]):
+			with mock.patch.object(safety, "orphan_state", return_value="clean"):
+				self.assertEqual(report_mod.mutated_files(self.root), set())
+
+	def test_a_broken_safety_layer_never_stops_a_report(self):
+		with mock.patch.object(safety, "find_orphaned_backups", side_effect=OSError("no /proc")):
+			self.assertEqual(report_mod.mutated_files(self.root), set())
+
+
+class CacheIdentityTest(unittest.TestCase):
+	"""The two workflows' cache path lists are one string, not two.
+
+	``actions/cache`` derives a cache entry's version from the raw ``path`` input, so a
+	restore only matches entries saved under the same list, byte for byte. The nightly
+	saves; the pull-request job restores from the same lineage. Add a third journal file to
+	one of them, or reorder the two lines, and every pull request misses the seed silently -
+	it just measures from scratch on a 600-second budget, stays green, and prints the same
+	"No seed journal" line a legitimate first run prints.
+	"""
+
+	def setUp(self) -> None:
+		self.nightly = _workflow(NIGHTLY_WORKFLOW)
+		self.pr = _workflow(PR_WORKFLOW)
+
+	def restore_paths(self, workflow: dict) -> list[str]:
+		steps = [s for s in _mutation_cache_steps(workflow) if "restore" in s["uses"]]
+		self.assertEqual(len(steps), 1)
+		return _cached_entries(steps[0])
+
+	def test_the_pull_request_restores_exactly_what_the_nightly_saves(self):
+		saves = [s for s in _mutation_cache_steps(self.nightly) if "save" in s["uses"]]
+		self.assertEqual(len(saves), 1)
+		self.assertEqual(self.restore_paths(self.pr), _cached_entries(saves[0]))
+
+	def test_the_two_restore_lists_are_identical_including_order(self):
+		self.assertEqual(self.restore_paths(self.pr), self.restore_paths(self.nightly))
+
+	def test_both_files_say_why_the_list_may_not_drift(self):
+		"""A comment is the only thing between this and a silent regression."""
+		for path in (NIGHTLY_WORKFLOW, PR_WORKFLOW):
+			text = path.read_text(encoding="utf-8")
+			self.assertIn("identity", text.lower())
+
+
+class PullRequestGateTest(unittest.TestCase):
+	"""What the pull-request job is allowed to turn red, and for whose module."""
+
+	def setUp(self) -> None:
+		self.pr = _workflow(PR_WORKFLOW)
+		self.gate = next(
+			step["run"] for step in _steps(self.pr) if step.get("name") == "Gate on the mutation signal"
+		)
+
+	def test_the_skip_gate_is_restricted_to_this_pull_request_s_targets(self):
+		"""The report covers the whole seeded journal; the gate must not blame the diff.
+
+		A module the nightly currently cannot measure appears in a report seeded from the
+		nightly's journal. Failing the pull request for it names a file the author never
+		touched, with a reason from another day - which is how a gate gets ignored.
+		"""
+		self.assertIn("needs.scope.outputs.targets", self.gate)
+		self.assertIn("if m in t", self.gate)
+
+	def test_it_fails_when_every_mutant_it_ran_produced_a_non_verdict(self):
+		"""The nightly is red for this; the pull-request job used to be green."""
+		self.assertIn('json-status }}" = "3"', self.gate)
+		self.assertIn("non-verdict", self.gate)
+
+	def test_it_does_not_fail_merely_because_there_was_nothing_to_report(self):
+		"""Exit 5 is the ordinary outcome of a settled diff, not a broken signal."""
+		self.assertNotIn('= "5"', self.gate)
+
+	def test_it_still_reads_the_summary_whatever_the_report_exit_code_was(self):
+		"""The report renders on every path now, so an unparseable one is a real failure."""
+		self.assertIn("no readable summary", self.gate)
+
+
+class NightlySummaryHonestyTest(unittest.TestCase):
+	"""A night that ground for 45 minutes must not render as an idle one."""
+
+	def setUp(self) -> None:
+		self.nightly = _workflow(NIGHTLY_WORKFLOW)
+		self.publish = next(
+			step["run"] for step in _steps(self.nightly) if step.get("name") == "Publish the report"
+		)
+		self.gate = next(
+			step["run"] for step in _steps(self.nightly) if step.get("name") == "Gate on the mutation signal"
+		)
+
+	def test_the_summary_reports_the_work_the_night_did(self):
+		self.assertIn("mutation work", self.publish)
+		self.assertIn('echo "${work}"', self.publish)
+
+	def test_the_rendered_report_is_printed_on_every_path(self):
+		"""The 'degraded' arm used to discard the only place a skipped module is named."""
+		self.assertEqual(self.publish.count('cat "${RUNNER_TEMP}/tonight.md"'), 1)
+		arms = self.publish.split('case "${tonight_status}"')[1]
+		self.assertNotIn('cat "${RUNNER_TEMP}/tonight.md"', arms.split("esac")[0])
+
+	def test_the_quiet_night_arm_does_not_call_it_degraded(self):
+		arm = self.publish[self.publish.index("5)") : self.publish.index(";;", self.publish.index("5)"))]
+		self.assertNotIn("degraded", arm)
+		self.assertIn("no verdict changed", arm)
+
+	def test_the_exit_three_gate_names_the_causes_it_cannot_distinguish(self):
+		"""The fix the pull-request job got and this one did not.
+
+		Budget-expired-inside-a-baseline-pass became a reachable cause of exit 3 once the
+		exit rules started firing on "budget stopped and nothing evaluated", and this arm
+		asserted a different one as fact.
+		"""
+		arm = self.gate[self.gate.index("3)") : self.gate.index(";;", self.gate.index("3)"))]
+		for cause in ("red baseline", "missing source", "budget expired"):
+			self.assertIn(cause, arm)
+		self.assertNotIn("the signal is broken", arm)
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/gameplan/tests/platform/test_mutation_classification.py
+++ b/gameplan/tests/platform/test_mutation_classification.py
@@ -1,0 +1,312 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# MIT License. See license.txt
+
+"""Unit tests for the mutation harness's outcome classification.
+
+These pin the one rule the harness's usefulness rests on: a "kill" is a claim that the
+TEST SUITE detected the mutation. A timeout, a wedged site, a broken venv, a runner that
+died halfway through - none of those are the suite making a judgement, so none of them
+may be scored as a kill, and all of them must be retried rather than cached.
+
+Every bug these tests were written for scored an infrastructure failure as coverage,
+which inflates the mutation score toward 100% and then caches the lie in the journal
+forever. Deliberately no site, no bench, no subprocess: ``RunResult`` is a plain
+dataclass over captured output, so classification is pure and must stay that way.
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+from gameplan.tests.mutation import campaign, config
+from gameplan.tests.mutation.runner import RunResult
+
+MUTATED_FILE = "gameplan/email_digest.py"
+OTHER_FILE = "gameplan/api.py"
+
+
+def result(output: str = "", returncode: int = 0, timed_out: bool = False) -> RunResult:
+	return RunResult(returncode=returncode, output=output, duration_s=1.0, timed_out=timed_out)
+
+
+# --- captured output shapes -------------------------------------------------------
+# Trimmed from real `bench run-tests` output; the parts the classifier reads are exact.
+
+PASSING = """\
+Running 6 old-frappe-test-class-category tests for gameplan
+
+gameplan.tests.features.test_email_digest.TestEmailDigest
+    test_digest_groups_by_space
+----------------------------------------------------------------------
+Ran 6 tests in 3.212s
+
+OK
+"""
+
+FAILING = """\
+Running 6 old-frappe-test-class-category tests for gameplan
+
+======================================================================
+ FAIL  test_digest_groups_by_space
+----------------------------------------------------------------------
+Traceback (most recent call last):
+  File "/home/f/frappe-bench/apps/gameplan/gameplan/tests/features/test_email_digest.py", line 88
+    self.assertEqual(len(items), 2)
+AssertionError: 0 != 2
+
+----------------------------------------------------------------------
+Ran 6 tests in 3.400s
+
+FAILED (failures=1)
+"""
+
+PASSING_WITH_SKIPS = PASSING.replace("OK\n", "OK (skipped=2)\n")
+
+# The mutant made its own module unparseable, so the test module could not be imported.
+MUTANT_BROKE_ITS_MODULE = """\
+Traceback (most recent call last):
+  File "/home/f/frappe-bench/apps/gameplan/gameplan/tests/features/test_email_digest.py", line 12
+    from gameplan.email_digest import EmailDigest
+  File "/home/f/frappe-bench/apps/gameplan/gameplan/email_digest.py", line 411
+    return None None
+           ^^^^^^^^^
+SyntaxError: invalid syntax
+"""
+
+# Same family of words, nothing whatsoever to do with the mutant: a broken environment.
+BROKEN_VENV = """\
+Traceback (most recent call last):
+  File "/home/f/frappe-bench/env/bin/bench", line 5, in <module>
+    from bench.cli import cli
+ModuleNotFoundError: No module named 'frappe'
+"""
+
+# bench never got as far as loading anything.
+SITE_LOCKED = """\
+Site gp-sqlite.test is currently in maintenance/locked state.
+"""
+
+# One suite finished, then the process was killed before the next one reported.
+DIED_MID_RUN = """\
+Running 12 unit tests for gameplan
+----------------------------------------------------------------------
+Ran 12 tests in 4.100s
+
+OK
+
+Running 533 integration tests for gameplan
+sqlite3.OperationalError: database is locked
+Killed
+"""
+
+# A real assertion failure that happens to print the word "ImportError" in a captured
+# log line. The old substring scan filed this as killed-import-error.
+FAILING_MENTIONING_IMPORTERROR = FAILING.replace(
+	"AssertionError: 0 != 2",
+	"AssertionError: 'ImportError' != 'ok'",
+)
+
+
+class TestClassify(unittest.TestCase):
+	"""campaign.classify maps one run outcome to one mutant status."""
+
+	def test_clean_pass_is_a_survivor(self):
+		self.assertEqual(
+			campaign.classify(result(PASSING, returncode=0), MUTATED_FILE),
+			config.STATUS_SURVIVED,
+		)
+
+	def test_pass_with_skips_is_a_survivor(self):
+		self.assertEqual(
+			campaign.classify(result(PASSING_WITH_SKIPS, returncode=0), MUTATED_FILE),
+			config.STATUS_SURVIVED,
+		)
+
+	def test_genuine_test_failure_is_a_kill(self):
+		self.assertEqual(
+			campaign.classify(result(FAILING, returncode=1), MUTATED_FILE),
+			config.STATUS_KILLED,
+		)
+
+	def test_failure_output_mentioning_importerror_is_still_an_ordinary_kill(self):
+		"""Tests ran and the suite said FAILED; the word in a log line is irrelevant."""
+		status = campaign.classify(result(FAILING_MENTIONING_IMPORTERROR, returncode=1), MUTATED_FILE)
+		self.assertEqual(status, config.STATUS_KILLED)
+
+	def test_timeout_is_never_a_kill(self):
+		status = campaign.classify(result("", returncode=None, timed_out=True), MUTATED_FILE)
+		self.assertEqual(status, config.STATUS_TIMEOUT)
+		self.assertNotIn(status, config.KILLED_STATUSES)
+		self.assertIn(status, config.NO_VERDICT_STATUSES)
+		self.assertIn(status, config.RETRYABLE_STATUSES)
+
+	def test_timeout_wins_over_every_other_signal(self):
+		"""Partial output captured before the kill must not promote a timeout to a kill."""
+		for output in (PASSING, FAILING, MUTANT_BROKE_ITS_MODULE, DIED_MID_RUN, BROKEN_VENV):
+			with self.subTest(output=output.splitlines()[0]):
+				status = campaign.classify(result(output, returncode=None, timed_out=True), MUTATED_FILE)
+				self.assertEqual(status, config.STATUS_TIMEOUT)
+
+	def test_zero_tests_and_no_explanation_is_infra(self):
+		status = campaign.classify(result(SITE_LOCKED, returncode=1), MUTATED_FILE)
+		self.assertEqual(status, config.STATUS_INFRA_ERROR)
+		self.assertNotIn(status, config.KILLED_STATUSES)
+
+	def test_infra_crash_mentioning_importerror_is_not_a_kill(self):
+		"""A broken venv names no mutated file, so it proves nothing about the mutant."""
+		status = campaign.classify(result(BROKEN_VENV, returncode=1), MUTATED_FILE)
+		self.assertEqual(status, config.STATUS_INFRA_ERROR)
+		self.assertNotIn(status, config.KILLED_STATUSES)
+		self.assertIn(status, config.RETRYABLE_STATUSES)
+
+	def test_import_error_naming_the_mutated_file_is_a_kill(self):
+		status = campaign.classify(result(MUTANT_BROKE_ITS_MODULE, returncode=1), MUTATED_FILE)
+		self.assertEqual(status, config.STATUS_KILLED_IMPORT_ERROR)
+		self.assertIn(status, config.KILLED_STATUSES)
+
+	def test_import_error_naming_a_different_file_is_not_a_kill(self):
+		status = campaign.classify(result(MUTANT_BROKE_ITS_MODULE, returncode=1), OTHER_FILE)
+		self.assertEqual(status, config.STATUS_INFRA_ERROR)
+
+	def test_import_error_without_a_known_mutated_file_is_not_a_kill(self):
+		"""No attribution possible means no verdict, not a free kill."""
+		status = campaign.classify(result(MUTANT_BROKE_ITS_MODULE, returncode=1), None)
+		self.assertEqual(status, config.STATUS_INFRA_ERROR)
+
+	def test_infra_crash_after_a_partial_run_is_not_a_kill(self):
+		"""12 tests passed, then the process died. Nothing judged the mutant."""
+		status = campaign.classify(result(DIED_MID_RUN, returncode=-9), MUTATED_FILE)
+		self.assertEqual(status, config.STATUS_INCOMPLETE)
+		self.assertNotIn(status, config.KILLED_STATUSES)
+		self.assertIn(status, config.RETRYABLE_STATUSES)
+
+	def test_exit_zero_without_a_verdict_is_not_a_survivor(self):
+		"""A survivor is a claim of missing coverage; a suite that never ran is not."""
+		status = campaign.classify(result("bench: nothing to do\n", returncode=0), MUTATED_FILE)
+		self.assertEqual(status, config.STATUS_INFRA_ERROR)
+
+	def test_no_tests_ran_verdict_with_failure_exit_is_infra(self):
+		status = campaign.classify(result("Ran 0 tests in 0.000s\n\nNO TESTS RAN\n", 1), MUTATED_FILE)
+		self.assertEqual(status, config.STATUS_INFRA_ERROR)
+
+	def test_every_reachable_status_is_survived_killed_or_no_verdict(self):
+		cases = [
+			result(PASSING, 0),
+			result(PASSING_WITH_SKIPS, 0),
+			result(FAILING, 1),
+			result(MUTANT_BROKE_ITS_MODULE, 1),
+			result(BROKEN_VENV, 1),
+			result(SITE_LOCKED, 1),
+			result(DIED_MID_RUN, -9),
+			result("", None, timed_out=True),
+			result("", 0),
+			result("", 1),
+		]
+		buckets = config.KILLED_STATUSES | config.NO_VERDICT_STATUSES | {config.STATUS_SURVIVED}
+		for case in cases:
+			with self.subTest(rc=case.returncode, timed_out=case.timed_out):
+				self.assertIn(campaign.classify(case, MUTATED_FILE), buckets)
+
+
+class TestRunResultFacts(unittest.TestCase):
+	"""RunResult reports facts about the output; it must not editorialise."""
+
+	def test_tests_ran_sums_every_block(self):
+		self.assertEqual(result(DIED_MID_RUN).tests_ran, 12)
+		self.assertEqual(result(PASSING).tests_ran, 6)
+
+	def test_tests_ran_is_none_when_never_reported(self):
+		self.assertIsNone(result(BROKEN_VENV).tests_ran)
+
+	def test_reached_verdict_needs_the_runners_own_summary_line(self):
+		self.assertTrue(result(PASSING).reached_verdict)
+		self.assertTrue(result(FAILING).reached_verdict)
+		self.assertFalse(result(BROKEN_VENV).reached_verdict)
+		self.assertFalse(result(SITE_LOCKED).reached_verdict)
+
+	def test_suite_reported_failure_only_on_the_failed_summary_line(self):
+		self.assertTrue(result(FAILING).suite_reported_failure)
+		self.assertFalse(result(PASSING).suite_reported_failure)
+		# A completed suite followed by a dead process is not a reported failure.
+		self.assertFalse(result(DIED_MID_RUN).suite_reported_failure)
+		# Nor is the word appearing inside a traceback body.
+		self.assertFalse(result("  raise Exception('FAILED to connect')\n").suite_reported_failure)
+
+	def test_blames_file_matches_traceback_frames_not_arbitrary_text(self):
+		res = result(MUTANT_BROKE_ITS_MODULE)
+		self.assertTrue(res.blames_file(MUTATED_FILE))
+		self.assertFalse(res.blames_file(OTHER_FILE))
+		self.assertFalse(res.blames_file(None))
+
+	def test_mutant_broke_import_requires_zero_tests(self):
+		"""If tests executed, the module imported fine whatever the output says."""
+		output = FAILING + MUTANT_BROKE_ITS_MODULE
+		self.assertFalse(result(output, 1).mutant_broke_import(MUTATED_FILE))
+
+	def test_mutant_broke_import_requires_a_marker(self):
+		output = 'File "/home/f/frappe-bench/apps/gameplan/gameplan/email_digest.py", line 1\n'
+		self.assertFalse(result(output, 1).mutant_broke_import(MUTATED_FILE))
+
+
+class TestStatusVocabularyInvariants(unittest.TestCase):
+	"""The config sets are the harness's safety net. Guard their relationships."""
+
+	def all_statuses(self) -> set[str]:
+		return {value for name, value in vars(config).items() if name.startswith("STATUS_")}
+
+	def test_no_verdict_is_never_a_kill(self):
+		self.assertEqual(config.NO_VERDICT_STATUSES & config.KILLED_STATUSES, frozenset())
+
+	def test_no_verdict_never_reaches_the_score(self):
+		self.assertTrue(config.NO_VERDICT_STATUSES <= config.NON_SCORING_STATUSES)
+
+	def test_no_verdict_is_always_retried(self):
+		self.assertTrue(config.NO_VERDICT_STATUSES <= config.RETRYABLE_STATUSES)
+
+	def test_a_kill_is_never_retried_or_unscored(self):
+		self.assertEqual(config.KILLED_STATUSES & config.RETRYABLE_STATUSES, frozenset())
+		self.assertEqual(config.KILLED_STATUSES & config.NON_SCORING_STATUSES, frozenset())
+
+	def test_every_status_has_been_classified(self):
+		"""A new STATUS_* must be sorted into a bucket, not left to default to 'scored'."""
+		accounted = (
+			config.KILLED_STATUSES
+			| config.NO_VERDICT_STATUSES
+			| {config.STATUS_SURVIVED, config.STATUS_BASELINE_SKIP}
+		)
+		self.assertEqual(self.all_statuses() - accounted, set())
+
+	def test_legacy_killed_timeout_is_demoted_not_counted(self):
+		"""Journals written before timeouts were demoted must be re-evaluated, not scored."""
+		self.assertNotIn(config.STATUS_KILLED_TIMEOUT, config.KILLED_STATUSES)
+		self.assertIn(config.STATUS_KILLED_TIMEOUT, config.NO_VERDICT_STATUSES)
+		self.assertIn(config.STATUS_KILLED_TIMEOUT, config.RETRYABLE_STATUSES)
+
+
+class TestControlCheck(unittest.TestCase):
+	"""The verify stage only believes a full-suite kill if the suite is provably green."""
+
+	def _control(self, res: RunResult):
+		with mock.patch.object(campaign, "run_tests", return_value=res):
+			return campaign._control_ok("site", 60)
+
+	def test_green_control_is_healthy(self):
+		healthy, reason, _ = self._control(result(PASSING, 0))
+		self.assertTrue(healthy)
+		self.assertEqual(reason, "")
+
+	def test_red_control_is_unhealthy(self):
+		healthy, reason, _ = self._control(result(FAILING, 1))
+		self.assertFalse(healthy)
+		self.assertIn("RED", reason)
+
+	def test_timed_out_control_is_unhealthy(self):
+		healthy, reason, _ = self._control(result("", None, timed_out=True))
+		self.assertFalse(healthy)
+		self.assertIn("timed out", reason)
+
+	def test_control_that_ran_nothing_is_unhealthy(self):
+		healthy, reason, _ = self._control(result("bench: ok\n", 0))
+		self.assertFalse(healthy)
+		self.assertIn("never reported", reason)

--- a/gameplan/tests/platform/test_mutation_classification.py
+++ b/gameplan/tests/platform/test_mutation_classification.py
@@ -273,9 +273,27 @@ class TestStatusVocabularyInvariants(unittest.TestCase):
 		accounted = (
 			config.KILLED_STATUSES
 			| config.NO_VERDICT_STATUSES
-			| {config.STATUS_SURVIVED, config.STATUS_BASELINE_SKIP}
+			# MODULE_STATUSES, not SKIP_STATUSES: a module-level record can also say the
+			# opposite of a skip ("this module has a current score"), and that one is not
+			# a skip while still being unscoreable.
+			| config.MODULE_STATUSES
+			| {config.STATUS_SURVIVED}
 		)
 		self.assertEqual(self.all_statuses() - accounted, set())
+
+	def test_a_module_skip_is_never_scored_and_never_a_kill(self):
+		"""Skips describe a module, not a mutant: they must not reach either side of a ratio."""
+		self.assertEqual(config.SKIP_STATUSES & config.KILLED_STATUSES, frozenset())
+		self.assertEqual(config.SKIP_STATUSES & config.NO_VERDICT_STATUSES, frozenset())
+		self.assertEqual(config.SKIP_STATUSES & config.RETRYABLE_STATUSES, frozenset())
+
+	def test_every_module_level_record_is_unscoreable(self):
+		"""Same rule for the record that CLEARS a skip: it is a statement, not a mutant."""
+		self.assertTrue(config.SKIP_STATUSES <= config.MODULE_STATUSES)
+		self.assertIn(config.STATUS_MODULE_CURRENT, config.MODULE_STATUSES)
+		self.assertEqual(config.MODULE_STATUSES & config.KILLED_STATUSES, frozenset())
+		self.assertEqual(config.MODULE_STATUSES & config.NO_VERDICT_STATUSES, frozenset())
+		self.assertEqual(config.MODULE_STATUSES & config.RETRYABLE_STATUSES, frozenset())
 
 	def test_legacy_killed_timeout_is_demoted_not_counted(self):
 		"""Journals written before timeouts were demoted must be re-evaluated, not scored."""

--- a/gameplan/tests/platform/test_mutation_cli.py
+++ b/gameplan/tests/platform/test_mutation_cli.py
@@ -30,10 +30,11 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
-from gameplan.tests.mutation import campaign, cli, mutators, safety
+from gameplan.tests.mutation import campaign, cli, mutators, safety, scope
 from gameplan.tests.mutation import report as report_mod
 from gameplan.tests.mutation.config import (
 	JOURNAL_PATH,
+	MODULE_STATUSES,
 	STATUS_KILLED,
 	STATUS_TIMEOUT,
 	VERIFY_PATH,
@@ -246,6 +247,14 @@ class CampaignLoopTestCase(unittest.TestCase):
 			encoding="utf-8",
 		)
 
+	def fingerprint(self, test_modules: list[str]) -> str:
+		"""What the campaign stamps on a verdict, for journals a test writes by hand.
+
+		A verdict is only settled while the tests behind it are unchanged, so a hand-written
+		record without this is stale by construction and would be re-measured.
+		"""
+		return scope.test_fingerprint(test_modules, self.app_root)
+
 	def journal_records(self) -> list[dict]:
 		if not self.journal.exists():
 			return []
@@ -309,7 +318,9 @@ class CampaignOrderingTest(CampaignLoopTestCase):
 		self.run_campaign({"pkg/compare.py": ["tests.test_compare"]})
 
 		expected = {s.key for s in mutators.collect_sites(ORIGINAL, "pkg/compare.py")}
-		journalled = {r["key"] for r in self.journal_records()}
+		# Mutant records only. A campaign also journals statements about the MODULE under
+		# a fixed "baseline:<path>" key, which is not a site and has no content hash.
+		journalled = {r["key"] for r in self.journal_records() if r["status"] not in MODULE_STATUSES}
 		self.assertTrue(journalled)
 		self.assertTrue(journalled <= expected)
 
@@ -320,7 +331,13 @@ class CampaignOrderingTest(CampaignLoopTestCase):
 		with open(self.journal, "w", encoding="utf-8") as handle:
 			for site in sites:
 				record = site.to_dict()
-				record.update({"module": "pkg/compare.py", "status": STATUS_KILLED})
+				record.update(
+					{
+						"module": "pkg/compare.py",
+						"status": STATUS_KILLED,
+						"tests_sha": self.fingerprint(["tests.test_compare"]),
+					}
+				)
 				handle.write(json.dumps(record, sort_keys=True) + "\n")
 		self.plant_crashed_run(path, ORIGINAL, LEFTOVER_MUTANT)
 

--- a/gameplan/tests/platform/test_mutation_cli.py
+++ b/gameplan/tests/platform/test_mutation_cli.py
@@ -1,0 +1,409 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# MIT License. See license.txt
+
+"""Unit tests for the mutation harness's CI boundary.
+
+Everything here guards one rule: the harness must never signal success for a run in
+which it measured nothing. That rule is enforced in three places, all covered below.
+
+* ``cli`` argument wiring - ``verify`` used to ignore ``--journal`` when choosing where
+  to write stage-2 verdicts, so an alternate campaign's results were invisible to its
+  own report and quietly overwrote the default campaign's.
+* ``campaign`` exit codes - a run that skipped every module on a red baseline exited 0,
+  so a nightly with a dead site reported success having evaluated zero mutants.
+* ``campaign`` per-module setup order - the ``FileGuard`` was built and the baseline run
+  *before* ``install_backup``, which is the only thing that undoes a crashed run's
+  leftover mutant. Sites were therefore collected from mutated source, and a module with
+  nothing pending returned without ever calling it, leaving the mutant on disk.
+
+Pure unit tests: a synthetic source tree in a tempdir, no bench and no site.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from gameplan.tests.mutation import campaign, cli, mutators, safety
+from gameplan.tests.mutation import report as report_mod
+from gameplan.tests.mutation.config import (
+	JOURNAL_PATH,
+	STATUS_KILLED,
+	STATUS_TIMEOUT,
+	VERIFY_PATH,
+)
+
+# Small but real: collect_sites must find several mutable sites in it, and the mutant
+# below has to be a plausible thing for a crashed run to have left behind.
+ORIGINAL = "def compare(a, b):\n\tif a > b:\n\t\treturn True\n\treturn False\n"
+LEFTOVER_MUTANT = "def compare(a, b):\n\tif a >= b:\n\t\treturn True\n\treturn False\n"
+
+
+class MutationCliWiringTest(unittest.TestCase):
+	"""``main`` must hand each subcommand the paths its flags actually named."""
+
+	def setUp(self) -> None:
+		self._tmp = tempfile.TemporaryDirectory()
+		self.addCleanup(self._tmp.cleanup)
+		self.tmp = Path(self._tmp.name)
+
+	def call(self, argv: list[str], target: str, module=campaign, returns: int = 0) -> dict:
+		"""Run ``main(argv)``, capturing the keyword arguments it passed to ``target``."""
+		with mock.patch.object(module, target, return_value=returns) as stub:
+			with contextlib.redirect_stdout(io.StringIO()):
+				code = cli.main(argv)
+		stub.assert_called_once()
+		self.assertEqual(code, returns)
+		return stub.call_args.kwargs
+
+	# --- verify writes where report reads ----------------------------------------
+
+	def test_verify_writes_the_stage_two_file_belonging_to_its_journal(self):
+		journal = self.tmp / "archived.jsonl"
+		kwargs = self.call(["verify", "--journal", str(journal)], "verify")
+		self.assertEqual(kwargs["verify_path"], report_mod.verify_path_for(journal))
+		self.assertEqual(kwargs["verify_path"], self.tmp / "archived.verify.jsonl")
+
+	def test_verify_does_not_contaminate_the_default_campaign(self):
+		"""The bug: every journal's verdicts landed in the default .mutation/verify.jsonl."""
+		journal = self.tmp / "archived.jsonl"
+		kwargs = self.call(["verify", "--journal", str(journal)], "verify")
+		self.assertNotEqual(kwargs["verify_path"], VERIFY_PATH)
+
+	def test_verify_keeps_the_historical_path_for_the_default_journal(self):
+		kwargs = self.call(["verify"], "verify")
+		self.assertEqual(kwargs["journal_path"], JOURNAL_PATH)
+		self.assertEqual(kwargs["verify_path"], VERIFY_PATH)
+
+	def test_verify_and_report_agree_by_construction(self):
+		"""Whatever --journal is given, stage 2 writes exactly where stage 3 looks."""
+		for name in ("journal.jsonl", "archived.jsonl", "nightly-2026-07-30.jsonl"):
+			with self.subTest(journal=name):
+				journal = self.tmp / name
+				written = self.call(["verify", "--journal", str(journal)], "verify")["verify_path"]
+				read = self.call(["report", "--journal", str(journal)], "report", module=report_mod)[
+					"verify_path"
+				]
+				self.assertEqual(written, read)
+
+	def test_explicit_verify_journal_overrides_the_derived_path(self):
+		journal = self.tmp / "archived.jsonl"
+		override = self.tmp / "elsewhere.jsonl"
+		for command, module in (("verify", campaign), ("report", report_mod)):
+			with self.subTest(command=command):
+				kwargs = self.call(
+					[command, "--journal", str(journal), "--verify-journal", str(override)],
+					command,
+					module=module,
+				)
+				self.assertEqual(kwargs["verify_path"], override)
+
+	# --- report gating flags -------------------------------------------------------
+
+	def test_report_passes_fail_under_through(self):
+		kwargs = self.call(["report", "--fail-under", "80"], "report", module=report_mod)
+		self.assertEqual(kwargs["fail_under"], 80.0)
+
+	def test_fail_under_defaults_to_off(self):
+		kwargs = self.call(["report"], "report", module=report_mod)
+		self.assertIsNone(kwargs["fail_under"])
+
+	def test_report_exit_code_is_returned_unchanged(self):
+		"""main is a pass-through: a gate that fails must reach the shell as a failure."""
+		for expected in (
+			report_mod.EXIT_OK,
+			report_mod.EXIT_BELOW_THRESHOLD,
+			report_mod.EXIT_NOTHING_MEASURED,
+		):
+			with self.subTest(expected=expected):
+				self.call(["report"], "report", module=report_mod, returns=expected)
+
+	def test_run_exit_code_is_returned_unchanged(self):
+		for expected in (campaign.EXIT_OK, campaign.EXIT_ABORTED, campaign.EXIT_NOTHING_MEASURED):
+			with self.subTest(expected=expected):
+				self.call(["run"], "run_campaign", returns=expected)
+
+	def test_exit_codes_are_documented_in_the_help_text(self):
+		parser = cli.build_parser()
+		help_text = io.StringIO()
+		with contextlib.redirect_stdout(help_text):
+			with self.assertRaises(SystemExit):
+				parser.parse_args(["report", "--help"])
+		text = help_text.getvalue()
+		self.assertIn("exit codes", text)
+		self.assertIn(str(report_mod.EXIT_NOTHING_MEASURED), text)
+		self.assertIn("--fail-under", text)
+
+
+class CampaignExitCodeTest(unittest.TestCase):
+	"""``_campaign_exit_code`` is the whole contract, so it is pinned in isolation."""
+
+	def test_a_normal_run_succeeds(self):
+		code = campaign._campaign_exit_code(targeted=2, skipped=0, pending=10, evaluated=10, aborted=False)
+		self.assertEqual(code, campaign.EXIT_OK)
+
+	def test_nothing_left_to_do_is_a_success(self):
+		"""Every mutant already journalled: a resumed campaign has genuinely nothing to do."""
+		code = campaign._campaign_exit_code(targeted=3, skipped=0, pending=0, evaluated=0, aborted=False)
+		self.assertEqual(code, campaign.EXIT_OK)
+
+	def test_every_module_skipped_is_a_failure(self):
+		"""A dead site skips every module on a red baseline and measures nothing."""
+		code = campaign._campaign_exit_code(targeted=3, skipped=3, pending=0, evaluated=0, aborted=False)
+		self.assertEqual(code, campaign.EXIT_NOTHING_MEASURED)
+
+	def test_pending_work_that_produced_nothing_is_a_failure(self):
+		code = campaign._campaign_exit_code(targeted=1, skipped=0, pending=12, evaluated=0, aborted=False)
+		self.assertEqual(code, campaign.EXIT_NOTHING_MEASURED)
+
+	def test_nothing_measured_and_nothing_to_do_do_not_share_an_exit_code(self):
+		broken = campaign._campaign_exit_code(targeted=2, skipped=2, pending=0, evaluated=0, aborted=False)
+		resumed = campaign._campaign_exit_code(targeted=2, skipped=0, pending=0, evaluated=0, aborted=False)
+		self.assertNotEqual(broken, resumed)
+
+	def test_a_partial_skip_that_still_measured_something_succeeds(self):
+		code = campaign._campaign_exit_code(targeted=3, skipped=2, pending=4, evaluated=4, aborted=False)
+		self.assertEqual(code, campaign.EXIT_OK)
+
+	def test_an_abort_outranks_everything(self):
+		code = campaign._campaign_exit_code(targeted=1, skipped=0, pending=5, evaluated=5, aborted=True)
+		self.assertEqual(code, campaign.EXIT_ABORTED)
+
+	def test_limit_zero_is_an_explicit_request_to_measure_nothing(self):
+		code = campaign._campaign_exit_code(
+			targeted=1, skipped=0, pending=9, evaluated=0, aborted=False, limit=0
+		)
+		self.assertEqual(code, campaign.EXIT_OK)
+
+
+class CampaignLoopTestCase(unittest.TestCase):
+	"""Drives ``_run_campaign_locked`` over a synthetic app tree.
+
+	Everything that would touch a site, a git repo or the real backup directory is
+	replaced; what is left under test is the per-module ordering and the exit code.
+	"""
+
+	def setUp(self) -> None:
+		self._tmp = tempfile.TemporaryDirectory()
+		self.addCleanup(self._tmp.cleanup)
+		self.tmp = Path(self._tmp.name)
+		self.app_root = self.tmp / "app"
+		self.app_root.mkdir()
+		self.backup_dir = self.tmp / "backup"
+		self.backup_dir.mkdir()
+		self.journal = self.tmp / "journal.jsonl"
+
+		for target, attribute, value in (
+			(campaign, "APP_ROOT", self.app_root),
+			(campaign, "BACKUP_DIR", self.backup_dir),
+			(safety, "BACKUP_DIR", self.backup_dir),
+			# Real ones would prompt, shell out to git, or rewire this process's signals.
+			(campaign, "check_orphans", lambda **_kwargs: True),
+			(safety, "git_is_clean", lambda _paths: (True, [])),
+			(safety, "install_handlers", lambda: None),
+		):
+			patcher = mock.patch.object(target, attribute, value)
+			patcher.start()
+			self.addCleanup(patcher.stop)
+
+		self.collected_sources: list[str] = []
+		real_collect = mutators.collect_sites
+
+		def recording_collect(source: str, rel_path: str, **kwargs: object):
+			self.collected_sources.append(source)
+			return real_collect(source, rel_path, **kwargs)
+
+		patcher = mock.patch.object(mutators, "collect_sites", recording_collect)
+		patcher.start()
+		self.addCleanup(patcher.stop)
+
+	def write_target(self, rel_path: str, source: str) -> Path:
+		path = self.app_root / rel_path
+		path.parent.mkdir(parents=True, exist_ok=True)
+		path.write_text(source, encoding="utf-8")
+		return path
+
+	def plant_crashed_run(self, path: Path, original: str, mutant: str) -> None:
+		"""Leave the tree exactly as a SIGKILLed run would: mutant on disk, backup beside it."""
+		path.write_text(mutant, encoding="utf-8")
+		slug = safety.sha256_text(str(path.resolve()))
+		(self.backup_dir / f"{slug}.orig").write_text(original, encoding="utf-8")
+		(self.backup_dir / f"{slug}.json").write_text(
+			json.dumps(
+				{
+					"path": str(path.resolve()),
+					"sha256": safety.sha256_text(original),
+					"mutated_sha256": safety.sha256_text(mutant),
+					"pid": os.getpid(),
+				}
+			),
+			encoding="utf-8",
+		)
+
+	def journal_records(self) -> list[dict]:
+		if not self.journal.exists():
+			return []
+		return [json.loads(line) for line in self.journal.read_text().splitlines() if line.strip()]
+
+	def run_campaign(
+		self,
+		targets: dict[str, list[str]],
+		baseline: tuple[bool, str] = (True, ""),
+		status: str = STATUS_KILLED,
+		limit: int | None = None,
+	) -> int:
+		self.evaluated_sources: list[str] = []
+
+		def fake_evaluate(_guard, mutated_source, *_args, **_kwargs):
+			self.evaluated_sources.append(mutated_source)
+			return status, "tests.some_module", 0.01
+
+		with mock.patch.object(campaign, "_baseline_ok", return_value=baseline):
+			with mock.patch.object(campaign, "_evaluate_mutant", fake_evaluate):
+				with contextlib.redirect_stdout(io.StringIO()) as out:
+					code = campaign._run_campaign_locked(
+						targets=targets,
+						site="unused.test",
+						timeout=1,
+						limit=limit,
+						mutate_strings=False,
+						assume_yes=True,
+						journal_path=self.journal,
+					)
+		self.output = out.getvalue()
+		return code
+
+
+class CampaignOrderingTest(CampaignLoopTestCase):
+	"""The backup must be installed before anything reads or measures the file."""
+
+	def test_sites_are_collected_from_the_recovered_original(self):
+		"""The bug: collect_sites ran before install_backup, so it saw the crashed run's mutant."""
+		path = self.write_target("pkg/compare.py", ORIGINAL)
+		self.plant_crashed_run(path, ORIGINAL, LEFTOVER_MUTANT)
+
+		code = self.run_campaign({"pkg/compare.py": ["tests.test_compare"]})
+
+		self.assertEqual(self.collected_sources, [ORIGINAL])
+		self.assertEqual(code, campaign.EXIT_OK)
+
+	def test_the_leftover_mutant_is_gone_from_disk_afterwards(self):
+		path = self.write_target("pkg/compare.py", ORIGINAL)
+		self.plant_crashed_run(path, ORIGINAL, LEFTOVER_MUTANT)
+
+		self.run_campaign({"pkg/compare.py": ["tests.test_compare"]})
+
+		self.assertEqual(path.read_text(), ORIGINAL)
+
+	def test_journalled_keys_belong_to_the_original_source(self):
+		"""Keys are content hashes: sites from mutated source resume against nothing."""
+		path = self.write_target("pkg/compare.py", ORIGINAL)
+		self.plant_crashed_run(path, ORIGINAL, LEFTOVER_MUTANT)
+
+		self.run_campaign({"pkg/compare.py": ["tests.test_compare"]})
+
+		expected = {s.key for s in mutators.collect_sites(ORIGINAL, "pkg/compare.py")}
+		journalled = {r["key"] for r in self.journal_records()}
+		self.assertTrue(journalled)
+		self.assertTrue(journalled <= expected)
+
+	def test_a_module_with_nothing_pending_still_gets_its_mutant_removed(self):
+		"""The second half of the ordering bug: 'if not pending: continue' skipped the backup."""
+		path = self.write_target("pkg/compare.py", ORIGINAL)
+		sites = mutators.collect_sites(ORIGINAL, "pkg/compare.py")
+		with open(self.journal, "w", encoding="utf-8") as handle:
+			for site in sites:
+				record = site.to_dict()
+				record.update({"module": "pkg/compare.py", "status": STATUS_KILLED})
+				handle.write(json.dumps(record, sort_keys=True) + "\n")
+		self.plant_crashed_run(path, ORIGINAL, LEFTOVER_MUTANT)
+
+		code = self.run_campaign({"pkg/compare.py": ["tests.test_compare"]})
+
+		self.assertEqual(path.read_text(), ORIGINAL)
+		self.assertEqual(self.evaluated_sources, [])
+		self.assertEqual(code, campaign.EXIT_OK)
+
+	def test_the_backup_is_released_when_the_module_is_skipped(self):
+		"""A red baseline must not leave the sidecar backup behind as a fake orphan."""
+		path = self.write_target("pkg/compare.py", ORIGINAL)
+		self.plant_crashed_run(path, ORIGINAL, LEFTOVER_MUTANT)
+
+		self.run_campaign({"pkg/compare.py": ["tests.test_compare"]}, baseline=(False, "site is down"))
+
+		self.assertEqual(path.read_text(), ORIGINAL)
+		self.assertEqual(list(self.backup_dir.iterdir()), [])
+
+
+class CampaignRunExitCodeTest(CampaignLoopTestCase):
+	"""End-to-end exit codes, so the contract holds through the real loop."""
+
+	def test_a_measured_run_exits_zero(self):
+		self.write_target("pkg/compare.py", ORIGINAL)
+		code = self.run_campaign({"pkg/compare.py": ["tests.test_compare"]})
+		self.assertEqual(code, campaign.EXIT_OK)
+		self.assertTrue(self.evaluated_sources)
+
+	def test_a_red_baseline_on_every_module_is_not_a_success(self):
+		"""The bug: a nightly whose site was down exited 0 having evaluated zero mutants."""
+		self.write_target("pkg/compare.py", ORIGINAL)
+		self.write_target("pkg/other.py", ORIGINAL)
+		code = self.run_campaign(
+			{"pkg/compare.py": ["tests.test_compare"], "pkg/other.py": ["tests.test_other"]},
+			baseline=(False, "site is down"),
+		)
+		self.assertEqual(code, campaign.EXIT_NOTHING_MEASURED)
+		self.assertIn("NOTHING MEASURED", self.output)
+		self.assertEqual(len(self.journal_records()), 2)
+
+	def test_missing_target_files_are_skipped_and_reported(self):
+		code = self.run_campaign({"pkg/gone.py": ["tests.test_gone"]})
+		self.assertEqual(code, campaign.EXIT_NOTHING_MEASURED)
+
+	def test_a_fully_journalled_run_exits_zero(self):
+		"""Nothing to do is not the same as nothing measured, and must not look like it."""
+		self.write_target("pkg/compare.py", ORIGINAL)
+		self.run_campaign({"pkg/compare.py": ["tests.test_compare"]})
+		self.assertTrue(self.evaluated_sources)
+
+		code = self.run_campaign({"pkg/compare.py": ["tests.test_compare"]})
+		self.assertEqual(code, campaign.EXIT_OK)
+		self.assertEqual(self.evaluated_sources, [])
+
+	def test_a_partially_skipped_run_still_exits_zero_but_says_so(self):
+		self.write_target("pkg/compare.py", ORIGINAL)
+		baselines = iter([(True, ""), (False, "site is down")])
+		with mock.patch.object(campaign, "_baseline_ok", side_effect=lambda *_a: next(baselines)):
+			with mock.patch.object(
+				campaign, "_evaluate_mutant", lambda *_a, **_k: (STATUS_KILLED, "tests.x", 0.01)
+			):
+				with contextlib.redirect_stdout(io.StringIO()) as out:
+					code = campaign._run_campaign_locked(
+						targets={
+							"pkg/compare.py": ["tests.test_compare"],
+							"pkg/gone.py": ["tests.test_gone"],
+						},
+						site="unused.test",
+						timeout=1,
+						limit=None,
+						mutate_strings=False,
+						assume_yes=True,
+						journal_path=self.journal,
+					)
+		self.assertEqual(code, campaign.EXIT_OK)
+		self.assertIn("WARNING", out.getvalue())
+
+	def test_the_circuit_breaker_still_reports_an_abort(self):
+		self.write_target("pkg/compare.py", ORIGINAL)
+		code = self.run_campaign({"pkg/compare.py": ["tests.test_compare"]}, status=STATUS_TIMEOUT)
+		self.assertEqual(code, campaign.EXIT_ABORTED)
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/gameplan/tests/platform/test_mutation_mutators.py
+++ b/gameplan/tests/platform/test_mutation_mutators.py
@@ -1,0 +1,299 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# MIT License. See license.txt
+
+"""Unit tests for mutation site discovery and mutant identity.
+
+The mutant key is the harness's memory. A campaign is hours long, so every verdict is
+cached under it and resumed from it; the verify stage re-derives a survivor's site from
+the current source by that key alone. Two properties therefore matter more than anything
+else in this module, and both are pinned here:
+
+* STABILITY - a behaviour-neutral edit (a comment, a reformat, a change inside an
+  unrelated block) must not change a key, or hours of verdicts are thrown away and
+  journalled survivors are silently dropped from the verify pass.
+* NON-REBINDING - a key must never move from one site to another. Deleting one of
+  several identical sites used to shift a positional ordinal, handing the deleted site's
+  cached verdict to a site that was never evaluated. Invalidation costs a re-run;
+  rebinding reports a fabricated verdict, so the tests below insist on the former.
+
+Deliberately no site, no bench, no subprocess: ``collect_sites`` takes a source string
+and returns dataclasses, so these stay pure.
+"""
+
+from __future__ import annotations
+
+import ast
+import unittest
+from pathlib import Path
+
+from gameplan.tests.mutation import mutators
+
+REL = "sample.py"
+
+# Two mutation sites that are identical in every respect except where they sit: same
+# function, same statement, same mutator, same original and mutated text.
+TWINS = """
+def f(a, b):
+	x = 1
+	if a or b:
+		x = 2
+	y = 3
+	if a or b:
+		y = 4
+	return x, y
+"""
+
+RICH = '''
+"""Module docstring - never mutated."""
+from __future__ import annotations
+
+import os
+
+__all__ = ["run"]
+
+LIMIT = 10
+
+
+class Thing:
+	"""Class docstring."""
+
+	def __init__(self, size=3):
+		self.size = size
+
+	def check(self, other, strict=False):
+		"""Method docstring."""
+		if self.size > other.size and not strict:
+			return True
+		total = self.size + other.size - 1
+		for index in range(0, total):
+			if index == LIMIT or index in (1, 2):
+				return index / 2
+		return "fallback"
+
+
+def run(items, retries=2):
+	if items is None or len(items) <= 0:
+		return None
+	while retries > 0:
+		retries = retries - 1
+	return os.path.join("a", "b")
+'''
+
+
+def keys(source: str, mutator: str | None = None, rel_path: str = REL) -> list[str]:
+	return [s.key for s in sites(source, mutator, rel_path)]
+
+
+def sites(
+	source: str, mutator: str | None = None, rel_path: str = REL, mutate_strings: bool = False
+) -> list[mutators.MutationSite]:
+	found = mutators.collect_sites(source, rel_path, mutate_strings=mutate_strings)
+	return [s for s in found if mutator is None or s.mutator == mutator]
+
+
+def normalised(text: str) -> str:
+	return " ".join(text.split())
+
+
+class TestKeyStability(unittest.TestCase):
+	"""Behaviour-neutral edits must leave every key untouched."""
+
+	def test_comments_do_not_change_keys(self):
+		base = "def g(x):\n\tif x > 1 and x < 9:\n\t\treturn 1\n\treturn 2\n"
+		commented = (
+			"def g(x):\n"
+			"\t# explain the guard\n"
+			"\tif x > 1 and x < 9:\n"
+			"\t\t# and the body\n"
+			"\t\treturn 1\n"
+			"\treturn 2\n"
+		)
+		self.assertEqual(keys(base), keys(commented))
+
+	def test_reformatting_does_not_change_keys(self):
+		base = "def g(x):\n\tif x > 1 and x < 9:\n\t\treturn h(x, 1)\n\treturn 2\n"
+		# What `ruff format` does to a long line: explode it and add a trailing comma.
+		reformatted = (
+			"def g(x):\n"
+			"\tif (\n\t\tx > 1\n\t\tand x < 9\n\t):\n"
+			"\t\treturn h(\n\t\t\tx,\n\t\t\t1,\n\t\t)\n"
+			"\treturn 2\n"
+		)
+		self.assertEqual(keys(base), keys(reformatted))
+
+	def test_editing_a_block_does_not_rekey_its_header(self):
+		"""A site in an `if` header is not about the block's body, so body edits are none of its business."""
+		base = "def g(x):\n\tif x > 1:\n\t\treturn 1\n\treturn 2\n"
+		bigger_body = "def g(x):\n\tif x > 1:\n\t\tlog('hi')\n\t\treturn compute(x)\n\treturn 2\n"
+		header_key = keys(base, mutators.MUTATOR_COMPARISON)
+		self.assertEqual(len(header_key), 1)
+		self.assertIn(header_key[0], keys(bigger_body, mutators.MUTATOR_COMPARISON))
+
+	def test_editing_another_function_does_not_rekey(self):
+		base = "def g(x):\n\tif x > 1:\n\t\treturn 1\n\treturn 2\n"
+		with_neighbour = "def new_helper(y):\n\treturn y or 0\n\n\n" + base
+		self.assertTrue(set(keys(base)).issubset(set(keys(with_neighbour))))
+
+	def test_key_is_scoped_to_the_file(self):
+		base = "def g(x):\n\tif x > 1:\n\t\treturn 1\n"
+		self.assertNotEqual(keys(base, rel_path="a.py"), keys(base, rel_path="b.py"))
+
+
+class TestIdenticalSites(unittest.TestCase):
+	"""Sites that differ only in position must stay distinguishable, and must never swap keys."""
+
+	def test_identical_sites_get_distinct_keys(self):
+		found = keys(TWINS, mutators.MUTATOR_BOOLEAN_OP)
+		self.assertEqual(len(found), 2)
+		self.assertEqual(len(set(found)), 2)
+
+	def test_every_key_in_a_file_is_unique(self):
+		found = keys(RICH)
+		self.assertEqual(len(found), len(set(found)))
+
+	def test_deleting_one_twin_does_not_rebind_the_other(self):
+		before = keys(TWINS, mutators.MUTATOR_BOOLEAN_OP)
+		trimmed = """
+def f(a, b):
+	x = 1
+	y = 3
+	if a or b:
+		y = 4
+	return x, y
+"""
+		after = keys(trimmed, mutators.MUTATOR_BOOLEAN_OP)
+		self.assertEqual(len(after), 1)
+		# The survivor may be re-keyed (it gets re-run, which is cheap and honest), but it
+		# must never adopt the key the deleted site's verdict is filed under.
+		self.assertNotIn(after[0], before)
+
+	def test_reordering_twins_does_not_rebind(self):
+		before = keys(TWINS, mutators.MUTATOR_BOOLEAN_OP)
+		reordered = """
+def f(a, b):
+	if a or b:
+		y = 4
+	x = 1
+	y = 3
+	if a or b:
+		x = 2
+	return x, y
+"""
+		after = keys(reordered, mutators.MUTATOR_BOOLEAN_OP)
+		self.assertEqual(len(after), 2)
+		self.assertEqual(set(after) & set(before), set())
+
+	def test_twins_are_stable_when_nothing_changes(self):
+		self.assertEqual(keys(TWINS), keys(TWINS))
+
+	def test_twins_survive_a_comment(self):
+		commented = TWINS.replace("\tx = 1\n", "\t# set up\n\tx = 1\n")
+		self.assertEqual(
+			keys(commented, mutators.MUTATOR_BOOLEAN_OP), keys(TWINS, mutators.MUTATOR_BOOLEAN_OP)
+		)
+
+	def test_three_identical_sites_are_all_addressable(self):
+		source = "def f(a, b):\n" + "\tif a or b:\n\t\tpass\n" * 3
+		found = keys(source, mutators.MUTATOR_BOOLEAN_OP)
+		self.assertEqual(len(found), 3)
+		self.assertEqual(len(set(found)), 3)
+
+
+class TestMutantValidity(unittest.TestCase):
+	"""Every site the campaign is handed must render to Python that actually parses."""
+
+	def assert_all_mutants_parse(self, source: str, mutate_strings: bool = False):
+		found = sites(source, mutate_strings=mutate_strings)
+		self.assertTrue(found)
+		for site in found:
+			built = mutators.build_mutant(source, site.node_index, site.mutator, site.param)
+			self.assertIsNotNone(built, f"{site.mutator} at line {site.line} produced no mutant")
+			mutated_source, _ = built
+			ast.parse(mutated_source)
+			self.assertNotEqual(ast.unparse(ast.parse(source)), mutated_source)
+
+	def test_synthetic_module(self):
+		self.assert_all_mutants_parse(RICH, mutate_strings=True)
+
+	def test_a_real_target_file(self):
+		"""Smoke test against shipped code: synthetic sources do not cover every node shape."""
+		target = Path(mutators.__file__).resolve().parents[3] / "gameplan" / "mixins" / "reactions.py"
+		self.assert_all_mutants_parse(target.read_text())
+
+	def test_mutated_segment_is_what_gets_written(self):
+		for site in sites(RICH, mutate_strings=True):
+			mutated_source, segment = mutators.build_mutant(RICH, site.node_index, site.mutator, site.param)
+			self.assertEqual(segment, site.mutated_segment)
+			self.assertIn(site.mutated_segment, normalised(mutated_source))
+
+	def test_original_segment_is_the_unmutated_code(self):
+		baseline = normalised(ast.unparse(ast.parse(RICH)))
+		for site in sites(RICH, mutate_strings=True):
+			self.assertIn(site.original_segment, baseline)
+
+	def test_line_and_column_point_at_the_site(self):
+		found = sites("def g(x):\n\tif x > 1:\n\t\treturn 1\n", mutators.MUTATOR_COMPARISON)
+		self.assertEqual([(s.line, s.col) for s in found], [(2, 4)])
+
+
+class TestSiteSelection(unittest.TestCase):
+	"""What is and is not a mutation site."""
+
+	def test_strings_are_not_mutated_by_default(self):
+		found = sites(RICH)
+		self.assertEqual([s for s in found if s.mutator == mutators.MUTATOR_STRING_CONST], [])
+
+	def test_mutate_strings_enables_string_constants(self):
+		found = sites(RICH, mutators.MUTATOR_STRING_CONST, mutate_strings=True)
+		self.assertTrue(found)
+		self.assertIn("fallback", [s.original_segment.strip("'\"") for s in found])
+
+	def test_docstrings_are_never_mutated(self):
+		found = sites(RICH, mutators.MUTATOR_STRING_CONST, mutate_strings=True)
+		originals = {s.original_segment.strip("'\"") for s in found}
+		self.assertNotIn("Module docstring - never mutated.", originals)
+		self.assertNotIn("Class docstring.", originals)
+		self.assertNotIn("Method docstring.", originals)
+
+	def test_imports_and_dunder_all_are_never_mutated(self):
+		found = sites(RICH, mutate_strings=True)
+		self.assertNotIn("run", [s.original_segment.strip("'\"") for s in found])
+		self.assertEqual([s for s in found if s.line in (3, 5)], [])
+
+	def test_type_checking_blocks_are_never_mutated(self):
+		source = (
+			"from typing import TYPE_CHECKING\n\n"
+			"if TYPE_CHECKING:\n\tLIMIT = 5\n\n"
+			"def g(x):\n\treturn x > 5\n"
+		)
+		self.assertEqual([s.line for s in sites(source, mutators.MUTATOR_NUMBER_INCREMENT)], [7])
+
+	def test_bare_return_has_no_return_none_mutant(self):
+		source = "def g(x):\n\tif x:\n\t\treturn\n\treturn None\n"
+		self.assertEqual(sites(source, mutators.MUTATOR_RETURN_NONE), [])
+
+
+class TestNumberMutants(unittest.TestCase):
+	"""The number mutators must not spend a bench run on a mutant they already produced."""
+
+	def numeric_segments(self, source: str) -> list[str]:
+		return sorted(s.mutated_segment for s in sites(source) if s.mutator.startswith("number-"))
+
+	def test_zero_yields_one_mutant_not_two(self):
+		"""increment(0) and zero(0) both render `1`, so the second is a duplicate, not a site."""
+		self.assertEqual(self.numeric_segments("def g():\n\treturn f(0)\n"), ["1"])
+
+	def test_nonzero_yields_both_mutants(self):
+		self.assertEqual(self.numeric_segments("def g():\n\treturn f(7)\n"), ["0", "8"])
+
+	def test_zeroing_keeps_the_literal_type(self):
+		self.assertEqual(self.numeric_segments("def g():\n\treturn f(0.0)\n"), ["1.0"])
+
+	def test_booleans_are_flipped_not_incremented(self):
+		found = sites("def g():\n\treturn f(True)\n")
+		constants = [(s.mutator, s.mutated_segment) for s in found if s.original_segment == "True"]
+		self.assertEqual(constants, [(mutators.MUTATOR_BOOLEAN_CONST, "False")])
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/gameplan/tests/platform/test_mutation_report.py
+++ b/gameplan/tests/platform/test_mutation_report.py
@@ -1,0 +1,375 @@
+"""Unit tests for the mutation report renderer.
+
+Pure unit tests: synthetic journals written to a tempdir, no bench and no site. What
+they pin is the one property the report exists to guarantee - an absence of evidence is
+never rendered as a result. A module nobody could measure must not look like a module
+that scored badly, and a non-verdict must never overwrite a real one.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from gameplan.tests.mutation import report as report_mod
+from gameplan.tests.mutation.config import (
+	JOURNAL_PATH,
+	KILLED_STATUSES,
+	NON_SCORING_STATUSES,
+	STATUS_BASELINE_SKIP,
+	STATUS_INFRA_ERROR,
+	STATUS_KILLED,
+	STATUS_KILLED_BY_OTHER_SUITE,
+	STATUS_SURVIVED,
+	VERIFY_PATH,
+)
+
+
+def _record(key: str, status: str, module: str = "gameplan/foo.py", **extra: object) -> dict:
+	record = {
+		"key": key,
+		"status": status,
+		"module": module,
+		"file": module,
+		"function": "fn",
+		"line": 1,
+		"mutator": "return-none",
+		"original_segment": "return True",
+		"mutated_segment": "return None",
+	}
+	record.update(extra)
+	return record
+
+
+class MutationReportTest(unittest.TestCase):
+	def setUp(self) -> None:
+		self._tmp = tempfile.TemporaryDirectory()
+		self.addCleanup(self._tmp.cleanup)
+		self.tmp = Path(self._tmp.name)
+
+	def write_journal(self, records: list[dict], name: str = "journal.jsonl") -> Path:
+		path = self.tmp / name
+		with open(path, "w", encoding="utf-8") as handle:
+			for record in records:
+				handle.write(json.dumps(record, sort_keys=True) + "\n")
+		return path
+
+	def summarise(self, records: list[dict], verify: list[dict] | None = None) -> dict:
+		journal = self.write_journal(records)
+		verify_path = None
+		if verify is not None:
+			verify_path = self.write_journal(verify, name="journal.verify.jsonl")
+		return report_mod.summarise(report_mod.load_results(journal, verify_path))
+
+	# --- dedup -----------------------------------------------------------------
+
+	def test_last_record_for_a_key_wins(self):
+		"""The journal is append-only and re-runs a mutant, so only the last verdict counts."""
+		summary = self.summarise(
+			[
+				_record("k1", STATUS_SURVIVED),
+				_record("k2", STATUS_KILLED),
+				_record("k1", STATUS_KILLED),  # re-run: k1 is now a kill
+			]
+		)
+		info = summary["modules"]["gameplan/foo.py"]
+		self.assertEqual(info["total"], 2)
+		self.assertEqual(info["killed"], 2)
+		self.assertEqual(info["counts"], {STATUS_KILLED: 2})
+		self.assertEqual(summary["survivors"], {})
+
+	def test_dedup_keeps_position_of_the_last_occurrence(self):
+		"""Ordering is load-bearing: baseline supersession is decided by journal position."""
+		journal = self.write_journal(
+			[
+				_record("k1", STATUS_SURVIVED),
+				_record("k2", STATUS_KILLED),
+				_record("k1", STATUS_KILLED),
+			]
+		)
+		keys = [r["key"] for r in report_mod.load_results(journal)]
+		self.assertEqual(keys, ["k2", "k1"])
+
+	def test_dedup_matches_an_independent_count(self):
+		records = [_record(f"k{i % 7}", STATUS_KILLED if i % 2 else STATUS_SURVIVED) for i in range(30)]
+		merged = report_mod.load_results(self.write_journal(records))
+		expected = {}
+		for record in records:
+			expected[record["key"]] = record["status"]
+		self.assertEqual({r["key"]: r["status"] for r in merged}, expected)
+		self.assertEqual(len(merged), 7)
+
+	# --- no verdict is not a zero score ----------------------------------------
+
+	def test_module_with_no_verdicts_has_no_score_rather_than_zero(self):
+		summary = self.summarise(
+			[
+				_record("a1", STATUS_INFRA_ERROR, module="gameplan/bar.py"),
+				_record("a2", STATUS_INFRA_ERROR, module="gameplan/bar.py"),
+				_record("b1", STATUS_SURVIVED, module="gameplan/foo.py"),
+				_record("b2", STATUS_SURVIVED, module="gameplan/foo.py"),
+			]
+		)
+		unmeasured = summary["modules"]["gameplan/bar.py"]
+		genuinely_zero = summary["modules"]["gameplan/foo.py"]
+		self.assertIsNone(unmeasured["score"])
+		self.assertEqual(unmeasured["scored"], 0)
+		self.assertEqual(unmeasured["unscored"], 2)
+		self.assertEqual(genuinely_zero["score"], 0.0)
+		self.assertEqual(summary["unmeasured_modules"], ["gameplan/bar.py"])
+
+	def test_unmeasured_and_zero_scoring_modules_render_differently(self):
+		summary = self.summarise(
+			[
+				_record("a1", STATUS_INFRA_ERROR, module="gameplan/bar.py"),
+				_record("b1", STATUS_SURVIVED, module="gameplan/foo.py"),
+			]
+		)
+		text = report_mod.render_text(summary)
+		lines = text.splitlines()
+		bar_score = lines[lines.index("gameplan/bar.py") + 1]
+		foo_score = lines[lines.index("gameplan/foo.py") + 1]
+		self.assertIn("n/a", bar_score)
+		self.assertIn("NOT MEASURED", bar_score)
+		self.assertNotIn("0%", bar_score)
+		self.assertIn("0%", foo_score)
+		self.assertIn("gameplan/bar.py", text.split("WARNING:")[-1])
+
+		markdown = report_mod.render_markdown(summary)
+		bar_row = next(line for line in markdown.splitlines() if "`gameplan/bar.py`" in line)
+		foo_row = next(line for line in markdown.splitlines() if "`gameplan/foo.py`" in line)
+		self.assertIn("n/a", bar_row)
+		self.assertNotIn("0%", bar_row)
+		self.assertIn("0%", foo_row)
+
+	def test_overall_score_is_none_when_nothing_was_measured(self):
+		summary = self.summarise([_record("a1", STATUS_INFRA_ERROR), _record("a2", STATUS_INFRA_ERROR)])
+		self.assertIsNone(summary["overall"]["score"])
+		self.assertEqual(summary["overall"]["unscored"], 2)
+		text = report_mod.render_text(summary)
+		self.assertIn("OVERALL: n/a", text)
+		self.assertNotIn("OVERALL: 0%", text)
+
+	def test_format_score_renders_none_as_na(self):
+		self.assertEqual(report_mod.format_score(None), "n/a")
+		self.assertEqual(report_mod.format_score(0.0), "0%")
+
+	# --- baseline skip precedence ----------------------------------------------
+
+	def test_baseline_skip_is_superseded_by_later_mutant_records(self):
+		"""A green re-run journals no 'baseline OK' record, so later mutants must clear it."""
+		summary = self.summarise(
+			[
+				_record("baseline:gameplan/foo.py", STATUS_BASELINE_SKIP, reason="red baseline"),
+				_record("k1", STATUS_KILLED),
+				_record("k2", STATUS_SURVIVED),
+			]
+		)
+		self.assertEqual(summary["baseline_skipped"], {})
+		self.assertIsNone(summary["modules"]["gameplan/foo.py"]["baseline_skip"])
+		self.assertEqual(summary["modules"]["gameplan/foo.py"]["score"], 0.5)
+		text = report_mod.render_text(summary)
+		self.assertNotIn("Skipped (red baseline)", text)
+
+	def test_baseline_skip_after_the_mutants_marks_the_score_stale(self):
+		summary = self.summarise(
+			[
+				_record("k1", STATUS_KILLED),
+				_record("k2", STATUS_SURVIVED),
+				_record("baseline:gameplan/foo.py", STATUS_BASELINE_SKIP, reason="red baseline"),
+			]
+		)
+		self.assertEqual(summary["baseline_skipped"], {"gameplan/foo.py": "red baseline"})
+		self.assertEqual(summary["modules"]["gameplan/foo.py"]["baseline_skip"], "red baseline")
+		text = report_mod.render_text(summary)
+		self.assertIn("STALE", text)
+		self.assertIn("Skipped (red baseline)", text)
+		self.assertIn("(stale: skipped, red baseline)", report_mod.render_markdown(summary))
+
+	def test_baseline_skip_alone_still_reported(self):
+		summary = self.summarise(
+			[_record("baseline:gameplan/foo.py", STATUS_BASELINE_SKIP, reason="import error")]
+		)
+		self.assertEqual(summary["baseline_skipped"], {"gameplan/foo.py": "import error"})
+		self.assertEqual(summary["modules"], {})
+		self.assertIn("import error", report_mod.render_text(summary))
+
+	def test_baseline_skip_is_never_counted_as_a_mutant(self):
+		summary = self.summarise(
+			[
+				_record("baseline:gameplan/bar.py", STATUS_BASELINE_SKIP, module="gameplan/bar.py"),
+				_record("k1", STATUS_KILLED),
+			]
+		)
+		self.assertEqual(summary["overall"]["total"], 1)
+		self.assertNotIn("gameplan/bar.py", summary["modules"])
+
+	# --- verify stage ------------------------------------------------------------
+
+	def test_verify_verdict_supersedes_a_stage_one_survivor(self):
+		summary = self.summarise(
+			[_record("k1", STATUS_SURVIVED)],
+			verify=[_record("k1", STATUS_KILLED_BY_OTHER_SUITE)],
+		)
+		self.assertEqual(summary["overall"]["killed"], 1)
+		self.assertEqual(summary["survivors"], {})
+
+	def test_non_verdict_never_supersedes_a_real_verdict(self):
+		for status in sorted(NON_SCORING_STATUSES):
+			with self.subTest(status=status):
+				summary = self.summarise(
+					[_record("k1", STATUS_SURVIVED)],
+					verify=[_record("k1", status)],
+				)
+				self.assertEqual(summary["modules"]["gameplan/foo.py"]["counts"], {STATUS_SURVIVED: 1})
+				self.assertEqual(summary["overall"]["unscored"], 0)
+				self.assertEqual(summary["overall"]["score"], 0.0)
+
+	def test_verify_path_is_derived_from_the_journal_path(self):
+		"""A custom journal must not be contaminated by the default campaign's verify file."""
+		self.assertEqual(report_mod.verify_path_for(JOURNAL_PATH), VERIFY_PATH)
+		custom = self.tmp / "archived.jsonl"
+		self.assertEqual(report_mod.verify_path_for(custom), self.tmp / "archived.verify.jsonl")
+		self.assertNotEqual(report_mod.verify_path_for(custom), VERIFY_PATH)
+
+	# --- arithmetic ---------------------------------------------------------------
+
+	def test_overall_score_arithmetic_excludes_non_verdicts_from_both_sides(self):
+		summary = self.summarise(
+			[
+				_record("a1", STATUS_KILLED, module="gameplan/foo.py"),
+				_record("a2", STATUS_KILLED, module="gameplan/foo.py"),
+				_record("a3", STATUS_SURVIVED, module="gameplan/foo.py"),
+				_record("a4", STATUS_INFRA_ERROR, module="gameplan/foo.py"),
+				_record("b1", STATUS_KILLED_BY_OTHER_SUITE, module="gameplan/bar.py"),
+				_record("b2", STATUS_SURVIVED, module="gameplan/bar.py"),
+				_record("b3", STATUS_SURVIVED, module="gameplan/bar.py"),
+			]
+		)
+		foo = summary["modules"]["gameplan/foo.py"]
+		self.assertEqual((foo["total"], foo["scored"], foo["unscored"], foo["killed"]), (4, 3, 1, 2))
+		self.assertAlmostEqual(foo["score"], 0.6667, places=4)
+		overall = summary["overall"]
+		self.assertEqual((overall["total"], overall["scored"], overall["unscored"]), (7, 6, 1))
+		self.assertEqual(overall["killed"], 3)
+		self.assertEqual(overall["score"], 0.5)
+		self.assertIn("3/6 killed", report_mod.render_text(summary))
+
+	def test_every_killed_status_counts_toward_the_score(self):
+		records = [_record(f"k{i}", status) for i, status in enumerate(sorted(KILLED_STATUSES))]
+		summary = self.summarise(records)
+		self.assertEqual(summary["overall"]["killed"], len(KILLED_STATUSES))
+		self.assertEqual(summary["overall"]["score"], 1.0)
+
+	def test_summary_is_json_serialisable(self):
+		summary = self.summarise([_record("a1", STATUS_INFRA_ERROR), _record("a2", STATUS_KILLED)])
+		payload = json.loads(json.dumps(summary, sort_keys=True))
+		self.assertEqual(payload["overall"]["score"], 1.0)
+
+
+class MutationReportExitCodeTest(unittest.TestCase):
+	"""The report is a CI gate, so its exit code has to carry the same honesty as its text.
+
+	Three outcomes, three codes: measured-and-good, measured-and-below-threshold, and
+	could-not-measure. Collapsing the third into either of the others is how a nightly
+	ends up reporting a healthy suite for a run in which nothing was ever executed.
+	"""
+
+	def setUp(self) -> None:
+		self._tmp = tempfile.TemporaryDirectory()
+		self.addCleanup(self._tmp.cleanup)
+		self.tmp = Path(self._tmp.name)
+
+	def run_report(self, records: list[dict] | None, **kwargs: object) -> tuple[int, str]:
+		"""Run the report over a synthetic journal. ``None`` means "no journal at all"."""
+		journal = self.tmp / "journal.jsonl"
+		if records is not None:
+			with open(journal, "w", encoding="utf-8") as handle:
+				for record in records:
+					handle.write(json.dumps(record, sort_keys=True) + "\n")
+		buffer = io.StringIO()
+		with contextlib.redirect_stdout(buffer):
+			code = report_mod.report(journal_path=journal, **kwargs)
+		return code, buffer.getvalue()
+
+	def test_exit_codes_are_three_distinct_values(self):
+		codes = {report_mod.EXIT_OK, report_mod.EXIT_BELOW_THRESHOLD, report_mod.EXIT_NOTHING_MEASURED}
+		self.assertEqual(len(codes), 3)
+		self.assertEqual(report_mod.EXIT_OK, 0)
+		self.assertNotEqual(report_mod.EXIT_NOTHING_MEASURED, report_mod.EXIT_BELOW_THRESHOLD)
+
+	def test_measured_and_good_exits_zero(self):
+		code, out = self.run_report([_record("k1", STATUS_KILLED), _record("k2", STATUS_SURVIVED)])
+		self.assertEqual(code, report_mod.EXIT_OK)
+		self.assertIn("OVERALL: 50%", out)
+
+	def test_nothing_measured_does_not_exit_zero(self):
+		"""The bug this closes: 'OVERALL: n/a - NOTHING MEASURED' used to exit 0."""
+		code, out = self.run_report([_record("k1", STATUS_INFRA_ERROR), _record("k2", STATUS_INFRA_ERROR)])
+		self.assertEqual(code, report_mod.EXIT_NOTHING_MEASURED)
+		self.assertIn("NOTHING MEASURED", out)
+		self.assertIn("FAIL", out)
+
+	def test_missing_journal_is_nothing_measured_not_success(self):
+		code, out = self.run_report(None)
+		self.assertEqual(code, report_mod.EXIT_NOTHING_MEASURED)
+		self.assertIn("no results", out)
+
+	def test_empty_journal_is_nothing_measured_not_success(self):
+		code, _out = self.run_report([])
+		self.assertEqual(code, report_mod.EXIT_NOTHING_MEASURED)
+
+	def test_report_still_renders_when_it_gates(self):
+		"""The numbers are the point; the exit code only decides whether a machine acts."""
+		for fmt in ("text", "md", "json"):
+			with self.subTest(fmt=fmt):
+				code, out = self.run_report([_record("k1", STATUS_SURVIVED)], fmt=fmt, fail_under=50)
+				self.assertEqual(code, report_mod.EXIT_BELOW_THRESHOLD)
+				self.assertIn("gameplan/foo.py", out)
+
+	# --- --fail-under ------------------------------------------------------------
+
+	def test_fail_under_fails_a_regressed_score(self):
+		records = [_record("k1", STATUS_KILLED), _record("k2", STATUS_SURVIVED)]
+		code, out = self.run_report(records, fail_under=80)
+		self.assertEqual(code, report_mod.EXIT_BELOW_THRESHOLD)
+		self.assertIn("below --fail-under 80%", out)
+
+	def test_fail_under_passes_a_score_that_meets_it(self):
+		records = [_record("k1", STATUS_KILLED), _record("k2", STATUS_SURVIVED)]
+		self.assertEqual(self.run_report(records, fail_under=50)[0], report_mod.EXIT_OK)
+		self.assertEqual(self.run_report(records, fail_under=25)[0], report_mod.EXIT_OK)
+
+	def test_fail_under_does_not_fail_a_score_exactly_on_the_threshold(self):
+		"""The score is rounded to 4 places, so an exact threshold must not fail on noise."""
+		records = [_record(f"k{i}", STATUS_KILLED if i < 2 else STATUS_SURVIVED) for i in range(3)]
+		self.assertAlmostEqual(report_mod.summarise(records)["overall"]["score"], 0.6667, places=4)
+		self.assertEqual(self.run_report(records, fail_under=66.67)[0], report_mod.EXIT_OK)
+
+	def test_without_fail_under_a_low_score_is_not_a_failure(self):
+		"""Reporting is not gating: --fail-under is opt-in, nothing-measured is not."""
+		code, _out = self.run_report([_record("k1", STATUS_SURVIVED)])
+		self.assertEqual(code, report_mod.EXIT_OK)
+
+	def test_could_not_measure_outranks_the_threshold_gate(self):
+		"""A broken run must not be reported as a score regression: they need different fixes."""
+		code, out = self.run_report([_record("k1", STATUS_INFRA_ERROR)], fail_under=90)
+		self.assertEqual(code, report_mod.EXIT_NOTHING_MEASURED)
+		self.assertNotIn("below --fail-under", out)
+
+	def test_gate_is_usable_on_a_summary_directly(self):
+		measured = report_mod.summarise([_record("k1", STATUS_KILLED)])
+		unmeasured = report_mod.summarise([_record("k1", STATUS_INFRA_ERROR)])
+		with contextlib.redirect_stdout(io.StringIO()):
+			self.assertEqual(report_mod.gate(measured), report_mod.EXIT_OK)
+			self.assertEqual(report_mod.gate(measured, fail_under=100), report_mod.EXIT_OK)
+			self.assertEqual(report_mod.gate(unmeasured), report_mod.EXIT_NOTHING_MEASURED)
+			self.assertEqual(report_mod.gate(unmeasured, fail_under=0), report_mod.EXIT_NOTHING_MEASURED)
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/gameplan/tests/platform/test_mutation_report.py
+++ b/gameplan/tests/platform/test_mutation_report.py
@@ -173,7 +173,7 @@ class MutationReportTest(unittest.TestCase):
 		self.assertIsNone(summary["modules"]["gameplan/foo.py"]["baseline_skip"])
 		self.assertEqual(summary["modules"]["gameplan/foo.py"]["score"], 0.5)
 		text = report_mod.render_text(summary)
-		self.assertNotIn("Skipped (red baseline)", text)
+		self.assertNotIn("Skipped - measured nothing this run", text)
 
 	def test_baseline_skip_after_the_mutants_marks_the_score_stale(self):
 		summary = self.summarise(
@@ -187,7 +187,7 @@ class MutationReportTest(unittest.TestCase):
 		self.assertEqual(summary["modules"]["gameplan/foo.py"]["baseline_skip"], "red baseline")
 		text = report_mod.render_text(summary)
 		self.assertIn("STALE", text)
-		self.assertIn("Skipped (red baseline)", text)
+		self.assertIn("Skipped - measured nothing this run", text)
 		self.assertIn("(stale: skipped, red baseline)", report_mod.render_markdown(summary))
 
 	def test_baseline_skip_alone_still_reported(self):
@@ -274,9 +274,11 @@ class MutationReportTest(unittest.TestCase):
 class MutationReportExitCodeTest(unittest.TestCase):
 	"""The report is a CI gate, so its exit code has to carry the same honesty as its text.
 
-	Three outcomes, three codes: measured-and-good, measured-and-below-threshold, and
-	could-not-measure. Collapsing the third into either of the others is how a nightly
-	ends up reporting a healthy suite for a run in which nothing was ever executed.
+	Four outcomes, four codes: measured-and-good, measured-and-below-threshold,
+	measured-and-got-no-verdict, and nothing-to-report. Collapsing any of the last two into
+	either of the first is how a nightly ends up reporting a healthy suite for a run in
+	which nothing was ever executed - or how a pull-request job turns "my one measurement
+	timed out" into "this pull request changed no mutable behaviour".
 	"""
 
 	def setUp(self) -> None:
@@ -292,13 +294,24 @@ class MutationReportExitCodeTest(unittest.TestCase):
 				for record in records:
 					handle.write(json.dumps(record, sort_keys=True) + "\n")
 		buffer = io.StringIO()
-		with contextlib.redirect_stdout(buffer):
+		errors = io.StringIO()
+		# stdout is the report itself (it is piped into a job summary and into json.load),
+		# so every human-facing notice must be on stderr. Captured separately here so a
+		# regression that puts chatter back on stdout fails a test instead of a CI job.
+		with contextlib.redirect_stdout(buffer), contextlib.redirect_stderr(errors):
 			code = report_mod.report(journal_path=journal, **kwargs)
-		return code, buffer.getvalue()
+		self.stdout = buffer.getvalue()
+		self.stderr = errors.getvalue()
+		return code, self.stdout
 
-	def test_exit_codes_are_three_distinct_values(self):
-		codes = {report_mod.EXIT_OK, report_mod.EXIT_BELOW_THRESHOLD, report_mod.EXIT_NOTHING_MEASURED}
-		self.assertEqual(len(codes), 3)
+	def test_exit_codes_are_four_distinct_values(self):
+		codes = {
+			report_mod.EXIT_OK,
+			report_mod.EXIT_BELOW_THRESHOLD,
+			report_mod.EXIT_NOTHING_MEASURED,
+			report_mod.EXIT_NOTHING_TO_REPORT,
+		}
+		self.assertEqual(len(codes), 4)
 		self.assertEqual(report_mod.EXIT_OK, 0)
 		self.assertNotEqual(report_mod.EXIT_NOTHING_MEASURED, report_mod.EXIT_BELOW_THRESHOLD)
 
@@ -312,16 +325,27 @@ class MutationReportExitCodeTest(unittest.TestCase):
 		code, out = self.run_report([_record("k1", STATUS_INFRA_ERROR), _record("k2", STATUS_INFRA_ERROR)])
 		self.assertEqual(code, report_mod.EXIT_NOTHING_MEASURED)
 		self.assertIn("NOTHING MEASURED", out)
-		self.assertIn("FAIL", out)
+		self.assertIn("FAIL", self.stderr)
 
-	def test_missing_journal_is_nothing_measured_not_success(self):
+	def test_missing_journal_has_nothing_to_report_and_does_not_succeed(self):
 		code, out = self.run_report(None)
-		self.assertEqual(code, report_mod.EXIT_NOTHING_MEASURED)
-		self.assertIn("no results", out)
+		self.assertEqual(code, report_mod.EXIT_NOTHING_TO_REPORT)
+		self.assertNotEqual(code, report_mod.EXIT_OK)
+		self.assertIn("no results", self.stderr)
+		# Rendered, not silent: both CI gates parse this stdout, and a step that prints
+		# nothing forces its caller to guess whether the report was empty or crashed.
+		self.assertIn("Nothing to report", out)
 
-	def test_empty_journal_is_nothing_measured_not_success(self):
+	def test_empty_journal_has_nothing_to_report_and_does_not_succeed(self):
 		code, _out = self.run_report([])
-		self.assertEqual(code, report_mod.EXIT_NOTHING_MEASURED)
+		self.assertEqual(code, report_mod.EXIT_NOTHING_TO_REPORT)
+		self.assertNotEqual(code, report_mod.EXIT_OK)
+
+	def test_an_empty_result_set_and_a_verdictless_one_do_not_share_a_code(self):
+		"""They license opposite statements: "nothing to say" vs "the measurement broke"."""
+		empty, _ = self.run_report([])
+		verdictless, _ = self.run_report([_record("k1", STATUS_INFRA_ERROR)])
+		self.assertNotEqual(empty, verdictless)
 
 	def test_report_still_renders_when_it_gates(self):
 		"""The numbers are the point; the exit code only decides whether a machine acts."""
@@ -337,7 +361,7 @@ class MutationReportExitCodeTest(unittest.TestCase):
 		records = [_record("k1", STATUS_KILLED), _record("k2", STATUS_SURVIVED)]
 		code, out = self.run_report(records, fail_under=80)
 		self.assertEqual(code, report_mod.EXIT_BELOW_THRESHOLD)
-		self.assertIn("below --fail-under 80%", out)
+		self.assertIn("below --fail-under 80%", self.stderr)
 
 	def test_fail_under_passes_a_score_that_meets_it(self):
 		records = [_record("k1", STATUS_KILLED), _record("k2", STATUS_SURVIVED)]

--- a/gameplan/tests/platform/test_mutation_safety.py
+++ b/gameplan/tests/platform/test_mutation_safety.py
@@ -1,0 +1,348 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# MIT License. See license.txt
+
+"""Tests for the mutation harness's crash-safety net.
+
+The harness edits real source files in place, so this module is the only thing standing
+between an interrupted run and a corrupted working tree. Every test here pins a way the
+net used to have a hole while still looking intact:
+
+* ``install_backup`` overwrote an existing sidecar backup with whatever was on disk, so
+  a crash that left a mutant behind turned that mutant into "the original" - and the
+  next restore wrote it back permanently.
+* the "belongs to another live process" guard in ``release()`` ran after ``restore()``
+  had already stamped our own pid on the manifest, so it could never fire.
+* ``CampaignLock.acquire`` created the lock file and wrote the owning pid in two steps,
+  and a second process arriving in between read no owner and stole a live lock.
+* ``git_is_clean`` called an untracked file clean, promising a ``git checkout --``
+  escape hatch that does not exist for it.
+
+Pure unit tests: tempfile only, no site and no bench.
+"""
+
+import fcntl
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from gameplan.tests.mutation import safety
+
+ORIGINAL = "def answer():\n\treturn 42\n"
+MUTANT = "def answer():\n\treturn 43\n"
+HAND_EDIT = "def answer():\n\treturn 'edited by a human'\n"
+
+# pid 1 always exists and is never us, so it is a stable stand-in for "another live
+# process" (os.kill raises PermissionError rather than ProcessLookupError for it).
+LIVE_FOREIGN_PID = 1
+
+
+def dead_pid() -> int:
+	"""A pid that is guaranteed to have exited and been reaped."""
+	proc = subprocess.Popen([sys.executable, "-c", ""])
+	proc.wait()
+	return proc.pid
+
+
+class MutationSafetyTestCase(unittest.TestCase):
+	"""Redirects the sidecar backup directory into a scratch dir."""
+
+	def setUp(self):
+		self.tmp = tempfile.TemporaryDirectory()
+		self.addCleanup(self.tmp.cleanup)
+		self.root = Path(self.tmp.name)
+		self.backup_dir = self.root / "backup"
+		self.backup_dir.mkdir()
+		patcher = mock.patch.object(safety, "BACKUP_DIR", self.backup_dir)
+		patcher.start()
+		self.addCleanup(patcher.stop)
+		self.source = self.root / "target.py"
+		self.source.write_text(ORIGINAL)
+
+	def guard(self) -> safety.FileGuard:
+		return safety.FileGuard(self.source)
+
+	def crashed_run(self) -> safety.FileGuard:
+		"""Leave a mutant on disk with its backup and manifest intact, as a SIGKILL would."""
+		guard = self.guard()
+		guard.install_backup()
+		guard.apply(MUTANT)
+		self.assertEqual(self.source.read_text(), MUTANT)
+		return guard
+
+
+class TestFileGuardRoundTrip(MutationSafetyTestCase):
+	def test_backup_restore_round_trip(self):
+		guard = self.guard()
+		guard.install_backup()
+		self.assertEqual(self.backup_dir_bytes(guard), ORIGINAL)
+
+		guard.apply(MUTANT)
+		self.assertEqual(self.source.read_text(), MUTANT)
+
+		guard.restore()
+		self.assertEqual(self.source.read_text(), ORIGINAL)
+
+	def test_release_restores_and_drops_the_backup(self):
+		guard = self.crashed_run()
+		guard.release()
+		self.assertEqual(self.source.read_text(), ORIGINAL)
+		self.assertFalse(guard.backup_path.exists())
+		self.assertFalse(guard.manifest_path.exists())
+
+	def test_restore_detects_a_file_that_did_not_go_back(self):
+		guard = self.guard()
+		guard.install_backup()
+		guard.apply(MUTANT)
+		# Simulate a restore that silently fails to land: the sha check must catch it.
+		with mock.patch.object(safety, "write_atomic"):
+			with self.assertRaises(safety.RestoreError):
+				guard.restore()
+
+	def test_manifest_records_the_mutant_before_it_is_written(self):
+		guard = self.crashed_run()
+		manifest = json.loads(guard.manifest_path.read_text())
+		self.assertEqual(manifest["sha256"], safety.sha256_text(ORIGINAL))
+		self.assertEqual(manifest["mutated_sha256"], safety.sha256_text(MUTANT))
+
+	def backup_dir_bytes(self, guard: safety.FileGuard) -> str:
+		return guard.backup_path.read_text()
+
+
+class TestInstallBackupNeverOverwrites(MutationSafetyTestCase):
+	"""An existing backup is evidence of an unrestored crash, not a stale file."""
+
+	def test_recovers_the_original_instead_of_backing_up_the_mutant(self):
+		crashed = self.crashed_run()
+
+		# A fresh run over the same file: it reads the mutant as its "original".
+		guard = self.guard()
+		self.assertEqual(guard.source, MUTANT)
+		guard.install_backup()
+
+		self.assertEqual(guard.backup_path, crashed.backup_path)
+		self.assertEqual(guard.backup_path.read_text(), ORIGINAL, "the backup was overwritten")
+		self.assertEqual(self.source.read_text(), ORIGINAL, "the mutant was not undone")
+		self.assertEqual(guard.source, ORIGINAL, "the guard still thinks the mutant is pristine")
+		self.assertEqual(guard.original_sha, safety.sha256_text(ORIGINAL))
+
+	def test_recovered_guard_restores_the_original_not_the_mutant(self):
+		self.crashed_run()
+		guard = self.guard()
+		guard.install_backup()
+		guard.apply("def answer():\n\treturn 44\n")
+		guard.release()
+		self.assertEqual(self.source.read_text(), ORIGINAL)
+
+	def test_adopts_a_leftover_backup_when_the_file_is_already_clean(self):
+		crashed = self.crashed_run()
+		crashed.restore()  # crashed after restoring but before deleting the sidecar
+		before = crashed.backup_path.read_bytes()
+
+		guard = self.guard()
+		guard.install_backup()
+		self.assertEqual(guard.backup_path.read_bytes(), before)
+		self.assertEqual(self.source.read_text(), ORIGINAL)
+
+	def test_refuses_when_the_target_was_edited_since_the_crash(self):
+		crashed = self.crashed_run()
+		self.source.write_text(HAND_EDIT)
+
+		guard = self.guard()
+		with self.assertRaises(safety.RestoreError):
+			guard.install_backup()
+
+		self.assertEqual(self.source.read_text(), HAND_EDIT, "a human edit was destroyed")
+		self.assertEqual(crashed.backup_path.read_text(), ORIGINAL)
+
+	def test_refuses_a_backup_owned_by_a_live_process(self):
+		crashed = self.crashed_run()
+		manifest = json.loads(crashed.manifest_path.read_text())
+		manifest["pid"] = LIVE_FOREIGN_PID
+		crashed.manifest_path.write_text(json.dumps(manifest))
+
+		with self.assertRaises(safety.LockError):
+			self.guard().install_backup()
+		self.assertEqual(crashed.backup_path.read_text(), ORIGINAL)
+
+	def test_refuses_a_corrupt_backup(self):
+		crashed = self.crashed_run()
+		crashed.backup_path.write_text("truncated")
+		with self.assertRaises(safety.RestoreError):
+			self.guard().install_backup()
+
+
+class TestReleaseOwnershipGuard(MutationSafetyTestCase):
+	"""The 'this backup belongs to somebody else' branch has to be reachable."""
+
+	def test_does_not_delete_a_backup_owned_by_another_live_process(self):
+		guard = self.crashed_run()
+		manifest = json.loads(guard.manifest_path.read_text())
+		manifest["pid"] = LIVE_FOREIGN_PID
+		guard.manifest_path.write_text(json.dumps(manifest))
+
+		guard.release()
+
+		self.assertEqual(self.source.read_text(), ORIGINAL, "a mutant was left on disk")
+		self.assertTrue(guard.backup_path.exists(), "another process's backup was deleted")
+		self.assertTrue(guard.manifest_path.exists())
+		owner = json.loads(guard.manifest_path.read_text())["pid"]
+		self.assertEqual(owner, LIVE_FOREIGN_PID, "we stamped our own pid on their manifest")
+
+	def test_restore_does_not_steal_a_foreign_manifest(self):
+		guard = self.crashed_run()
+		manifest = json.loads(guard.manifest_path.read_text())
+		manifest["pid"] = LIVE_FOREIGN_PID
+		guard.manifest_path.write_text(json.dumps(manifest))
+
+		guard.restore()
+
+		self.assertEqual(json.loads(guard.manifest_path.read_text())["pid"], LIVE_FOREIGN_PID)
+
+	def test_deletes_its_own_backup_when_the_owner_is_dead(self):
+		guard = self.crashed_run()
+		manifest = json.loads(guard.manifest_path.read_text())
+		manifest["pid"] = dead_pid()
+		guard.manifest_path.write_text(json.dumps(manifest))
+
+		guard.release()
+
+		self.assertFalse(guard.backup_path.exists())
+		self.assertFalse(guard.manifest_path.exists())
+
+
+class TestCampaignLock(unittest.TestCase):
+	def setUp(self):
+		self.tmp = tempfile.TemporaryDirectory()
+		self.addCleanup(self.tmp.cleanup)
+		self.path = Path(self.tmp.name) / "nested" / "campaign.lock"
+
+	def lock(self) -> safety.CampaignLock:
+		return safety.CampaignLock(self.path)
+
+	def test_acquire_writes_the_owner_and_release_removes_the_file(self):
+		lock = self.lock()
+		lock.acquire()
+		self.assertTrue(self.path.exists())
+		self.assertEqual(json.loads(self.path.read_text())["pid"], os.getpid())
+		lock.release()
+		self.assertFalse(self.path.exists())
+
+	def test_context_manager_releases(self):
+		with self.lock():
+			self.assertTrue(self.path.exists())
+		self.assertFalse(self.path.exists())
+
+	def test_stale_lock_from_a_dead_pid_is_reclaimed(self):
+		self.path.parent.mkdir(parents=True)
+		self.path.write_text(json.dumps({"pid": dead_pid(), "started": 0}))
+
+		lock = self.lock()
+		lock.acquire()
+		self.addCleanup(lock.release)
+		self.assertEqual(json.loads(self.path.read_text())["pid"], os.getpid())
+
+	def test_live_lock_is_not_stolen(self):
+		self.path.parent.mkdir(parents=True)
+		self.path.write_text(json.dumps({"pid": LIVE_FOREIGN_PID, "started": 0}))
+
+		with self.assertRaises(safety.LockError):
+			self.lock().acquire()
+		self.assertEqual(json.loads(self.path.read_text())["pid"], LIVE_FOREIGN_PID)
+
+	def test_half_written_lock_is_not_stolen(self):
+		"""The exact state that used to exist between O_EXCL create and the pid write."""
+		self.path.parent.mkdir(parents=True)
+		self.path.write_text("")
+
+		with self.assertRaises(safety.LockError):
+			self.lock().acquire()
+		self.assertEqual(self.path.read_text(), "")
+
+	def test_flock_held_by_another_descriptor_is_not_stolen(self):
+		"""Liveness comes from the held descriptor, not from a pid that may be recycled."""
+		self.path.parent.mkdir(parents=True)
+		self.path.write_text(json.dumps({"pid": dead_pid(), "started": 0}))
+		fd = os.open(self.path, os.O_RDONLY)
+		self.addCleanup(os.close, fd)
+		fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+		with self.assertRaises(safety.LockError):
+			self.lock().acquire()
+
+	def test_lock_file_is_never_published_without_an_owner(self):
+		"""Whatever a concurrent reader sees at the lock path, it names a pid."""
+		lock = self.lock()
+		lock.acquire()
+		self.addCleanup(lock.release)
+		self.assertIsNotNone(safety.CampaignLock(self.path)._read_owner())
+
+	def test_release_leaves_a_lock_that_is_no_longer_ours(self):
+		lock = self.lock()
+		lock.acquire()
+		self.path.write_text(json.dumps({"pid": LIVE_FOREIGN_PID, "started": 0}))
+		lock.release()
+		self.assertTrue(self.path.exists())
+
+
+class TestGitIsClean(unittest.TestCase):
+	def setUp(self):
+		self.tmp = tempfile.TemporaryDirectory()
+		self.addCleanup(self.tmp.cleanup)
+		self.repo = Path(self.tmp.name)
+		self.git("init", "-q")
+		self.git("config", "user.email", "test@example.com")
+		self.git("config", "user.name", "Test")
+		(self.repo / "tracked.py").write_text(ORIGINAL)
+		(self.repo / "staged.py").write_text(ORIGINAL)
+		(self.repo / "hidden.py").write_text(ORIGINAL)
+		self.git("add", "tracked.py", "staged.py", "hidden.py")
+		self.git("commit", "-qm", "seed")
+		patcher = mock.patch.object(safety, "APP_ROOT", self.repo)
+		patcher.start()
+		self.addCleanup(patcher.stop)
+
+	def git(self, *args: str) -> None:
+		subprocess.run(["git", *args], cwd=self.repo, check=True, capture_output=True)
+
+	def test_committed_file_is_clean(self):
+		self.assertEqual(safety.git_is_clean(["tracked.py"]), (True, []))
+
+	def test_modified_file_is_dirty(self):
+		(self.repo / "tracked.py").write_text(MUTANT)
+		self.assertEqual(safety.git_is_clean(["tracked.py"]), (False, ["tracked.py"]))
+
+	def test_staged_file_is_dirty(self):
+		(self.repo / "staged.py").write_text(MUTANT)
+		self.git("add", "staged.py")
+		self.assertEqual(safety.git_is_clean(["staged.py"]), (False, ["staged.py"]))
+
+	def test_untracked_file_is_dirty(self):
+		(self.repo / "untracked.py").write_text(ORIGINAL)
+		# git diff is silent about it, but 'git checkout -- untracked.py' cannot
+		# recover it, so the escape hatch the check promises does not exist.
+		clean, dirty = safety.git_is_clean(["untracked.py"])
+		self.assertFalse(clean)
+		self.assertEqual(dirty, ["untracked.py"])
+
+	def test_assume_unchanged_file_is_dirty(self):
+		self.git("update-index", "--assume-unchanged", "hidden.py")
+		(self.repo / "hidden.py").write_text(MUTANT)
+		clean, dirty = safety.git_is_clean(["hidden.py"])
+		self.assertFalse(clean)
+		self.assertEqual(dirty, ["hidden.py"])
+
+	def test_reports_every_dirty_path(self):
+		(self.repo / "tracked.py").write_text(MUTANT)
+		(self.repo / "untracked.py").write_text(ORIGINAL)
+		clean, dirty = safety.git_is_clean(["tracked.py", "staged.py", "untracked.py"])
+		self.assertFalse(clean)
+		self.assertEqual(dirty, ["tracked.py", "untracked.py"])
+
+
+if __name__ == "__main__":
+	unittest.main()


### PR DESCRIPTION
Adds mutation testing to the backend, wires it into CI so it runs every night, and fixes the bugs it found.

Mutation testing edits the source — flips a `>` to `>=`, turns a `return False` into `return None` — reruns the tests, and asks whether anything noticed. A mutant that survives is a line no test is actually checking. The point is that a green suite tells you the tests ran, not that they assert anything.

Suite goes **960 → 1081 tests**.

## What it found

Every bug below started as a surviving mutant. None of them was on a list of suspected problems.

**Correctness**

- `get_unread_count` could not run on SQLite at all. `query1 + query2` renders a set operation with each term parenthesised, which SQLite rejects outright. It only looked healthy because the empty case returns first. Rewritten as one OR'd predicate over a single pair of joins — portable and simpler. `COUNT` is `DISTINCT` because a Space can carry duplicate visit rows and both branches then fire for the same discussion.
- Merging a Space into itself deleted it. The guard compared `self.name` against the target *before* coercing: `GP Project` autoincrements so the name is an int, the dialog sends a string, `"7" != 7`, and the rename emptied the Space into nothing.
- `get_joined_spaces` returned a Space twice to anyone holding it both as a member and as a guest — one query plucked the id as an int, the other as a str, so the set deduped nothing.
- A poll's close instant meant two different things: the feed hid a poll at `stopped_at` that the ballot would still accept a vote on. The rule is written once now, with a query mirror, and a test pins the two together.
- Withdrawing a reaction re-lit the post owner's bell. `notify_reactions` used a length comparison as a proxy for "someone reacted", which is wrong in both directions — a removal changes the length too, and an emoji swap keeps it equal so a genuine new reaction notified nobody.
- `archive()` deleted pins for the session user only, so everyone else who pinned that Space kept an archived Space in their sidebar. There is already a patch that exists purely to clean this state up, and its precondition regenerated on every archive.

**Input handling**

`get_discussions` passed two client-supplied strings to the query builder without validation: `order_by` (splice as a field plus a bare direction keyword) and `start` (straight into `OFFSET`). Both are parsed against fixed lists now, and a rejected value is a 417 rather than a traceback. `filters` was audited at the same time and is genuinely safe — field names are charset-validated, operators come from a fixed map, values are escaped — though a non-dict was a 500, which is fixed.

**Permissions**

- Merging a Space checked write on the source only. `validate_rename=False` skipped frappe's own "you need write permission on the target to merge" check, so a manager of one Space could empty it into a Space they had no rights over. Gated explicitly, guests refused up front the way `can_invite_guest` refuses them, and the gate runs *before* the target-exists check so a forbidden target is indistinguishable from a missing one.
- Four doctypes holding per-user state — `GP Notification`, `GP Project Visit`, `GP Discussion Visit`, `GP Pinned Project` — were not scoped to the user they belong to. Now scoped with query-condition and `has_permission` hooks in a new `per_user_state.py`. Not `if_owner`, which is wrong for `GP Notification`: its `owner` is whoever *triggered* it, so `if_owner` would hand each notification to the sender and hide it from the recipient. Every server-side writer was enumerated first; cascade deletes needed the existing `from_gameplan_delete_cascade` exemption, and pins needed a `create` carve-out because `Document.insert` runs its create check before `before_insert`, which is where the controller stamps the user.

**Dead code**: an unreferenced `get_meta_tags` that made an outbound HTTP request from a doctype controller; a no-op `as_dict` override; and `force=True` on the merge rename, which `Document.rename` forwards in a way that `validate=False` skips entirely.

## The harness was inflating its own score

Worth calling out because it invalidates any number measured before it. Timeouts, wedged sites, any subprocess output containing the substring `ImportError`, and mid-run deaths were all recorded as permanent, non-retryable **kills** — the most favourable verdict, cached forever, never retried. The circuit breaker meant to catch a run going bad watched statuses the code never wrote, so it could not fire.

"No verdict from the suite" is now its own class: never scored, always retried, and it trips the breaker. `config.py` holds one source of truth with two aliases, and three set relations between them are asserted by a test, so a new status has to land in the right place.

## CI

**Nightly** grinds for a fixed 45-minute budget, resuming from a cached journal and rotating least-recently-measured modules first, so the corpus is covered over several nights instead of one ~2h job pinned against the Actions ceiling. The budget is enforced *inside* the harness, between mutants, never mid-mutant — a SIGKILL at the wrong moment is what the restore guard exists to prevent — so `timeout-minutes` is a backstop only.

**Per-PR** mutates only the targets the diff touches and reports into the step summary rather than gating on a score. A percentage threshold on a five-minute sample gets gamed or ignored; the useful artefact is the list of survivors in code the author just wrote.

Three adversarial reviews found flaws before merge, two of which would have been silent:

- Caching the whole `.mutation/` directory transplanted crash sidecars and the campaign lock onto the next runner, so a cancelled run would wedge every subsequent night — self-sustaining, and red on every PR too, under a message blaming the circuit breaker. Only the journal files are cached now.
- Mutant identity is derived from source, so nothing invalidated a verdict when the **tests** changed. Deleting an assertion would never be re-measured: the nightly would look green while doing less work every night, blind to the one regression it exists to catch. Verdicts now carry a fingerprint of the test modules that produced them, including the shared helpers in `tests/base.py` and `tests/fixtures.py`.
- Skip records were immortal — currency was inferred from position in a list callers could filter, so the PR job resurrected weeks-old red baselines. Currency is data now.

## Numbers

Five modules re-measured under the fixed harness, **zero no-verdict rows** — every mutant got a real verdict, so these are honest stage-1 floors rather than low-denominator artefacts.

| Module | Mutants | Killed | Score | Old figure |
|---|---|---|---|---|
| `permissions.py` | 273 | 171 | 63% | 44% |
| `gp_discussion/api.py` | 74 | 65 | 88% | 82% |
| `gp_poll.py` | 54 | 45 | 83% | 87% |
| `gp_project.py` | 46 | 30 → **38** | 65% → **83%** | 42% |
| `mixins/reactions.py` | 38 | 32 → **38** | 84% → **100%** | 81% |

Read those honestly:

- **Denominators changed for four of five modules**, so the percentages are not like-for-like.
- **`gp_poll` did not regress.** It dropped because the fix *added* code. On the 45 mutants common to both runs the score went *up*, and the one old survivor that disappeared is exactly the boundary the fix replaced.
- **`gp_project` 42% → 65% is about half real.** Deleting `as_dict` and `get_meta_tags` took 8 never-killed survivors out of the denominator. Deleting untested code raises a mutation score without testing anything.
- **`permissions.py` did not move at all.** Its verdict set is identical to the pre-branch run, function by function. The 235 lines of tests added to its mapped test files killed **zero** additional mutants. The 44% → 63% jump is entirely the harness getting honest.

Stage-1 scores mean "not caught by this module's own tests", which is weaker than "not caught by anything".

## One prediction that failed

Seven `ignore_permissions=True` mutants survived, which is the harness asking whether a security flag does anything. Following that pointer found the per-user-state problem above. The prediction that fixing it would make those mutants killable was **measured, and wrong** — zero of six died. Those call sites only ever write the caller's own row, so the hook permits them either way; what the hooks close is the neighbouring surface where the row belongs to somebody else.

The mutants were a good pointer and a bad test. Only the re-measure separated those — and it also caught the fix having missed `GP Pinned Project`, a doctype of the same shape, including a new survivor of the same kind in the `archive()` line this branch had just rewritten.

## Two reported findings that did not survive scrutiny

Recorded because the reason generalises. **"Guests can enumerate every Community"** does not reproduce — the report was based on `frappe.get_all`, which defaults to `ignore_permissions=True` and is not client-reachable; every real door filters correctly. **"`content_has_permission`'s trailing `return True` is unreachable"** is false — `get_doc_permissions` calls the hook with `ptype=None` to build the whole permission dict, and returning False collapses it to `{None: 0}`. `permissions.py` therefore changes by **comments only**, verified identical at the AST level; all three branches flagged as dead are kept, two as fail-safe defaults whose removal would turn a future denial into a future grant.

## Not done

- **`frontend/src/components/MergeSpaceDialog.vue` is not browser-verified.** It filters merge targets to Spaces the user can manage, mirroring the new backend gate, so a user is not offered an action that will be refused. Reviewed statically and type-checked, but not opened in a browser — the dev tunnel serves a different bench.
- `SpaceOptions.vue` still gates the Merge menu entry on `canEditSpace`, so a non-manager can open the dialog (and now sees an explanation with the button disabled).
- `GP Project Visit` has no unique constraint on `(user, project)` and `track_visit` is a get-then-insert, so duplicate rows are reachable. `COUNT DISTINCT` makes the read side robust; the root cause stands.
- The upstream fix for the SQLite set-operation rendering belongs in frappe, whose SQLite builder leaves pypika's `wrap_set_operation_queries` at `True`. Nothing here is blocked on it.

`HANDOFF-mutation.md` documents the harness, the gotchas that cost real time, and what to pick up next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
