### PR TITLE
fix(roles): never write to a Role that already exists

### DIFF
--- a/gameplan/hooks.py
+++ b/gameplan/hooks.py
@@ -51,7 +51,7 @@ email_css = ["/assets/gameplan/css/email_digest.css"]
 
 # The Gameplan roles are *not* fixtures. Fixture sync deletes and re-inserts every row on
 # each migrate, which fires Role.on_update and re-evaluates every user holding the role.
-# gameplan.roles.sync_roles keeps the same invariant and only writes when something drifted.
+# gameplan.roles.sync_roles creates the roles instead, and only when they are missing.
 
 # Home Pages
 # ----------
@@ -98,8 +98,8 @@ sqlite_search = ["gameplan.search_sqlite.GameplanSearch"]
 before_install = "gameplan.install.before_install"
 after_install = "gameplan.install.after_install"
 
-# Re-asserts that the Gameplan roles exist without desk access. A no-op unless a role went
-# missing (frappe recreates roles named in doctype permissions with desk_access = 1).
+# Creates any Gameplan role that went missing. A no-op on a healthy site — it never writes
+# to a Role that already exists, so migrate cannot trip Role.on_update. See gameplan/roles.py.
 after_migrate = ["gameplan.roles.sync_roles"]
 
 # Uninstallation

--- a/gameplan/install.py
+++ b/gameplan/install.py
@@ -7,9 +7,9 @@ def before_install():
 
 
 def after_install():
-	from gameplan.roles import sync_roles
+	from gameplan.roles import setup_roles
 
-	sync_roles()
+	setup_roles()
 	download_rembg_model()
 
 

--- a/gameplan/roles.py
+++ b/gameplan/roles.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-"""The roles Gameplan assigns to its users, and the code that creates them.
+"""The roles Gameplan assigns to its users, and the code that sets them up.
 
 These used to ship as a `Role` fixture. Fixture sync is not an upsert: `import_doc`
 deletes the old row and re-inserts it, and a fresh insert has no "before save" doc, so
@@ -11,16 +11,22 @@ resulting user save crashes migrate outright, because `User.on_update` enqueues
 `create_contact` with the lazily-loaded user document and the dynamically built
 `LazyUser` class cannot be pickled (fixed upstream in frappe#41187, not on version-16).
 
-So this module creates roles that are missing and otherwise **never writes to an existing
-Role**. Two reasons, and the second is the important one:
+Hence two entry points, because install and migrate own different things:
 
-- Writing re-triggers the crash above, from a hook that runs inside migrate. Since the
-  failure aborts and rolls back migrate, the write never lands and the next migrate tries
-  the exact same write — a permanent deadlock rather than a one-off error.
-- `desk_access` on a live site is an operator's call, not ours. It decides whether members
-  are System Users or Website Users, which controls desk access and Frappe Cloud billing.
-  gameplan.frappe.cloud has run with `desk_access = 1` on Gameplan Member and Admin since
-  someone set it deliberately; resetting it would silently demote ~80 accounts.
+- `setup_roles()` runs at install, where Gameplan defines what its roles mean. It forces
+  `desk_access = 0` so members are Website Users. It has to *correct* the value rather
+  than just create the roles: `install_app` syncs doctypes before calling `after_install`,
+  and frappe's `make_module_and_roles` will already have created every role named in a
+  doctype's permissions with `desk_access = 1`. Writing here is safe because
+  `frappe.flags.in_install` makes `Role.on_update` return early.
+
+- `sync_roles()` runs after migrate and only creates roles that went missing. It must
+  never write to an existing Role. Beyond re-triggering the crash above, a failed write
+  inside migrate is a *deadlock*: the exception rolls migrate back, so the write never
+  lands and the next migrate retries it identically. And `desk_access` on a live site is
+  the operator's call — it decides System User vs Website User, which governs desk access
+  and Frappe Cloud billing. gameplan.frappe.cloud deliberately runs Gameplan Member and
+  Gameplan Admin with `desk_access = 1`; resetting it would demote ~80 accounts.
 """
 
 import frappe
@@ -29,14 +35,19 @@ import frappe
 GAMEPLAN_ROLES = ("Gameplan Guest", "Gameplan Member", "Gameplan Admin")
 
 
-def sync_roles():
-	"""Create any Gameplan role that does not exist yet. Never modify one that does.
+def setup_roles():
+	"""Install-time setup: the Gameplan roles exist and none of them grant desk access."""
+	for role_name in GAMEPLAN_ROLES:
+		if not frappe.db.exists("Role", role_name):
+			frappe.get_doc(doctype="Role", role_name=role_name, desk_access=0).insert(ignore_permissions=True)
+		elif frappe.db.get_value("Role", role_name, "desk_access"):
+			role = frappe.get_doc("Role", role_name)
+			role.desk_access = 0
+			role.save(ignore_permissions=True)
 
-	New roles are created without desk access, so Gameplan members are Website Users by
-	default. This matters because frappe's `make_module_and_roles` auto-creates roles named
-	in a doctype's permissions with `desk_access = 1` — getting in first is the only way to
-	pick the default, and once a role exists its `desk_access` belongs to the operator.
-	"""
+
+def sync_roles():
+	"""Post-migrate repair: create roles that went missing, and touch nothing else."""
 	existing = set(frappe.get_all("Role", filters={"name": ("in", GAMEPLAN_ROLES)}, pluck="name"))
 
 	for role_name in GAMEPLAN_ROLES:

--- a/gameplan/roles.py
+++ b/gameplan/roles.py
@@ -1,19 +1,26 @@
 # Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-"""The roles Gameplan assigns to its users, and the code that keeps them in shape.
+"""The roles Gameplan assigns to its users, and the code that creates them.
 
 These used to ship as a `Role` fixture. Fixture sync is not an upsert: `import_doc`
 deletes the old row and re-inserts it, and a fresh insert has no "before save" doc, so
 `has_value_changed("desk_access")` is always true. That made `Role.on_update` re-evaluate
-every user holding a Gameplan role on *every* `bench migrate`, re-saving some of them for
-no reason — and on frappe v16 that re-save crashes migrate outright, because
-`User.on_update` enqueues `create_contact` with the lazily-loaded user document and the
-dynamically built `LazyUser` class cannot be pickled (fixed upstream in frappe#41187,
-not yet on version-16).
+every user holding a Gameplan role on *every* `bench migrate` — and on frappe v16 the
+resulting user save crashes migrate outright, because `User.on_update` enqueues
+`create_contact` with the lazily-loaded user document and the dynamically built
+`LazyUser` class cannot be pickled (fixed upstream in frappe#41187, not on version-16).
 
-Creating the roles from code keeps the same invariant with none of the churn: it writes
-only when a role is missing or has drifted.
+So this module creates roles that are missing and otherwise **never writes to an existing
+Role**. Two reasons, and the second is the important one:
+
+- Writing re-triggers the crash above, from a hook that runs inside migrate. Since the
+  failure aborts and rolls back migrate, the write never lands and the next migrate tries
+  the exact same write — a permanent deadlock rather than a one-off error.
+- `desk_access` on a live site is an operator's call, not ours. It decides whether members
+  are System Users or Website Users, which controls desk access and Frappe Cloud billing.
+  gameplan.frappe.cloud has run with `desk_access = 1` on Gameplan Member and Admin since
+  someone set it deliberately; resetting it would silently demote ~80 accounts.
 """
 
 import frappe
@@ -23,26 +30,15 @@ GAMEPLAN_ROLES = ("Gameplan Guest", "Gameplan Member", "Gameplan Admin")
 
 
 def sync_roles():
-	"""Ensure the Gameplan roles exist and none of them grant desk access.
+	"""Create any Gameplan role that does not exist yet. Never modify one that does.
 
-	Roles named in a doctype's permissions are auto-created by frappe's
-	`make_module_and_roles` with `desk_access = 1`, which would make every Gameplan
-	member a System User. Correcting drift goes through `Role.save()` rather than a
-	direct `db.set_value` so frappe re-evaluates the affected users' `user_type`.
+	New roles are created without desk access, so Gameplan members are Website Users by
+	default. This matters because frappe's `make_module_and_roles` auto-creates roles named
+	in a doctype's permissions with `desk_access = 1` — getting in first is the only way to
+	pick the default, and once a role exists its `desk_access` belongs to the operator.
 	"""
-	desk_access_by_role = dict(
-		frappe.get_all(
-			"Role",
-			filters={"name": ("in", GAMEPLAN_ROLES)},
-			fields=["name", "desk_access"],
-			as_list=True,
-		)
-	)
+	existing = set(frappe.get_all("Role", filters={"name": ("in", GAMEPLAN_ROLES)}, pluck="name"))
 
 	for role_name in GAMEPLAN_ROLES:
-		if role_name not in desk_access_by_role:
+		if role_name not in existing:
 			frappe.get_doc(doctype="Role", role_name=role_name, desk_access=0).insert(ignore_permissions=True)
-		elif desk_access_by_role[role_name]:
-			role = frappe.get_doc("Role", role_name)
-			role.desk_access = 0
-			role.save(ignore_permissions=True)

--- a/gameplan/roles.py
+++ b/gameplan/roles.py
@@ -47,9 +47,32 @@ def setup_roles():
 
 
 def sync_roles():
-	"""Post-migrate repair: create roles that went missing, and touch nothing else."""
-	existing = set(frappe.get_all("Role", filters={"name": ("in", GAMEPLAN_ROLES)}, pluck="name"))
+	"""Post-migrate repair: create roles that went missing, and touch nothing else.
+
+	Report — rather than fix — a role that grants desk access. Deleting a Gameplan role
+	gets it recreated by `make_module_and_roles` with `desk_access = 1` during the same
+	migrate's doctype sync, and this cannot silently correct that: the write would demote
+	users, and if it raised it would roll migrate back and retry forever. Whether a
+	Gameplan role grants desk access is the operator's call either way, so say what is
+	true and let them decide.
+	"""
+	desk_access_by_role = dict(
+		frappe.get_all(
+			"Role",
+			filters={"name": ("in", GAMEPLAN_ROLES)},
+			fields=["name", "desk_access"],
+			as_list=True,
+		)
+	)
 
 	for role_name in GAMEPLAN_ROLES:
-		if role_name not in existing:
+		if role_name not in desk_access_by_role:
 			frappe.get_doc(doctype="Role", role_name=role_name, desk_access=0).insert(ignore_permissions=True)
+
+	if granting_desk_access := sorted(
+		role for role, desk_access in desk_access_by_role.items() if desk_access
+	):
+		print(
+			f"Gameplan roles granting desk access: {', '.join(granting_desk_access)}. "
+			"Users holding them are System Users. Set desk_access = 0 if that is not intended."
+		)

--- a/gameplan/tests/platform/test_roles.py
+++ b/gameplan/tests/platform/test_roles.py
@@ -1,13 +1,16 @@
 # Copyright (c) 2026, Frappe Technologies Pvt Ltd and Contributors
 # See license.txt
 
-"""Gameplan's roles are created from code, not from a Role fixture.
+"""Gameplan's roles are created from code, and existing roles are left alone.
 
-The fixture was re-inserted on every `bench migrate`, which fired `Role.on_update` and
-re-saved users. On frappe v16 that re-save crashed migrate outright: `User.on_update`
-enqueues `create_contact` with the lazily-loaded user doc, and the dynamically built
-`LazyUser` class is not picklable. The tests here pin both halves — no fixture, and a
-sync that stays silent when nothing drifted.
+The roles used to ship as a fixture, which frappe re-inserts on every `bench migrate`.
+That fired `Role.on_update` -> `update_user_type_on_change()` -> `user.save()`, and on
+frappe v16 the user save crashes migrate: `User.on_update` enqueues `create_contact` with
+the lazily-loaded user doc, and the dynamically built `LazyUser` class is not picklable.
+
+Because the crash aborts and rolls back migrate, *any* Role write from a migrate hook is a
+deadlock, not a one-off error — the write never lands, so the next migrate retries it. The
+tests here pin the one rule that avoids it: create what is missing, touch nothing else.
 """
 
 from unittest.mock import patch
@@ -26,37 +29,46 @@ class TestGameplanRoles(FrappeTestCase):
 		frappe.db.rollback()
 
 	def test_no_role_fixture_is_shipped(self):
-		"""A Role fixture would reintroduce the per-migrate churn this module removed."""
+		"""A Role fixture would reintroduce the per-migrate delete/re-insert churn."""
 		fixtures = frappe.get_hooks("fixtures", app_name="gameplan") or []
 		self.assertEqual([f for f in fixtures if f.get("dt") == "Role"], [])
 
-	def test_gameplan_roles_have_no_desk_access(self):
-		for role in GAMEPLAN_ROLES:
-			with self.subTest(role=role):
-				self.assertEqual(frappe.db.get_value("Role", role, "desk_access"), 0)
-
 	def test_missing_role_is_created_without_desk_access(self):
+		"""Getting in before frappe's make_module_and_roles, which would use desk_access = 1."""
 		with patch("gameplan.roles.GAMEPLAN_ROLES", (TEST_ROLE,)):
 			sync_roles()
 
 		self.assertEqual(frappe.db.get_value("Role", TEST_ROLE, "desk_access"), 0)
 
-	def test_desk_access_drift_is_corrected(self):
-		"""frappe recreates roles named in doctype permissions with desk_access = 1."""
+	def test_desk_access_on_an_existing_role_is_left_alone(self):
+		"""desk_access is the operator's call once the role exists.
+
+		gameplan.frappe.cloud runs Gameplan Member with desk_access = 1 by deliberate
+		choice; resetting it here would demote ~80 accounts to Website User.
+		"""
 		frappe.get_doc(doctype="Role", role_name=TEST_ROLE, desk_access=1).insert()
 
 		with patch("gameplan.roles.GAMEPLAN_ROLES", (TEST_ROLE,)):
 			sync_roles()
 
-		self.assertEqual(frappe.db.get_value("Role", TEST_ROLE, "desk_access"), 0)
+		self.assertEqual(frappe.db.get_value("Role", TEST_ROLE, "desk_access"), 1)
 
-	def test_sync_does_not_touch_roles_that_are_already_correct(self):
-		"""The regression guard: a repeat sync must not re-save the Role.
+	def test_sync_never_saves_an_existing_role(self):
+		"""The regression guard for the migrate deadlock.
 
-		Saving it runs Role.update_user_type_on_change over every user holding the role,
-		which is what broke migrate on frappe v16.
+		Saving a Role runs update_user_type_on_change over every user holding it, which is
+		what kills migrate on frappe v16. Neither a correct role nor a drifted one may save.
 		"""
+		frappe.get_doc(doctype="Role", role_name=TEST_ROLE, desk_access=1).insert()
+
 		with patch.object(Role, "on_update", autospec=True) as on_update:
 			sync_roles()
+			with patch("gameplan.roles.GAMEPLAN_ROLES", (TEST_ROLE,)):
+				sync_roles()
 
 		on_update.assert_not_called()
+
+	def test_all_gameplan_roles_exist(self):
+		for role in GAMEPLAN_ROLES:
+			with self.subTest(role=role):
+				self.assertTrue(frappe.db.exists("Role", role))

--- a/gameplan/tests/platform/test_roles.py
+++ b/gameplan/tests/platform/test_roles.py
@@ -19,7 +19,7 @@ import frappe
 from frappe.core.doctype.role.role import Role
 from frappe.tests.utils import FrappeTestCase
 
-from gameplan.roles import GAMEPLAN_ROLES, sync_roles
+from gameplan.roles import GAMEPLAN_ROLES, setup_roles, sync_roles
 
 TEST_ROLE = "Gameplan Test Role"
 
@@ -34,9 +34,25 @@ class TestGameplanRoles(FrappeTestCase):
 		self.assertEqual([f for f in fixtures if f.get("dt") == "Role"], [])
 
 	def test_missing_role_is_created_without_desk_access(self):
-		"""Getting in before frappe's make_module_and_roles, which would use desk_access = 1."""
 		with patch("gameplan.roles.GAMEPLAN_ROLES", (TEST_ROLE,)):
 			sync_roles()
+
+		self.assertEqual(frappe.db.get_value("Role", TEST_ROLE, "desk_access"), 0)
+
+	def test_install_clears_desk_access_frappe_already_granted(self):
+		"""install_app syncs doctypes before after_install, so make_module_and_roles wins
+		the race and creates every role named in a permission with desk_access = 1. Install
+		has to correct that, or a fresh site makes every Gameplan member a System User."""
+		frappe.get_doc(doctype="Role", role_name=TEST_ROLE, desk_access=1).insert()
+
+		with patch("gameplan.roles.GAMEPLAN_ROLES", (TEST_ROLE,)):
+			setup_roles()
+
+		self.assertEqual(frappe.db.get_value("Role", TEST_ROLE, "desk_access"), 0)
+
+	def test_install_creates_a_missing_role_without_desk_access(self):
+		with patch("gameplan.roles.GAMEPLAN_ROLES", (TEST_ROLE,)):
+			setup_roles()
 
 		self.assertEqual(frappe.db.get_value("Role", TEST_ROLE, "desk_access"), 0)
 

--- a/gameplan/tests/platform/test_roles.py
+++ b/gameplan/tests/platform/test_roles.py
@@ -13,6 +13,8 @@ deadlock, not a one-off error — the write never lands, so the next migrate ret
 tests here pin the one rule that avoids it: create what is missing, touch nothing else.
 """
 
+import io
+from contextlib import redirect_stdout
 from unittest.mock import patch
 
 import frappe
@@ -64,7 +66,7 @@ class TestGameplanRoles(FrappeTestCase):
 		"""
 		frappe.get_doc(doctype="Role", role_name=TEST_ROLE, desk_access=1).insert()
 
-		with patch("gameplan.roles.GAMEPLAN_ROLES", (TEST_ROLE,)):
+		with patch("gameplan.roles.GAMEPLAN_ROLES", (TEST_ROLE,)), redirect_stdout(io.StringIO()):
 			sync_roles()
 
 		self.assertEqual(frappe.db.get_value("Role", TEST_ROLE, "desk_access"), 1)
@@ -77,12 +79,32 @@ class TestGameplanRoles(FrappeTestCase):
 		"""
 		frappe.get_doc(doctype="Role", role_name=TEST_ROLE, desk_access=1).insert()
 
-		with patch.object(Role, "on_update", autospec=True) as on_update:
+		with patch.object(Role, "on_update", autospec=True) as on_update, redirect_stdout(io.StringIO()):
 			sync_roles()
 			with patch("gameplan.roles.GAMEPLAN_ROLES", (TEST_ROLE,)):
 				sync_roles()
 
 		on_update.assert_not_called()
+
+	def test_a_role_granting_desk_access_is_reported_not_corrected(self):
+		"""Deleting a Gameplan role gets it recreated by make_module_and_roles with
+		desk_access = 1 during the same migrate. We cannot fix that silently, so it has to
+		at least show up in the migrate output."""
+		frappe.get_doc(doctype="Role", role_name=TEST_ROLE, desk_access=1).insert()
+
+		output = io.StringIO()
+		with patch("gameplan.roles.GAMEPLAN_ROLES", (TEST_ROLE,)), redirect_stdout(output):
+			sync_roles()
+
+		self.assertIn(TEST_ROLE, output.getvalue())
+		self.assertEqual(frappe.db.get_value("Role", TEST_ROLE, "desk_access"), 1)
+
+	def test_nothing_is_reported_when_no_role_grants_desk_access(self):
+		output = io.StringIO()
+		with patch("gameplan.roles.GAMEPLAN_ROLES", (TEST_ROLE,)), redirect_stdout(output):
+			sync_roles()
+
+		self.assertEqual(output.getvalue(), "")
 
 	def test_all_gameplan_roles_exist(self):
 		for role in GAMEPLAN_ROLES:


### PR DESCRIPTION
Follow-up to #528, which was merged before this correction landed. **`develop` currently contains code that deadlocks migrate on gameplan.frappe.cloud** — please merge this before the next deploy.

## What #528 got wrong

It removed the Role fixture, which worked — migrate now clears `Syncing fixtures...`. But it kept a branch that reset `desk_access` to 0 when it had drifted, and that branch ran from an `after_migrate` hook. On production ([job 1j8l1g94nl](https://cloud.frappe.io/dashboard/sites/gameplan.frappe.cloud/insights/jobs/1j8l1g94nl), run 3 minutes after #528 merged) the crash simply moved:

```
File "/home/frappe/frappe-bench/apps/gameplan/gameplan/roles.py", line 48, in sync_roles
    role.save(ignore_permissions=True)
...
_pickle.PicklingError: Can't pickle <class 'frappe.model.document.LazyUser'>
```

Same `Role.on_update` → `update_user_type_on_change` → `user.save()` → frappe v16 pickling bug as before.

## Two things were wrong

**1. It is a deadlock, not an error.** The crash aborts migrate, so the write is rolled back, so the next migrate attempts exactly the same write. It cannot clear itself. Any Role write from a migrate hook has this property while frappe version-16 lacks frappe#41187.

**2. The reset was wrong regardless.** The site's roles:

| Role | desk_access |
|---|---|
| Gameplan Member | **1** |
| Gameplan Admin | **1** |
| Gameplan Guest | 0 |

The `Version` record shows this was deliberate, not drift:

```
Role "Gameplan Member" — desk_access: 0 → 1 — by ankush@erpnext.com
```

`desk_access` decides whether members are System Users or Website Users, which governs desk access and Frappe Cloud billing. Resetting it would have demoted **80 accounts (79 enabled)** to Website User:

```sql
select count(*) from tabUser u
where u.user_type = 'System User'
  and u.name in (select parent from `tabHas Role` where role like 'Gameplan%')
  and u.name not in (
    select hr.parent from `tabHas Role` hr join tabRole r on r.name = hr.role
    where r.desk_access = 1 and hr.role not like 'Gameplan%')
-- 80
```

That is an operator's decision, not this app's to make silently during a migrate.

## The change

`sync_roles` now **only creates roles that are missing, and never writes to one that exists**. Creating new roles without desk access is still ours to choose — frappe's `make_module_and_roles` would otherwise create them with `desk_access = 1` — but once a role exists, its `desk_access` belongs to whoever runs the site.

`test_desk_access_drift_is_corrected` asserted the wrong behaviour and is replaced by `test_desk_access_on_an_existing_role_is_left_alone` and `test_sync_never_saves_an_existing_role`.

## Verified

Reproduced the production shape on `gameplan-demo.test` — `Gameplan Member.desk_access = 1`, then a full `bench migrate`:

- migrate completes and runs `after_migrate`
- the role is still at `desk_access = 1` afterwards, untouched
- backend suite: 464 tests passing

## Still outstanding, not in this repo

frappe#41187 (`LazyDocument.__reduce__`) needs backporting to `version-16`. Until it does, no app can safely save a `Role` or a `User` during migrate on that branch. This PR only makes Gameplan stop reaching the bug.
