### PR TITLE
fix(discussions): as_dict shadowing is_bookmarked; wrap desktop reaction row

### DIFF
--- a/frontend/src/components/ReactionsDesktop.vue
+++ b/frontend/src/components/ReactionsDesktop.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex select-none items-stretch space-x-1.5">
+  <div class="flex select-none flex-wrap items-stretch gap-1.5">
     <HoverCard
       v-model:open="isPickerOpen"
       side="bottom"

--- a/gameplan/gameplan/doctype/gp_discussion/gp_discussion.py
+++ b/gameplan/gameplan/doctype/gp_discussion/gp_discussion.py
@@ -63,7 +63,7 @@ class GPDiscussion(HasActivity, HasAttachments, HasMentions, HasReactions, HasTa
 			pluck="name",
 		)
 		d.last_unread_poll = polls[0] if polls else None
-		d.is_bookmarked = self.is_bookmarked()
+		d.is_bookmarked = self.is_bookmarked_by_current_user()
 		d.views = frappe.db.count("GP Discussion Visit", {"discussion": self.name})
 		return d
 
@@ -191,7 +191,7 @@ class GPDiscussion(HasActivity, HasAttachments, HasMentions, HasReactions, HasTa
 
 	@frappe.whitelist(methods=["POST"])
 	def add_bookmark(self):
-		if self.is_bookmarked():
+		if self.is_bookmarked_by_current_user():
 			return
 		frappe.new_doc("GP Bookmark", discussion=self.name, user=frappe.session.user).insert()
 
@@ -216,7 +216,14 @@ class GPDiscussion(HasActivity, HasAttachments, HasMentions, HasReactions, HasTa
 		for name in frappe.get_all("GP Bookmark", filters={"discussion": self.name}, pluck="name"):
 			frappe.delete_doc("GP Bookmark", name, ignore_permissions=True)
 
-	def is_bookmarked(self):
+	def is_bookmarked_by_current_user(self):
+		"""Deliberately not named `is_bookmarked` — `as_dict` publishes an `is_bookmarked` key.
+
+		That key is not a docfield, so when the client posts the dict back (desk save,
+		`frappe.get_doc(json)`) `Document.update` sets it as a plain instance attribute. A
+		method of the same name would be shadowed by that bool and the next `as_dict` would
+		raise `TypeError: 'bool' object is not callable`.
+		"""
 		return bool(frappe.db.exists("GP Bookmark", {"discussion": self.name, "user": frappe.session.user}))
 
 	def update_slug(self):

--- a/gameplan/tests/features/test_bookmarks.py
+++ b/gameplan/tests/features/test_bookmarks.py
@@ -97,6 +97,20 @@ class TestAddAndRemoveBookmark(BookmarkTestCase):
 		with self.as_user(self.second_member):
 			self.assertFalse(frappe.get_doc("GP Discussion", self.discussion.name).as_dict().is_bookmarked)
 
+	def test_as_dict_survives_a_round_trip_through_the_client(self):
+		"""A saved doc comes back from the client carrying the keys `as_dict` added.
+
+		`is_bookmarked` is not a docfield, so `Document.update` sets it as a plain
+		attribute. If a method shared that name it would be shadowed by the bool and the
+		re-serialisation frappe does after every save would blow up.
+		"""
+		self.add_bookmark(self.discussion, self.member)
+
+		with self.as_user(self.member):
+			posted_back = frappe.get_doc(frappe.get_doc("GP Discussion", self.discussion.name).as_dict())
+
+			self.assertTrue(posted_back.as_dict().is_bookmarked)
+
 	def test_deleting_a_discussion_removes_every_users_bookmark(self):
 		"""A bookmark points at a discussion with a Link field, so a leftover row both
 		blocks the delete (link check) and dangles for the user who bookmarked it."""


### PR DESCRIPTION
Two independent fixes.

## 1. `TypeError: 'bool' object is not callable` on discussion save

```
File "apps/gameplan/gameplan/gameplan/doctype/gp_discussion/gp_discussion.py", line 66, in as_dict
    d.is_bookmarked = self.is_bookmarked()
TypeError: 'bool' object is not callable
```

**Cause:** `GPDiscussion.as_dict` publishes an `is_bookmarked` key that is not a docfield. When the client posts that dict back — `savedocs` does `frappe.get_doc(json.loads(...))` — `Document.update` has nowhere to put an unknown key except as a plain instance attribute, so `self.is_bookmarked` becomes `False`, shadowing the method. `savedocs` then calls `send_updated_docs(doc)` → `doc.as_dict()`, which tries to call the bool.

**Fix:** rename the method to `is_bookmarked_by_current_user` so the computed key and the method no longer share a namespace. The serialised key stays `is_bookmarked`, so the frontend is unaffected.

**Test:** `test_as_dict_survives_a_round_trip_through_the_client` round-trips a discussion through `frappe.get_doc(doc.as_dict())` and re-serialises it. Confirmed it fails with the original `TypeError` on the pre-fix code and passes after. Full bookmark suite: 22 passed.

## 2. Reaction row overflows on desktop

A discussion with many distinct emoji reactions pushed the row past the content width — the container was a plain `flex` with `space-x-1.5` and no wrapping, so the pills ran off the side.

Switched to `flex-wrap` with `gap-1.5`, matching what `ReactionsMobile` already does (`gap` rather than `space-x` so wrapped rows get vertical spacing too). Verified in the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
