### PR TITLE
fix(mentions): don't fail a post save on a mention of a deleted user

### DIFF
--- a/frontend/src/pages/NewDiscussion/useNewDiscussion.ts
+++ b/frontend/src/pages/NewDiscussion/useNewDiscussion.ts
@@ -6,6 +6,7 @@ import { useGroupedSpaceOptions } from '@/data/groupedSpaces'
 import { getSpace } from '@/data/spaces'
 import { useSessionUser, useUser } from '@/data/users'
 import { tags } from '@/data/tags'
+import { extractServerMessage } from '@/utils'
 import type { GPDiscussion } from '@/types/doctypes'
 
 const PUBLISH_DRAFT = 'gameplan.gameplan.doctype.gp_draft.gp_draft.publish_draft'
@@ -203,7 +204,7 @@ export function useNewDiscussion() {
         tags.reload()
       }
     } catch (error: any) {
-      publishError.value = error?.message || String(error)
+      publishError.value = extractServerMessage(error) || 'Could not publish this post.'
       publishing.value = false
     } finally {
       isPublishingSuccessfully.value = false

--- a/frontend/src/pages/ProfileCustomize.vue
+++ b/frontend/src/pages/ProfileCustomize.vue
@@ -99,6 +99,7 @@ import { createServerProfileBentoSource } from '@/components/ProfileBento/profil
 import { profileCardTypeOptions } from '@/components/ProfileBento/types'
 import { useProfileBentoCustomization } from '@/components/ProfileBento/useProfileBentoCustomization'
 import { useSessionUser } from '@/data/users'
+import { extractServerMessage } from '@/utils'
 
 const sessionUser = useSessionUser()
 const profileCustomizeBreadcrumbs = computed(() => [
@@ -221,25 +222,5 @@ function getSaveErrorMessage(error: unknown) {
 
   let message = extractServerMessage(error)
   return message || 'Could not save profile layout'
-}
-
-/**
- * frappe-ui's `frappeRequest` puts the clean `frappe.throw()` text on the
- * error's `messages` array (parsed out of `_server_messages`). The plain
- * `message` is the noisy "<method> <ExcType>" string, so prefer `messages`.
- */
-function extractServerMessage(error: unknown): string {
-  if (error instanceof Error && Array.isArray((error as { messages?: unknown }).messages)) {
-    let messages = (error as { messages: unknown[] }).messages.filter(
-      (message): message is string => typeof message === 'string',
-    )
-    if (messages.length) return stripHtml(messages.join('\n'))
-  }
-  if (error instanceof Error && error.message) return stripHtml(error.message)
-  return typeof error === 'string' ? error : ''
-}
-
-function stripHtml(value: string) {
-  return value.replace(/<[^>]*>/g, '').trim()
 }
 </script>

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -62,3 +62,27 @@ export function relativeTimestamp(timestamp: string): string {
   }
   return dayjsLocal(timestamp).format('D MMM YYYY')
 }
+
+/**
+ * Pull the human-readable text out of a frappe-ui request error.
+ *
+ * `frappeRequest`/`call` put the clean `frappe.throw()` text on the error's
+ * `messages` array (parsed out of `_server_messages`) and leave the noisy
+ * "<method> <ExcType>" string on `message`, so prefer `messages`.
+ */
+export function extractServerMessage(error: unknown): string {
+  if (!(error instanceof Error)) return typeof error === 'string' ? error : ''
+
+  let serverMessages = (error as Error & { messages?: unknown }).messages
+  if (Array.isArray(serverMessages)) {
+    let messages = serverMessages.filter(
+      (message): message is string => typeof message === 'string',
+    )
+    if (messages.length) return stripHtml(messages.join('\n'))
+  }
+  return error.message ? stripHtml(error.message) : ''
+}
+
+function stripHtml(value: string) {
+  return value.replace(/<[^>]*>/g, '').trim()
+}

--- a/gameplan/mixins/mentions.py
+++ b/gameplan/mixins/mentions.py
@@ -68,6 +68,13 @@ class HasMentions:
 
 		if user_email == self.owner:
 			return False
+		# A mention or rich quote outlives the account it points at: delete the user (or
+		# paste content quoting one) and the email stays in the HTML forever. None of the
+		# permission checks below require the User row to exist, and GP Notification.to_user
+		# is a Link — so without this the notification insert raises LinkValidationError and
+		# takes the whole post save down with it.
+		if not frappe.db.exists("User", user_email):
+			return False
 		return can_view_content(user_email, self)
 
 	def _notify_user(self, user_email, is_everyone=False, notification_type="Mention"):

--- a/gameplan/tests/features/test_notifications.py
+++ b/gameplan/tests/features/test_notifications.py
@@ -237,6 +237,28 @@ class TestMentionNotifications(NotificationTestCase):
 
 		self.assertEqual(self.notifications_for(self.member), [])
 
+	def test_a_mention_of_a_deleted_user_does_not_block_the_post(self):
+		"""A mention outlives the account it names, and GP Notification.to_user is a Link.
+
+		Publishing a draft written before the mentioned user was deleted used to fail with
+		LinkValidationError, taking the whole discussion insert with it.
+		"""
+		with self.as_user(self.member):
+			discussion = create_discussion(
+				"Ghost mention", self.space, content=mention_html("ghost@example.com", "Ghost")
+			)
+
+		self.assertTrue(frappe.db.exists("GP Discussion", discussion.name))
+		self.assertEqual(self.notifications_for("ghost@example.com"), [])
+
+	def test_a_rich_quote_of_a_deleted_author_does_not_block_the_post(self):
+		discussion = create_discussion("Plain thread", self.space, owner=self.member)
+		with self.as_user(self.member):
+			comment = create_comment(discussion, content=quote_html("ghost@example.com"))
+
+		self.assertTrue(frappe.db.exists("GP Comment", comment.name))
+		self.assertEqual(self.notifications_for("ghost@example.com"), [])
+
 	def test_a_mentioned_quoted_author_is_notified_only_once(self):
 		discussion = create_discussion("Plain thread", self.space, owner=self.second_member)
 		content = quote_html(self.second_member) + mention_html(self.second_member, "Second Member")


### PR DESCRIPTION
## Problem

Publishing a draft failed with an opaque error:

> `gameplan.gameplan.doctype.gp_draft.gp_draft.publish_draft LinkValidationError`

The draft's content contained an @-mention of a user that no longer exists on the site. On save, `HasMentions._create_notification` inserts a `GP Notification` whose `to_user` is a **Link to `User`** — the missing account made that insert raise `LinkValidationError`, which rolled back the entire discussion insert.

`_can_notify` only asked two things: is this the author, and can they view the space. Neither check requires the `User` row to actually exist (`can_view_space` on a public space returns `True` for any email string), so a stale email sailed through.

This is not draft-specific — it breaks any save of content carrying the stale mention: publishing, editing a post, or commenting.

## Reproduction

Publishing a draft whose content contains either of these fails:

```html
<span data-type="mention" data-id="ghost@example.com" data-label="Ghost">@Ghost</span>
<blockquote data-author="ghost@example.com"><p>quoted</p></blockquote>
```

```
LinkValidationError: Could not find To User: ghost@example.com
```

## Fix

`_can_notify` now skips emails with no `User` row. Covers mentions and rich-quote authors on every surface (discussions, comments, tasks, edits).

## Also

The composer showed the error's noisy `message` (`<method> <ExcType>`) instead of the server text frappe-ui parses onto `messages`, which is why the failure was unreadable. `ProfileCustomize.vue` already had a private `extractServerMessage` helper for exactly this — promoted it to `@/utils` and used it in the publish path too.

## Tests

Two regression tests in `test_notifications.py`: a mention and a rich quote of a deleted user must still let the post save, and must create no notification.

`bench run-tests --module gameplan.tests.features.test_notifications` — 37 passed. Ruff, Prettier, and `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)