### PR TITLE
Fix scroll position when opening thread with unread reply

### DIFF
--- a/frontend/src/components/CommentsArea.vue
+++ b/frontend/src/components/CommentsArea.vue
@@ -824,6 +824,15 @@ watch(
   { immediate: true },
 )
 
+watch(
+  () => route.query.comment,
+  (commentId) => {
+    if (!commentId || !comments.data?.length) return
+    const comment = comments.data.find((c) => c.name === commentId)
+    if (comment) scrollToItem(comment)
+  },
+)
+
 // Reopen the composer if a saved draft is restored for this discussion.
 watch(
   () => draft.ready.value,


### PR DESCRIPTION
Comments could finish loading before DiscussionView's scrollToUnread() set the comment query param, causing onSuccess() to fall through to scrollToEnd() with nothing to correct it afterward. Added a watcher on route.query.comment so the scroll corrects itself once the param arrives.

Fixes #522