### PR TITLE
A batch of July bug fixes

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,7 @@
     "@tiptap/vue-3": "^3.26.0",
     "@vueuse/core": "^10.1.2",
     "feather-icons": "^4.28.0",
-    "frappe-ui": "^1.0.0-beta.31",
+    "frappe-ui": "1.0.0-beta.34",
     "fuzzysort": "^2.0.4",
     "gemoji": "^7.1.0",
     "htmldiff-js": "^1.0.5",

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -9,11 +9,10 @@
       </Layout>
     </div>
     <NewTaskDialog />
-    <SettingsDialog v-if="$session.isLoggedIn && users.isFinished" />
-    <component
-      :is="DevUserSwitcher"
-      v-if="DevUserSwitcher && $session.isLoggedIn && users.isFinished"
-    />
+    <!-- usersReady, not users.isFinished: a mid-session reload of the user list would
+         flip isFinished back to false and unmount the open settings dialog. -->
+    <SettingsDialog v-if="$session.isLoggedIn && usersReady" />
+    <component :is="DevUserSwitcher" v-if="DevUserSwitcher && $session.isLoggedIn && usersReady" />
   </FrappeUIProvider>
 </template>
 
@@ -21,7 +20,7 @@
 import { computed, defineAsyncComponent, nextTick, shallowRef, watch } from 'vue'
 import { loadRouteLocation, useRoute, useRouter } from 'vue-router'
 import { FrappeUIProvider } from 'frappe-ui'
-import { users } from '@/data/users'
+import { users, usersReady } from '@/data/users'
 import { session } from '@/data/session'
 import { useScreenSize } from 'frappe-ui'
 import { useTheme } from '@/utils/useTheme'
@@ -108,9 +107,9 @@ watch(
 // Back-compat: ?settings=notifications deep links now redirect to the canonical
 // settings URL.
 watch(
-  () => [route.query.settings, session.isLoggedIn, users.isFinished],
+  () => [route.query.settings, session.isLoggedIn, usersReady.value],
   async ([settings]) => {
-    if (settings !== 'notifications' || !session.isLoggedIn || !users.isFinished) return
+    if (settings !== 'notifications' || !session.isLoggedIn || !usersReady.value) return
 
     await nextTick()
     router.replace({ name: 'SettingsTab', params: { tab: 'notifications' } })

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -53,13 +53,19 @@ const Layout = computed(() => {
 
 users.fetch()
 
-// On a /settings/* URL, render the page the dialog was opened over (or Home on a
-// cold load) behind the overlay; otherwise render the current route normally.
-//
+const isSettingsOverlay = (r) => r.matched.some((record) => record.meta?.settingsOverlay)
+
 // A resolved-but-never-navigated route still holds its lazy `() => import()`
 // components unresolved, which <router-view :route> renders as "[object Promise]"
 // (hit on a cold load / reload of a settings URL). loadRouteLocation() forces
 // those imports to resolve before we hand the route to the view.
+const isRouteLoaded = (target) =>
+  target.matched.every((record) =>
+    Object.values(record.components ?? {}).every((component) => typeof component !== 'function'),
+  )
+
+// On a /settings/* URL, render the page the dialog was opened over (or Home on a
+// cold load) behind the overlay; otherwise render the current route normally.
 //
 // shallowRef (not ref): a route object holds its matched components, and deep
 // reactivity would wrap those component definitions in a Proxy ("received a
@@ -67,20 +73,34 @@ users.fetch()
 const displayedRoute = shallowRef(route)
 watch(
   [() => route.fullPath, settingsBackgroundPath],
-  async () => {
-    if (!route.matched.some((r) => r.meta?.settingsOverlay)) {
+  () => {
+    if (!isSettingsOverlay(route)) {
       displayedRoute.value = route
       return
     }
     const target = router.resolve(settingsBackgroundPath.value || getHomeRoute())
-    await loadRouteLocation(target)
-    // Closing the dialog nulls settingsBackgroundPath (router guard) a tick before
-    // the URL leaves /settings, so this watcher can start resolving a background
-    // page (falling back to Home) while still on the settings route. If the
-    // overlay has since closed, the non-overlay branch already set the real route
-    // — don't let this stale async result clobber it back to Home.
-    if (!route.matched.some((r) => r.meta?.settingsOverlay)) return
-    displayedRoute.value = target
+    // Point the view at the background page SYNCHRONOUSLY. `useRoute()` hands back one
+    // live object whose properties are getters onto the router's current route, so
+    // `displayedRoute` aliases it — yielding here (even for one microtask) lets the main
+    // <router-view> render the /settings route first. Its only component is the no-op
+    // RouteGuard, so the page behind the overlay is unmounted and then rebuilt a tick
+    // later while the URL still says /settings. Pages that canonicalise their own URL on
+    // mount then rewrite it off /settings and the dialog closes the frame it appeared.
+    if (isRouteLoaded(target)) {
+      displayedRoute.value = target
+      return
+    }
+    // Cold load / reload on a /settings URL: no page is mounted yet, so there is nothing
+    // to tear down and waiting for the lazy chunks is safe.
+    loadRouteLocation(target).then(() => {
+      // Closing the dialog nulls settingsBackgroundPath (router guard) a tick before
+      // the URL leaves /settings, so this watcher can start resolving a background
+      // page (falling back to Home) while still on the settings route. If the
+      // overlay has since closed, the non-overlay branch already set the real route
+      // — don't let this stale async result clobber it back to Home.
+      if (!isSettingsOverlay(route)) return
+      displayedRoute.value = target
+    })
   },
   { immediate: true },
 )

--- a/frontend/src/components/Activity.vue
+++ b/frontend/src/components/Activity.vue
@@ -60,13 +60,16 @@
       </span>
       <span class="text-ink-gray-5" v-if="activity.action == 'Task Value Changed'">
         <template v-if="activity.data.field === 'assigned_to'">
-          assigned this to
-          <UserProfileLink
-            class="font-medium text-ink-gray-7 hover:text-ink-gray-5"
-            :user="assignedUser.name"
-          >
-            {{ assignedUser.full_name }}
-          </UserProfileLink>
+          <template v-if="assignedUser">
+            assigned this to
+            <UserProfileLink
+              class="font-medium text-ink-gray-7 hover:text-ink-gray-5"
+              :user="assignedUser.name"
+            >
+              {{ assignedUser.full_name }}
+            </UserProfileLink>
+          </template>
+          <template v-else>unassigned this</template>
         </template>
         <template v-else-if="activity.data.field === 'description'">
           updated the description
@@ -143,5 +146,9 @@ const props = defineProps<{
 }>()
 
 const user = computed(() => useUser(props.activity.user))
-const assignedUser = computed(() => useUser(props.activity.data.new_value))
+// Clearing an assignee logs the same activity with an empty new_value, so there is no
+// user to name — the template renders "unassigned this" instead.
+const assignedUser = computed(() =>
+  props.activity.data?.new_value ? useUser(props.activity.data.new_value) : null,
+)
 </script>

--- a/frontend/src/components/Comment.vue
+++ b/frontend/src/components/Comment.vue
@@ -4,8 +4,16 @@
       v-if="highlight"
       class="absolute inset-0 translate-y- z-[5] rounded border-2 -mx-4 -mb-4 mt-11 pointer-events-none"
     />
+    <!--
+      The author row is opaque, so while it is sticky it paints over the top of
+      the comment's own body once the comment is taller than the scrollport —
+      fine when reading, but it buries the line you are typing while editing
+      (worst on a phone, where it eats ~56px of a keyboard-shrunk viewport).
+      Same treatment the post editor already gets in DiscussionView.
+    -->
     <div
-      class="sticky -top-px z-[1] flex items-center bg-surface-base pb-2 pt-2 text-md text-ink-gray-8 sm:top-0 sm:pt-14 sm:text-base"
+      class="flex items-center bg-surface-base pb-2 pt-2 text-md text-ink-gray-8 sm:pt-14 sm:text-base"
+      :class="{ 'sticky -top-px z-[1] sm:top-0': !isEditing }"
     >
       <UserProfileLink class="mr-3" :user="author.name">
         <UserAvatarWithHover class="sm:hidden" size="xl" :user="author.name" />

--- a/frontend/src/components/CommentsList.vue
+++ b/frontend/src/components/CommentsList.vue
@@ -78,8 +78,11 @@
               {{ $user().full_name }}
             </span>
           </div>
+          <!-- Bounded: this composer is pinned under the comment list, so it scrolls
+               internally past 50vh rather than pushing the task's comments off screen. -->
           <CommentEditor
             ref="newCommentEditor"
+            max-height="50vh"
             :value="draftData.content"
             @change="onNewCommentChange"
             :submitButtonProps="{

--- a/frontend/src/components/DesktopLayout.vue
+++ b/frontend/src/components/DesktopLayout.vue
@@ -1,5 +1,7 @@
 <template>
-  <div class="relative flex h-full flex-col" v-if="users.isFinished">
+  <!-- usersReady, not users.isFinished: a mid-session reload of the user list would flip
+       isFinished back to false and unmount the entire shell — the app blanks out. -->
+  <div class="relative flex h-full flex-col" v-if="usersReady">
     <DesktopShell class="gameplan-desktop-shell h-full flex-1 standalone:border-t">
       <template #rail>
         <AppRail :show-border="onCommunityRoute" :show-community-active-state="onCommunityRoute" />
@@ -23,7 +25,7 @@ import AppSidebar from './AppSidebar.vue'
 import CommandPalette from './CommandPalette/CommandPalette.vue'
 import ReadOnlyBanner from './ReadOnlyBanner.vue'
 import { readOnlyMode } from '@/data/readOnlyMode'
-import { users } from '@/data/users'
+import { usersReady } from '@/data/users'
 import { settingsBackgroundPath } from '@/components/Settings'
 import { getHomeRoute } from '@/router'
 

--- a/frontend/src/components/DiscussionList.vue
+++ b/frontend/src/components/DiscussionList.vue
@@ -89,10 +89,15 @@ const pinnedDiscussions = useDiscussions({
     const baseFilters = toValue(props.filters)
 
     if (baseFilters?.project) {
+      // A community pin is a superset of a space pin — "Show in all <community>
+      // discussions" has to include the discussion's own space, or the pin is
+      // invisible everywhere the author looks for it. This also brings back every
+      // pre-2025-10 pin, which set_default_pin_scope + rename_global_pin_scope_to_category
+      // stamped `Category` without ever asking the user to pick a scope.
       return {
         ...baseFilters,
         pinned_at: ['is', 'set'],
-        pin_scope: 'Space',
+        pin_scope: ['in', ['Space', 'Category']],
       }
     }
 

--- a/frontend/src/components/DiscussionRow.vue
+++ b/frontend/src/components/DiscussionRow.vue
@@ -33,7 +33,7 @@
               </div>
               <div>
                 <span>
-                  {{ $user(discussion.last_post_by).full_name.trim() }}
+                  {{ $user(discussion.last_post_by || discussion.owner).full_name.trim() }}
                 </span>
                 <span class="inline-flex items-center" v-if="showSpaceName">
                   &nbsp;in {{ discussion.project_title }}

--- a/frontend/src/components/DiscussionRow.vue
+++ b/frontend/src/components/DiscussionRow.vue
@@ -63,6 +63,8 @@
             <span class="lucide-bar-chart-2 h-4 w-4 -rotate-90" />
           </Tooltip>
           <Tooltip v-if="discussion.unread">
+            <!-- Amber is deliberate and owner-requested. Known AA trade: white on amber-600 is
+                 about 3.22:1, below the 4.5:1 floor. Do not swap it for a gray Badge. -->
             <div
               class="bg-amber-600 dark:bg-dark-amber-500 text-white rounded-full h-4 min-w-4 px-1 grid place-content-center text-xs"
             >

--- a/frontend/src/components/DiscussionView.vue
+++ b/frontend/src/components/DiscussionView.vue
@@ -137,6 +137,14 @@
                 />
               </div>
             </div>
+            <!-- An empty body renders as nothing at all, which reads as a broken page rather
+                 than an empty post. Say so explicitly. -->
+            <p
+              v-if="!editingPost && isEditorContentEmpty(discussion.doc.content)"
+              class="text-p-base text-ink-gray-5"
+            >
+              This post has no content.
+            </p>
             <DiscussionViewEditor
               ref="postEditor"
               :content="editingPost ? postDraftData.content : discussion.doc.content"
@@ -267,6 +275,17 @@
           again.
         </p>
       </EmptyStateBox>
+      <!-- Fetch finished, but there is no doc and no recognised not-found/forbidden error.
+           Fail visibly instead of rendering a blank page. Gated on isFinished so the
+           pre-fetch tick (useFetch defers its first execute by a microtask) doesn't flash
+           an error. -->
+      <EmptyStateBox v-else-if="discussion.isFinished" class="mx-auto mt-14 max-w-2xl px-6">
+        <LucideTriangleAlert class="mb-3 size-7 text-ink-gray-4" />
+        <div class="text-base text-ink-gray-7">Could not load this discussion</div>
+        <p class="mt-2 max-w-md text-center text-p-sm text-ink-gray-5">
+          Something went wrong while loading it. Refresh to try again.
+        </p>
+      </EmptyStateBox>
     </div>
     <div
       v-if="!isMobileViewport && !editingPost"
@@ -320,7 +339,7 @@ import UserProfileLink from './UserProfileLink.vue'
 const RevisionsDialog = defineAsyncComponent(() => import('./RevisionsDialog.vue'))
 import SpaceBreadcrumbs from './SpaceBreadcrumbs.vue'
 import EmptyStateBox from './EmptyStateBox.vue'
-import { copyToClipboard } from '@/utils'
+import { copyToClipboard, isEditorContentEmpty } from '@/utils'
 import { getSpace, useSpace } from '@/data/spaces'
 import { useCommunity } from '@/data/communities'
 import { useGroupedSpaceOptions } from '@/data/groupedSpaces'
@@ -574,7 +593,13 @@ function moveToSpace() {
   }
 }
 
-const canSavePost = computed(() => Boolean(postDraftData.value.title?.trim()))
+// A post needs both halves: saving an empty body over a real one leaves a post that renders
+// as a blank page for everyone, with no way back except the revision history.
+const canSavePost = computed(
+  () =>
+    Boolean(postDraftData.value.title?.trim()) &&
+    !isEditorContentEmpty(postDraftData.value.content),
+)
 
 // Read content from the editor's own serializer rather than discussion.doc.content:
 // the editor re-normalizes HTML on load and writes it back, so the stored value

--- a/frontend/src/components/DiscussionView.vue
+++ b/frontend/src/components/DiscussionView.vue
@@ -353,6 +353,7 @@ import { refreshUnreadCountForProjects } from '@/data/unreadCount'
 import { useSessionUser } from '@/data/users'
 import { canDeleteContent, canEditContent } from '@/utils/permissions'
 import { useCommandPaletteCommands } from './CommandPalette/registry'
+import { useOwnedRouteWrites } from '@/composables/useOwnedRouteWrites'
 
 const props = defineProps<{
   postId: string
@@ -361,6 +362,10 @@ const props = defineProps<{
 
 const router = useRouter()
 const route = useRoute()
+// This view also renders behind the settings overlay, where the URL belongs to /settings/*.
+// Rewriting it from there would both throw (no postId param to spread) and navigate the app
+// off the settings route, closing the dialog. A page may only rewrite a URL it owns.
+const runWhenOwned = useOwnedRouteWrites(() => route.name === 'Discussion')
 const isMobileViewport = useIsMobile()
 const commentsArea = useTemplateRef('commentsArea')
 const postEditor = useTemplateRef<{ editor: Editor | null }>('postEditor')
@@ -502,6 +507,7 @@ async function scrollToUnread() {
 
   let doc = discussion.doc
   if (
+    route.name === 'Discussion' &&
     !route.query.comment &&
     !route.query.poll &&
     !route.query.fromSearch &&
@@ -670,7 +676,13 @@ function updatePost() {
   editSnapshot.value = null
 }
 
+// Runs once per visit, when the doc resolves — so if the URL is not ours at that moment,
+// the correction has to wait for it rather than be dropped for the rest of the visit.
 function canonicalizeRoute() {
+  runWhenOwned(applyCanonicalRoute)
+}
+
+function applyCanonicalRoute() {
   let doc = discussion.doc
   if (!doc) return
 

--- a/frontend/src/components/Settings/ProfileSettings.vue
+++ b/frontend/src/components/Settings/ProfileSettings.vue
@@ -41,7 +41,7 @@
         </div>
 
         <div class="grid gap-6 sm:grid-cols-2">
-          <div>
+          <div ref="firstNameField">
             <TextInput
               label="First name"
               class="w-full"
@@ -50,7 +50,7 @@
               @blur="saveName"
             />
           </div>
-          <div>
+          <div ref="lastNameField">
             <TextInput
               label="Last name"
               class="w-full"
@@ -61,7 +61,7 @@
           </div>
         </div>
 
-        <div>
+        <div ref="bioField">
           <Textarea
             label="Bio"
             class="w-full"
@@ -129,6 +129,7 @@ import type { DropdownOptions } from 'frappe-ui'
 import ProfileImageEditor from '@/components/ProfileImageEditor.vue'
 import UserAvatar from '@/components/UserAvatar.vue'
 import { useSessionUser } from '@/data/users'
+import { useSyncedField } from '@/utils/useSyncedField'
 import type { GPUserProfile } from '@/types/doctypes'
 
 interface ProfileMethods {
@@ -176,9 +177,28 @@ const profileChildResource = computed(() => ({
   ...profileResource,
   doc: profile.value,
 }))
-const firstName = ref('')
-const lastName = ref('')
-const bio = ref('')
+const firstNameField = useTemplateRef<HTMLElement>('firstNameField')
+const lastNameField = useTemplateRef<HTMLElement>('lastNameField')
+const bioField = useTemplateRef<HTMLElement>('bioField')
+const userNameParts = computed(() => getUserNameParts(user.value))
+// These stay in step with the document until they are focused or typed in. See
+// useSyncedField for the doc store's double publish and why neither "always copy"
+// nor "copy once" is safe.
+const firstName = useSyncedField({
+  source: () => userNameParts.value.first_name,
+  identity: () => user.value?.name,
+  target: firstNameField,
+})
+const lastName = useSyncedField({
+  source: () => userNameParts.value.last_name,
+  identity: () => user.value?.name,
+  target: lastNameField,
+})
+const bio = useSyncedField({
+  source: () => profile.value?.bio,
+  identity: () => profile.value?.name,
+  target: bioField,
+})
 const savingName = computed(() => userResource.setValue.loading)
 const savingBio = computed(() => profileResource.setValue.loading)
 const showAvatarEditor = ref(false)
@@ -223,24 +243,6 @@ watch(
     if (sessionUser.name) {
       userResource.reload()
     }
-  },
-  { immediate: true },
-)
-
-watch(
-  user,
-  (currentUser) => {
-    let nameParts = getUserNameParts(currentUser)
-    firstName.value = nameParts.first_name
-    lastName.value = nameParts.last_name
-  },
-  { immediate: true },
-)
-
-watch(
-  profile,
-  (currentProfile) => {
-    bio.value = currentProfile?.bio || ''
   },
   { immediate: true },
 )

--- a/frontend/src/components/editor/CommentEditor.vue
+++ b/frontend/src/components/editor/CommentEditor.vue
@@ -112,12 +112,19 @@ const textToolsItem: MenuItem = {
   isActive: () => props.toolbarExpanded,
 }
 
+// Both buttons open a suggestion menu, which can only be done by typing its
+// trigger char. The command owns that char: it takes it back out when the menu
+// is dismissed rather than used, and declines without touching the document
+// where no menu can open at all, such as inside code. It also focuses the
+// editor itself, so these calls need no `.focus()` of their own. Without that
+// focus the click would leave the caret on the button, and the button would
+// swallow the keystrokes meant for the menu.
 function openSlashCommands(editor: Editor) {
-  editor.chain().focus().insertContent(' /').run()
+  editor.commands.openSuggestionMenu('slashCommands')
 }
 
-function insertTrigger(editor: Editor, trigger: '@') {
-  editor.chain().focus().insertContent(` ${trigger}`).run()
+function openMentions(editor: Editor) {
+  editor.commands.openSuggestionMenu('mentionSuggestion')
 }
 
 function insertEmoji(editor: Editor, emoji: string) {
@@ -214,7 +221,7 @@ function canInsertCodeBlock(editor: Editor) {
                 icon="lucide-at-sign"
                 label="Mention"
                 tooltip="Mention"
-                @click="insertTrigger(e, '@')"
+                @click="openMentions(e)"
               />
               <EmojiPicker @select="insertEmoji(e, $event)">
                 <template #trigger>

--- a/frontend/src/components/editor/CommentEditor.vue
+++ b/frontend/src/components/editor/CommentEditor.vue
@@ -16,7 +16,11 @@ import {
   Paragraph,
   Separator,
   Strike,
-  type Editor,
+  // `Editor` in this package is the Vue component; the tiptap instance these
+  // helpers receive is `TiptapEditor`. Importing it from here rather than
+  // @tiptap/core keeps it on the same tiptap copy frappe-ui augments, so its
+  // editor commands are visible.
+  type TiptapEditor as Editor,
   type MenuItem,
 } from 'frappe-ui/editor'
 import EmojiPicker from '@/components/EmojiPicker.vue'
@@ -187,7 +191,9 @@ function canInsertCodeBlock(editor: Editor) {
       <QuoteReplyButton v-if="e" :editor="e" :source-id="quoteSourceId" :author="author ?? ''" />
     </template>
     <template v-if="editable" #bottom="{ editor: e }">
-      <div class="mt-2 flex flex-col justify-between gap-2 sm:flex-row sm:items-center">
+      <!-- The slot yields null until the editor mounts, and every control here
+      needs one. Same guard as the #top slot above. -->
+      <div v-if="e" class="mt-2 flex flex-col justify-between gap-2 sm:flex-row sm:items-center">
         <div class="flex min-w-0 items-center gap-1 overflow-x-auto">
           <template v-if="toolbarExpanded">
             <EditorFixedMenu

--- a/frontend/src/components/editor/CommentEditor.vue
+++ b/frontend/src/components/editor/CommentEditor.vue
@@ -37,6 +37,13 @@ const props = withDefaults(
     editable?: boolean
     submitButtonProps?: Record<string, any>
     discardButtonProps?: Record<string, any>
+    // Unset on purpose: the editor grows to its content by default, so editing an
+    // existing comment reads like editing a post body instead of a fixed box that
+    // scrolls internally. Only the new-comment composers pass a max-height — they
+    // sit at the bottom of a scrolling list, so an unbounded box would push the
+    // conversation off screen as you type. Don't reinstate a default here: a caller
+    // cannot opt out of one, since withDefaults substitutes it for an explicit
+    // `undefined`.
     maxHeight?: string
     minHeight?: string
     toolbarExpanded?: boolean
@@ -46,7 +53,7 @@ const props = withDefaults(
     // comment owner — stamped on quotes created from this comment's selection
     author?: string
   }>(),
-  { value: '', placeholder: null, editable: true, maxHeight: '50vh', toolbarExpanded: false },
+  { value: '', placeholder: null, editable: true, toolbarExpanded: false },
 )
 
 const emit = defineEmits<{

--- a/frontend/src/composables/useOwnedRouteWrites.ts
+++ b/frontend/src/composables/useOwnedRouteWrites.ts
@@ -1,0 +1,39 @@
+import { watch } from 'vue'
+
+/**
+ * Postpones a page's own URL rewrites while it does not own the URL.
+ *
+ * Pages keep rendering behind the settings overlay, where the URL belongs to /settings/*.
+ * A canonicalising `router.replace()` issued then would either throw (the page's params
+ * are gone from the URL) or navigate the app off the settings route, closing the dialog
+ * the moment it opened. Dropping those writes instead is not safe either — the composer's
+ * `?draft=` link to its server row is written exactly once, and losing it strands the
+ * draft row.
+ *
+ * So: run the write now if the page owns the URL, otherwise queue it and run it as soon as
+ * the page owns the URL again (i.e. when the overlay closes). Queued writes run in the
+ * order they were made and read their state when they run, so each one is postponed, not
+ * frozen — pass a closure that re-reads, not pre-computed params.
+ *
+ * Must be called during setup: the watcher is disposed with the owning component, so a
+ * page the user navigated away from simply drops whatever it had queued.
+ *
+ * @param ownsRoute Whether the current URL is one this page may rewrite.
+ * @returns `runWhenOwned(write)` — run `write` now, or when the page owns the URL again.
+ */
+export function useOwnedRouteWrites(ownsRoute: () => boolean) {
+  const pending: Array<() => void> = []
+
+  watch(ownsRoute, (owned) => {
+    if (!owned || pending.length === 0) return
+    for (const write of pending.splice(0)) write()
+  })
+
+  return function runWhenOwned(write: () => void) {
+    if (ownsRoute()) {
+      write()
+      return
+    }
+    pending.push(write)
+  }
+}

--- a/frontend/src/data/notifications.ts
+++ b/frontend/src/data/notifications.ts
@@ -1,4 +1,5 @@
 import { useCall } from 'frappe-ui'
+import { useDebounceFn } from '@vueuse/core'
 import { onSocketEvent } from '@/socket'
 
 export let unreadNotifications = useCall({
@@ -7,8 +8,52 @@ export let unreadNotifications = useCall({
   initialData: 0,
 })
 
-// Keeps the rail badge live: the backend signals this user whenever a notification is created
-// for them or their notifications are marked read, including from another tab or device.
-onSocketEvent('gameplan:notification_count_changed', () => {
-  unreadNotifications.reload()
-})
+const listeners = new Set<() => void>()
+
+/**
+ * Run `handler` when this user's unread notifications changed into something this tab is
+ * not already showing — a new notification, or one read or cleared elsewhere. Returns an
+ * unsubscribe function.
+ *
+ * The backend signals this user on every change, from any tab or device, this one
+ * included. An event this tab caused is pure duplication: the tab has already reloaded
+ * itself, so acting on the echo doubles the requests per click and aborts the reload still
+ * in flight, which frappe-ui's fetch wrapper reports as an AbortError.
+ *
+ * The echo is told apart by *what it reports*, not by when it arrives: the event carries
+ * the user's current unread count (see gameplan/realtime.py), and an event naming the
+ * count the badge already shows says nothing this tab does not know. A clock cannot decide
+ * this — clicking a notification marks it read here and, one navigation later, has
+ * `track_visit` clear the rest of that thread on the server, so a window wide enough to
+ * cover the echo swallowed that real change and left the badge too high.
+ *
+ * Losing an event whose count matches by coincidence — one notification read elsewhere
+ * while another arrives — is the whole cost, and it leaves the badge correct and only the
+ * open list stale until the next change.
+ */
+export function onRemoteNotificationChange(handler: () => void) {
+  listeners.add(handler)
+  return () => {
+    listeners.delete(handler)
+  }
+}
+
+// One subscription, so every listener acts on the same set of events. Deciding per listener
+// would race: whichever ran first would reload the badge and change the answer for the rest.
+onSocketEvent(
+  'gameplan:notification_count_changed',
+  useDebounceFn(({ count }) => {
+    if (count === unreadNotifications.data) return
+    // Reloaded rather than taken from the event: `data` is a computed inside useCall, and a
+    // single fetched count keeps the badge and the lists reading the same server state.
+    unreadNotifications.reload()
+    for (const handler of [...listeners]) {
+      try {
+        handler()
+      } catch (error) {
+        // One bad listener must not skip the rest.
+        console.error('Notification change listener failed', error)
+      }
+    }
+  }, 500),
+)

--- a/frontend/src/data/useDraftSync.ts
+++ b/frontend/src/data/useDraftSync.ts
@@ -15,6 +15,7 @@
 import { ref, computed, watch, toValue, nextTick, onScopeDispose, type MaybeRefOrGetter } from 'vue'
 import { call, debounce, toast, dayjsLocal } from 'frappe-ui'
 import { session } from './session'
+import { isEditorContentEmpty } from '@/utils'
 import {
   getDraftRecord,
   putDraftRecord,
@@ -53,9 +54,7 @@ export interface UseDraftSyncOptions {
 }
 
 function hasContent(payload: DraftPayload): boolean {
-  const body = (payload.content ?? '').trim()
-  const title = (payload.title ?? '').trim()
-  return (body.length > 0 && body !== '<p></p>') || title.length > 0
+  return !isEditorContentEmpty(payload.content) || (payload.title ?? '').trim().length > 0
 }
 
 let instanceCounter = 0
@@ -159,23 +158,30 @@ export function useDraftSync(options: UseDraftSyncOptions) {
 
   async function persistToServer() {
     if (!isEnabled() || !dirty.value || !canSave(data.value)) return
+    // Snapshot what we are about to send, and the edit clock it belongs to, BEFORE the
+    // request goes out. Marking the draft synced as of the response time would mark every
+    // keystroke typed while the request was in flight as already pushed — those edits go
+    // permanently un-synced, and publishing (which builds the discussion from the server
+    // row, not the local buffer) then produces a post with an empty body.
+    const pushedAt = updatedAt.value
+    const fields = payloadFields()
     saving.value = true
     try {
       if (serverName.value) {
         await call('frappe.client.set_value', {
           doctype: 'GP Draft',
           name: serverName.value,
-          fieldname: payloadFields(),
+          fieldname: fields,
         })
       } else {
         const doc = await call('frappe.client.insert', {
-          doc: { doctype: 'GP Draft', ...identityFields(), ...payloadFields() },
+          doc: { doctype: 'GP Draft', ...identityFields(), ...fields },
         })
         serverName.value = doc.name
         onCreate?.(doc.name)
       }
-      syncedAt.value = Date.now()
-      savedAt.value = syncedAt.value
+      syncedAt.value = Math.max(syncedAt.value ?? 0, pushedAt)
+      savedAt.value = Date.now()
       await persistLocal()
       pushFailed.value = false
     } catch (error) {
@@ -194,12 +200,16 @@ export function useDraftSync(options: UseDraftSyncOptions) {
     }
   }
 
-  function pushToServer() {
-    if (activePush) return activePush
-    activePush = persistToServer().finally(() => {
-      activePush = null
+  // Chain behind an in-flight push rather than joining it: that request was built from an
+  // older snapshot, so returning its promise would report edits made since as pushed. The
+  // chained run is free when nothing changed — persistToServer() bails on `!dirty`.
+  function pushToServer(): Promise<void> {
+    const next = (activePush ?? Promise.resolve()).then(persistToServer)
+    const push = next.finally(() => {
+      if (activePush === push) activePush = null
     })
-    return activePush
+    activePush = push
+    return push
   }
 
   const debouncedPush = debounce(pushToServer, debounceMs)
@@ -328,7 +338,9 @@ export function useDraftSync(options: UseDraftSyncOptions) {
     broadcastDraftChange(localKey)
   }
 
-  /** Force any pending change to the server now (creating the row if needed). */
+  /** Force any pending change to the server now (creating the row if needed). Chains behind
+   *  an in-flight push, so on return the server row reflects the local buffer — unless
+   *  `dirty` is still true, which means the push failed. */
   async function flush() {
     debouncedPush.cancel?.()
     await pushToServer()

--- a/frontend/src/data/users.ts
+++ b/frontend/src/data/users.ts
@@ -43,12 +43,22 @@ export interface UserInfo {
   isGuest?: boolean
   isNotGuest?: boolean
   isDisabled?: boolean
+  /**
+   * True for a record `useUser` invented because the id is not in the store — either the
+   * user list has not loaded yet, or the user is not in it at all (`get_user_info` only
+   * returns users holding a Gameplan role). Its `full_name` is a guess (the local part of
+   * the email), so callers with a better name of their own should prefer theirs.
+   */
+  isPlaceholder?: boolean
 }
 
 function mergeUserInfo(user: UserInfo) {
   user.isGuest = user.role === 'Gameplan Guest'
   user.isNotGuest = !user.isGuest
   user.isDisabled = user.enabled === 0
+  // Set explicitly (not just left undefined) so merging a real record over a placeholder
+  // already in the store clears the flag — `Object.assign` only copies keys it has.
+  user.isPlaceholder = false
   const existing = usersByName[user.name]
   if (existing) {
     Object.assign(existing, user)
@@ -94,11 +104,29 @@ export function updateUserInfo(user: UserInfo) {
   if (listedUser) Object.assign(listedUser, user)
 }
 
-export function useUser(email?: string | null) {
-  if (!email || email === 'sessionUser') {
+// Shared so `useUser('')` is referentially stable across renders, and never lands in
+// `usersByName` (its key would be the empty string and the next unknown actor would
+// inherit whatever the last one merged into it).
+const unknownUser = getPlaceholderUser('', 'Unknown')
+
+/**
+ * Resolve a user id to its `UserInfo`, or to a placeholder (`isPlaceholder`) when the id
+ * is not in the store — the user list is still loading, or the user is not in it at all.
+ *
+ * "The session user" is what *calling it with no arguments* means, plus the explicit
+ * `'sessionUser'` sentinel. Any id that is actually passed resolves to that id, and an
+ * empty, `null` or `undefined` one resolves to the shared Unknown placeholder — never to
+ * the session user. That is why the sentinel is an arity check and not a parameter
+ * default: a default also fires for an explicitly passed `undefined`, which is how the
+ * viewer's own name ended up rendered as the actor on someone else's activity whenever
+ * the actor field came back empty.
+ */
+export function useUser(...args: [] | [email: string | null | undefined]): UserInfo {
+  let email = args.length === 0 ? session.user : args[0]
+  if (email === 'sessionUser') {
     email = session.user
   }
-  if (!email) return getPlaceholderUser('guest@example.com', 'Guest')
+  if (!email) return unknownUser
   if (!usersByName[email]) {
     usersByName[email] = getPlaceholderUser(email, email.split('@')[0])
   }
@@ -110,6 +138,7 @@ function getPlaceholderUser(email: string, full_name: string) {
     name: email,
     email: email,
     full_name: full_name,
+    isPlaceholder: true,
     user_image: '',
     role: 'Gameplan Member',
     enabled: 1,

--- a/frontend/src/data/users.ts
+++ b/frontend/src/data/users.ts
@@ -1,4 +1,4 @@
-import { computed, reactive } from 'vue'
+import { computed, reactive, readonly, ref, watch } from 'vue'
 import { useCall } from 'frappe-ui'
 import router from '@/router'
 import { setCommunityOrder } from './communityOrder'
@@ -90,12 +90,45 @@ export let users = useCall<UserInfo[]>({
   immediate: false,
 })
 
+const firstFetchSettled = ref(false)
+
+/**
+ * True once the first `get_user_info` request has SETTLED — succeeded or failed — and
+ * never false again. It is `users.isFinished`, latched.
+ *
+ * Anything that renders the app shell must gate on this and NOT on `users.isFinished`
+ * directly. `isFinished` only means "no request in flight", so it flips back to false on
+ * every reload, and a profile edit anywhere broadcasts `gameplan:users_changed`, which
+ * reloads this list mid-session. Gating on it unmounts the whole layout and any open
+ * dialog for the length of that refetch: the app visibly blanks out. A refetch must never
+ * unmount anything.
+ *
+ * Settle, not success, is deliberate. A failed load (500, offline, permission error) has
+ * to leave the app mounted and degraded, the way `isFinished` did. Latching on success
+ * only would leave the shell unmounted forever after one bad response — a permanently
+ * blank page, which is worse than the bug being fixed here.
+ */
+export const usersReady = readonly(firstFetchSettled)
+
+// Latched from `isFinished` rather than from the onSuccess/onError hooks so it cannot
+// drift from what "the request has settled" means: onSuccess is skipped for a response
+// with no body, which would strand the flag at false. Never stopped, by design — this
+// module lives as long as the app.
+watch(
+  () => users.isFinished,
+  (isFinished) => {
+    if (isFinished) firstFetchSettled.value = true
+  },
+  { immediate: true },
+)
+
 // A profile edit changes what everyone else renders (avatar, name, role), so the backend
-// broadcasts this to every session. Skipped until the list has actually loaded: `users` is
+// broadcasts this to every session. Skipped until the first fetch has settled: `users` is
 // `immediate: false` and App.vue fetches it once the session is known, and reloading before
-// that would race that first fetch on the same instance.
+// that would race that first fetch on the same instance. After a failed first fetch this
+// does allow a reload, which is wanted — it is the one path that can recover the list.
 onSocketEvent('gameplan:users_changed', () => {
-  if (users.data) users.reload()
+  if (usersReady.value) users.reload()
 })
 
 export function updateUserInfo(user: UserInfo) {

--- a/frontend/src/pages/NewDiscussion/useNewDiscussion.ts
+++ b/frontend/src/pages/NewDiscussion/useNewDiscussion.ts
@@ -1,6 +1,7 @@
 import { ref, computed, onMounted, provide, inject, watch, type InjectionKey } from 'vue'
 import { useRoute, useRouter, onBeforeRouteLeave } from 'vue-router'
 import { call, useDoctype, dialog } from 'frappe-ui'
+import { useOwnedRouteWrites } from '@/composables/useOwnedRouteWrites'
 import { useDraftSync, type DraftPayload } from '@/data/useDraftSync'
 import { useGroupedSpaceOptions } from '@/data/groupedSpaces'
 import { getSpace } from '@/data/spaces'
@@ -87,19 +88,39 @@ export function useNewDiscussion() {
 
   const immediateSave = () => draft.flush()
 
+  // The composer stays mounted behind the settings overlay, where the URL is /settings/*
+  // and every composer param reads as empty. A route sync issued then would navigate off
+  // /settings and close the dialog, so the syncs below wait until the composer owns the
+  // URL again. Waiting rather than skipping matters most for the draft name: it is written
+  // to the URL exactly once, and a draft with no ?draft= link is stranded after a reload.
+  const runWhenOwned = useOwnedRouteWrites(
+    () => route.name === 'NewDiscussion' || route.name === 'LegacyNewDiscussion',
+  )
+
   function syncDraftToRoute(name: string) {
-    if (communityId.value) {
-      router.replace({
-        name: 'NewDiscussion',
-        params: { communityId: communityId.value },
-        query: draftRouteQuery(name, draftData.value.project),
-      })
-    } else {
-      router.replace({
-        name: 'LegacyNewDiscussion',
-        query: draftRouteQuery(name, draftData.value.project),
-      })
-    }
+    runWhenOwned(() => {
+      // A deferred sync could land after the composer moved on to a different draft; never
+      // point the URL at a row this composer no longer holds.
+      if (draft.serverName.value !== name) return
+      if (communityId.value) {
+        router.replace({
+          name: 'NewDiscussion',
+          params: { communityId: communityId.value },
+          query: draftRouteQuery(name, draftData.value.project),
+        })
+      } else {
+        router.replace({
+          name: 'LegacyNewDiscussion',
+          query: draftRouteQuery(name, draftData.value.project),
+        })
+      }
+    })
+  }
+
+  // Keep the URL in step with the draft's space. Only ever called through runWhenOwned,
+  // which is what makes it safe for these to rewrite the route unconditionally.
+  function syncRouteToDraft() {
+    if (!normalizeDraftRoute()) syncSelectedSpaceToRoute(draftData.value.project)
   }
 
   // A draft opened on the legacy route that already belongs to a space is moved onto the
@@ -250,15 +271,15 @@ export function useNewDiscussion() {
         () => draft.ready.value,
         (ready) => {
           if (!ready) return
-          if (!normalizeDraftRoute()) syncSelectedSpaceToRoute(draftData.value.project)
+          runWhenOwned(syncRouteToDraft)
         },
         { immediate: true },
       )
       watch(
         () => draftData.value.project,
-        (spaceId) => {
+        () => {
           if (!draft.ready.value) return
-          if (!normalizeDraftRoute()) syncSelectedSpaceToRoute(spaceId)
+          runWhenOwned(syncRouteToDraft)
         },
       )
     })

--- a/frontend/src/pages/NewDiscussion/useNewDiscussion.ts
+++ b/frontend/src/pages/NewDiscussion/useNewDiscussion.ts
@@ -6,7 +6,7 @@ import { useGroupedSpaceOptions } from '@/data/groupedSpaces'
 import { getSpace } from '@/data/spaces'
 import { useSessionUser, useUser } from '@/data/users'
 import { tags } from '@/data/tags'
-import { extractServerMessage } from '@/utils'
+import { extractServerMessage, isEditorContentEmpty } from '@/utils'
 import type { GPDiscussion } from '@/types/doctypes'
 
 const PUBLISH_DRAFT = 'gameplan.gameplan.doctype.gp_draft.gp_draft.publish_draft'
@@ -14,9 +14,7 @@ const LOADING_STATUS_DELAY_MS = 200
 
 /** Title or non-empty body — the threshold for persisting a draft at all. */
 function hasMeaningfulContent(payload: Partial<DraftPayload>): boolean {
-  const body = (payload.content ?? '').trim()
-  const title = (payload.title ?? '').trim()
-  return title.length > 0 || (body.length > 0 && body !== '<p></p>')
+  return (payload.title ?? '').trim().length > 0 || !isEditorContentEmpty(payload.content)
 }
 
 export function useNewDiscussion() {
@@ -176,6 +174,16 @@ export function useNewDiscussion() {
     publishing.value = true
     try {
       await draft.flush()
+
+      // publish_draft builds the discussion from the SERVER row, so a draft that is still
+      // dirty after a flush would be published minus whatever failed to push — most often
+      // as an empty body. Stop instead of shipping a post the author didn't write.
+      if (draft.serverName.value && draft.dirty.value) {
+        publishError.value =
+          'Could not save your draft to the server. Check your connection and try again.'
+        publishing.value = false
+        return
+      }
 
       let discussionId: string | undefined
       if (draft.serverName.value) {

--- a/frontend/src/pages/Notifications.vue
+++ b/frontend/src/pages/Notifications.vue
@@ -131,7 +131,7 @@
 </template>
 <script setup lang="ts">
 import { computed, onScopeDispose, ref } from 'vue'
-import { useDebounceFn, watchDebounced } from '@vueuse/core'
+import { watchDebounced } from '@vueuse/core'
 import type { RouteLocationRaw } from 'vue-router'
 import {
   PageHeader,
@@ -149,10 +149,9 @@ import { List, ListRow, ListCell } from 'frappe-ui/list'
 import ReactionFaceIcon from '@/components/ReactionFaceIcon.vue'
 import UserAvatarWithHover from '@/components/UserAvatarWithHover.vue'
 import { getCommunity } from '@/data/communities'
-import { unreadNotifications } from '@/data/notifications'
+import { onRemoteNotificationChange, unreadNotifications } from '@/data/notifications'
 import { getSpace } from '@/data/spaces'
 import { useSessionUser } from '@/data/users'
-import { onSocketEvent } from '@/socket'
 import type { GPNotification } from '@/types/doctypes'
 
 type ActiveTab = 'Unread' | 'Read'
@@ -185,15 +184,14 @@ const readNotificationList = useNotificationList(1, 'Read Notifications')
 // The rail badge and these lists read the same state, so they have to move together.
 // Without this the badge would count a notification raised (or cleared from another tab)
 // while this page is open, and the list beneath it would keep showing something else.
-// Debounced because the same event also fires for this tab's own mark-as-read.
+// `onRemoteNotificationChange` hands over only the events reporting a count this tab is not
+// already showing, so its own writes — which reload these lists themselves — do not come
+// back around as a second reload.
 onScopeDispose(
-  onSocketEvent(
-    'gameplan:notification_count_changed',
-    useDebounceFn(() => {
-      unreadNotificationList.reload()
-      readNotificationList.reload()
-    }, 500),
-  ),
+  onRemoteNotificationChange(() => {
+    unreadNotificationList.reload()
+    readNotificationList.reload()
+  }),
 )
 
 const loadedNotifications = computed<NotificationRow[]>(() => [
@@ -252,6 +250,8 @@ function markAsRead(name: string) {
   // success. Asking for it twice aborted the first request, which left the abort error
   // parked in the list's `error` ref.
   unreadNotificationList.setValue.submit({ name, read: 1 }).then(() => {
+    // The badge reload is what makes the echo of this write recognisable: once it lands,
+    // the badge holds the same count the echo reports and the echo is dropped.
     unreadNotifications.reload()
     readNotificationList.reload()
   })

--- a/frontend/src/pages/Notifications.vue
+++ b/frontend/src/pages/Notifications.vue
@@ -80,6 +80,12 @@
         </ListCell>
         <ListCell class="justify-end">
           <div>
+            <!-- `creation`, not `modified`: marking a notification read is a PUT that bumps
+                 `modified`, so a Monday mention opened on Thursday would claim to be "a few
+                 seconds ago" for the rest of its life. The list is still ordered by
+                 `modified` so a re-lit notification resurfaces (see useNotificationList),
+                 which can read slightly out of order here — an honest timestamp out of order
+                 beats a wrong one in order. -->
             <time
               class="block shrink-0 whitespace-nowrap text-right text-sm text-ink-gray-5"
               :datetime="notification.creation"
@@ -124,7 +130,8 @@
   </div>
 </template>
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, onScopeDispose, ref } from 'vue'
+import { useDebounceFn } from '@vueuse/core'
 import type { RouteLocationRaw } from 'vue-router'
 import {
   PageHeader,
@@ -145,6 +152,7 @@ import { getCommunity } from '@/data/communities'
 import { unreadNotifications } from '@/data/notifications'
 import { getSpace } from '@/data/spaces'
 import { useSessionUser } from '@/data/users'
+import { onSocketEvent } from '@/socket'
 import type { GPNotification } from '@/types/doctypes'
 
 type ActiveTab = 'Unread' | 'Read'
@@ -161,6 +169,8 @@ const notificationFields = [
   'read',
   'type',
   'creation',
+  // Not displayed — it is what the list is ordered by.
+  'modified',
   'comment',
   'discussion',
   'poll',
@@ -171,6 +181,20 @@ const notificationFields = [
 
 const unreadNotificationList = useNotificationList(0, 'Unread Notifications')
 const readNotificationList = useNotificationList(1, 'Read Notifications')
+
+// The rail badge and these lists read the same state, so they have to move together.
+// Without this the badge would count a notification raised (or cleared from another tab)
+// while this page is open, and the list beneath it would keep showing something else.
+// Debounced because the same event also fires for this tab's own mark-as-read.
+onScopeDispose(
+  onSocketEvent(
+    'gameplan:notification_count_changed',
+    useDebounceFn(() => {
+      unreadNotificationList.reload()
+      readNotificationList.reload()
+    }, 500),
+  ),
+)
 
 const loadedNotifications = computed<NotificationRow[]>(() => [
   ...(unreadNotificationList.data ?? []),
@@ -224,9 +248,11 @@ function openNotification(notification: NotificationRow) {
 }
 
 function markAsRead(name: string) {
+  // No `unreadNotificationList.reload()` here: `setValue` already re-runs its own list on
+  // success. Asking for it twice aborted the first request, which left the abort error
+  // parked in the list's `error` ref.
   unreadNotificationList.setValue.submit({ name, read: 1 }).then(() => {
     unreadNotifications.reload()
-    unreadNotificationList.reload()
     readNotificationList.reload()
   })
 }
@@ -340,7 +366,16 @@ function useNotificationList(read: 0 | 1, cacheKey: string) {
     doctype: 'GP Notification',
     filters: () => ({ to_user: sessionUser.name, read }),
     fields: notificationFields,
-    orderBy: 'creation desc',
+    // `modified desc`, not `creation desc`: a reaction notification is a single row that
+    // gets re-lit in place, so ordering by `creation` left a freshly raised notification
+    // buried at its original position — unreachable once newer ones pushed it off the page.
+    // The row still *displays* `creation`, because `modified` also moves when the row is
+    // marked read and would date every read notification to the moment it was opened.
+    orderBy: 'modified desc',
+    // The page has no pagination control, so the window has to be wide enough to hold a
+    // realistic backlog. `useList.reload()` refetches at the current offset and appends,
+    // which makes a "load more" button unsafe on a list that mark-as-read reloads.
+    limit: 100,
     cacheKey,
   })
 }

--- a/frontend/src/pages/Notifications.vue
+++ b/frontend/src/pages/Notifications.vue
@@ -4,8 +4,8 @@
     <Breadcrumbs :items="[{ label: 'Notifications', route: { name: 'Notifications' } }]" />
   </PageHeader>
 
-  <div class="body-container pl-0 pt-4 pr-4 sm:pl-5 sm:pt-5">
-    <div class="mb-3 flex items-center justify-between pl-4 sm:pl-3 gap-3">
+  <div class="body-container pt-4 sm:pt-5">
+    <div class="mb-3 flex items-center justify-between px-4 sm:px-3 gap-3">
       <TabButtons :buttons="tabButtons" v-model="activeTab" />
       <Button
         @click="confirmMarkAllAsRead"
@@ -113,7 +113,7 @@
 
     <div
       v-else
-      class="ml-4 rounded border border-dashed border-outline-gray-2 px-6 py-12 text-center sm:ml-3"
+      class="mx-4 rounded border border-dashed border-outline-gray-2 px-6 py-12 text-center sm:mx-3"
     >
       <div class="mx-auto grid size-10 place-items-center rounded bg-surface-gray-2">
         <span class="lucide-bell-check size-5 text-ink-gray-5" aria-hidden="true" />

--- a/frontend/src/pages/Notifications.vue
+++ b/frontend/src/pages/Notifications.vue
@@ -131,7 +131,7 @@
 </template>
 <script setup lang="ts">
 import { computed, onScopeDispose, ref } from 'vue'
-import { useDebounceFn } from '@vueuse/core'
+import { useDebounceFn, watchDebounced } from '@vueuse/core'
 import type { RouteLocationRaw } from 'vue-router'
 import {
   PageHeader,
@@ -306,7 +306,10 @@ function notificationLocation(notification: NotificationRow) {
 }
 
 function linkedIds(notifications: NotificationRow[], field: 'discussion' | 'poll' | 'task') {
-  return [...new Set(notifications.map((row) => row[field]).filter(Boolean))].map(String)
+  // Sorted because order is meaningless to an `in` filter but not to `useList`, which
+  // refetches whenever the request URL changes. Marking a notification read reorders the
+  // list without changing which documents it points at; sorting keeps that a no-op.
+  return [...new Set(notifications.map((row) => row[field]).filter(Boolean))].map(String).sort()
 }
 
 /**
@@ -323,12 +326,27 @@ function linkedIds(notifications: NotificationRow[], field: 'discussion' | 'poll
  * and this bench moves to a frappe version that carries it.
  */
 function useLinkedTitles(doctype: 'GP Discussion' | 'GP Poll' | 'GP Task', ids: () => string[]) {
+  // `queryIds` only ever holds a settled, non-empty id set, and that is what the lookup is
+  // keyed on. The unread and read lists resolve a beat apart, so the ids arrive in more than
+  // one step: fetching on each step fired a query for the empty set on mount and then a
+  // second query that aborted the first, and `useList` reports an aborted fetch as an error.
+  const queryIds = ref<string[]>([])
+  watchDebounced(
+    computed(ids),
+    (settledIds) => {
+      if (settledIds.length) queryIds.value = settledIds
+    },
+    { debounce: 150 },
+  )
+
   const list = useList<{ name: string; title: string }>({
     doctype,
     fields: ['name', 'title'],
-    // An impossible name keeps the request harmless while nothing is loaded yet.
-    filters: () => ({ name: ['in', ids().length ? ids() : ['']] }),
+    filters: () => ({ name: ['in', queryIds.value] }),
     limit: 100,
+    // Nothing to look up until the notifications land; the first id set starts the request,
+    // and an id set that repeats leaves the request URL unchanged, so it does not refetch.
+    immediate: false,
   })
   return computed(() => new Map((list.data ?? []).map((doc) => [String(doc.name), doc.title])))
 }

--- a/frontend/src/pages/Page.vue
+++ b/frontend/src/pages/Page.vue
@@ -112,6 +112,7 @@ import { relativeTimestamp } from '@/utils'
 import { useSessionUser } from '@/data/users'
 import { canDeleteContent, canEditContent } from '@/utils/permissions'
 import { useCommandPaletteCommands } from '@/components/CommandPalette/registry'
+import { useOwnedRouteWrites } from '@/composables/useOwnedRouteWrites'
 const props = defineProps<{
   communityId?: string
   pageId: string
@@ -122,6 +123,11 @@ const props = defineProps<{
 const route = useRoute()
 const router = useRouter()
 const history = window.history
+
+// This page also renders behind the settings overlay, where the URL belongs to /settings/*.
+// Rewriting it from there would both throw (no pageId param to spread) and navigate the app
+// off the settings route, closing the dialog. A page may only rewrite a URL it owns.
+const runWhenOwned = useOwnedRouteWrites(() => route.name === 'SpacePage' || route.name === 'Page')
 
 const titleInput = useTemplateRef('titleInput')
 const textEditor = useTemplateRef('textEditor')
@@ -264,19 +270,29 @@ const handleKeyboardShortcuts = (e: KeyboardEvent) => {
   }
 }
 
+// Runs once per visit, when the doc resolves — so if the URL is not ours at that moment,
+// the correction has to wait for it rather than be dropped for the rest of the visit.
 const updateUrlSlug = () => {
-  if (!route.params.slug || route.params.slug !== page.doc?.slug) {
-    router.replace({
-      name: page.doc?.project ? 'SpacePage' : 'Page',
-      params: {
-        ...route.params,
-        communityId: page.doc?.project ? space.value?.team : undefined,
-        spaceId: page.doc?.project,
-        slug: page.doc?.slug,
-      },
-      query: route.query,
-    })
-  }
+  runWhenOwned(applyCanonicalSlug)
+}
+
+// Reads its state when it runs, not when it was queued, so a deferred correction can't
+// stamp the slug of the page we started on onto the page the URL ended up on.
+function applyCanonicalSlug() {
+  const doc = page.doc
+  if (!doc) return
+  if (route.params.slug && route.params.slug === doc.slug) return
+
+  router.replace({
+    name: doc.project ? 'SpacePage' : 'Page',
+    params: {
+      ...route.params,
+      communityId: doc.project ? space.value?.team : undefined,
+      spaceId: doc.project,
+      slug: doc.slug,
+    },
+    query: route.query,
+  })
 }
 
 onMounted(() => {

--- a/frontend/src/pages/PersonProfile.vue
+++ b/frontend/src/pages/PersonProfile.vue
@@ -56,7 +56,7 @@ import {
 import { confirmRestoreDefaultLayout } from '@/components/ProfileBento/restoreDefaultLayout'
 import { useProfileFieldEditing } from '@/components/ProfileBento/useProfileFieldEditing'
 import type { ProfileBentoCard } from '@/components/ProfileBento/types'
-import { useSessionUser } from '@/data/users'
+import { useSessionUser, useUser } from '@/data/users'
 import type { GPUserProfile } from '@/types/doctypes'
 
 defineOptions({
@@ -100,6 +100,14 @@ const profileNotFound = computed(() => {
   return !profile.value && (Boolean(profileResource.error) || profileResource.isFinished)
 })
 
+// The name comes from the users store (User.full_name), not GP User Profile.full_name.
+// The latter is a copy kept in sync by a server hook, so the cached profile doc keeps
+// showing the old name after a rename; the store is refreshed by the users_changed event.
+const displayName = computed(() => {
+  let user = profile.value?.user
+  return (user ? useUser(user).full_name : '') || profile.value?.full_name || ''
+})
+
 const profileBentoCards = ref<ProfileBentoCard[]>([])
 const profileBentoLoaded = ref(false)
 /** False once this profile has a saved layout, which is the only thing to restore. */
@@ -117,7 +125,7 @@ const fieldEditor = useProfileFieldEditing({
 const profileBreadcrumbs = computed(() => [
   { label: 'People', route: { name: 'People' } },
   {
-    label: profile.value?.full_name || 'Profile',
+    label: displayName.value || 'Profile',
     route: { name: 'PersonProfileProfile', params: { personId: personId.value } },
     isPageTitle: true,
   },
@@ -227,7 +235,7 @@ async function refreshProfile() {
 
 usePageMeta(() => {
   return {
-    title: [profile.value?.full_name || '', 'Profile'].join(' | '),
+    title: [displayName.value, 'Profile'].join(' | '),
   }
 })
 </script>

--- a/frontend/src/pages/PersonProfile.vue
+++ b/frontend/src/pages/PersonProfile.vue
@@ -103,9 +103,17 @@ const profileNotFound = computed(() => {
 // The name comes from the users store (User.full_name), not GP User Profile.full_name.
 // The latter is a copy kept in sync by a server hook, so the cached profile doc keeps
 // showing the old name after a rename; the store is refreshed by the users_changed event.
+//
+// The fallback is on `isPlaceholder`, not on a falsy name: an id the store does not know
+// gets a placeholder whose full_name is the email's local part ("faris"), which is truthy.
+// That happens on every cold load before the user list arrives, and permanently for anyone
+// `get_user_info` skips (it only returns holders of a Gameplan role), so the profile doc's
+// own copy of the name is the better answer there.
 const displayName = computed(() => {
   let user = profile.value?.user
-  return (user ? useUser(user).full_name : '') || profile.value?.full_name || ''
+  let storeUser = user ? useUser(user) : null
+  if (storeUser && !storeUser.isPlaceholder) return storeUser.full_name
+  return profile.value?.full_name || storeUser?.full_name || ''
 })
 
 const profileBentoCards = ref<ProfileBentoCard[]>([])

--- a/frontend/src/pages/Space.vue
+++ b/frontend/src/pages/Space.vue
@@ -66,7 +66,7 @@
 </template>
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
-import { useRouter } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import {
   BottomSheet,
   PageHeaderBackButton,
@@ -83,6 +83,7 @@ import SpaceBreadcrumbs from '@/components/SpaceBreadcrumbs.vue'
 import SpaceIcon from '@/components/SpaceIcon.vue'
 import { useCommunity } from '@/data/communities'
 import { readOnlyMode } from '@/data/readOnlyMode'
+import { useOwnedRouteWrites } from '@/composables/useOwnedRouteWrites'
 
 const props = defineProps<{
   communityId: string
@@ -90,25 +91,39 @@ const props = defineProps<{
 }>()
 
 const router = useRouter()
+// Named apart from the slot-scoped `route` in the template above: that one is the route
+// this page is rendering, this one is the URL the browser is actually on.
+const currentRoute = useRoute()
 const community = useCommunity(() => props.communityId)
 const menuOpen = ref(false)
 const space = useSpace(() => props.spaceId)
 const canEditSpace = computed(() => !readOnlyMode && !space.value?.archived_at)
 
+// This page also renders behind the settings overlay, where the URL belongs to /settings/*
+// and healing it from here would navigate the app off the settings route, closing the dialog.
+// Wait for the URL to be ours again instead — the mismatch is still worth correcting then.
+const runWhenOwned = useOwnedRouteWrites(
+  () => routeParam(currentRoute.params.spaceId) === props.spaceId,
+)
+
 // A space can only be reached under the community that owns it. If the URL carries a stale
 // community (e.g. after a move), heal it to the canonical route instead of rendering a mismatch.
-watch(
-  space,
-  (resolved) => {
-    if (resolved?.team && resolved.team !== props.communityId) {
-      router.replace({
-        name: 'Space',
-        params: { communityId: resolved.team, spaceId: props.spaceId },
-      })
-    }
-  },
-  { immediate: true },
-)
+// Reads its state when it runs, not when it was queued, so a deferred heal can't pair the
+// community of the space we started on with the space the URL ended up on.
+function healStaleCommunityInUrl() {
+  const canonicalCommunityId = space.value?.team
+  if (!canonicalCommunityId || canonicalCommunityId === props.communityId) return
+  router.replace({
+    name: 'Space',
+    params: { communityId: canonicalCommunityId, spaceId: props.spaceId },
+  })
+}
+
+watch(space, () => runWhenOwned(healStaleCommunityInUrl), { immediate: true })
+
+function routeParam(value: string | string[] | undefined) {
+  return Array.isArray(value) ? value[0] : value
+}
 
 onMounted(() => {
   trackSpaceVisit(props.spaceId)

--- a/frontend/src/router.ts
+++ b/frontend/src/router.ts
@@ -8,7 +8,7 @@ import {
 import { until } from '@vueuse/core'
 import { call } from 'frappe-ui'
 import { session } from './data/session'
-import { users } from './data/users'
+import { users, usersReady } from './data/users'
 import { communities, getCommunity } from './data/communities'
 import { spaces, getSpace } from './data/spaces'
 import type { Space } from './data/spaces'
@@ -741,7 +741,9 @@ router.beforeEach(async (to, from) => {
     return { name: 'Login' }
   }
 
-  if (!users.isFinished) {
+  // Wait only for the first load. Gating on `users.isFinished` would also block every
+  // navigation behind a background reload of the user list (see `usersReady`).
+  if (!usersReady.value) {
     try {
       await users.promise
     } catch (error) {

--- a/frontend/src/socket.ts
+++ b/frontend/src/socket.ts
@@ -22,7 +22,8 @@ export type NewActivityEvent = {
  */
 export type GameplanSocketEvents = {
   'gameplan:unread_counts_changed': void
-  'gameplan:notification_count_changed': void
+  /** `count` is the recipient's unread notification count after the change. */
+  'gameplan:notification_count_changed': { count: number }
   'gameplan:users_changed': void
 }
 

--- a/frontend/src/types/doctypes.ts
+++ b/frontend/src/types/doctypes.ts
@@ -183,7 +183,7 @@ export interface GPDiscussion extends DocType {
   /** Tags: Table (GP Tag Link) */
   tags: GPTagLink[]
   /** Pin Scope: Select */
-  pin_scope?: 'Global' | 'Space'
+  pin_scope?: 'Category' | 'Space'
 }
 
 // Last updated: 2026-05-01 22:51:01.454329

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -77,6 +77,25 @@ export function relativeTimestamp(timestamp: string): string {
 }
 
 /**
+ * Whether an editor body carries nothing a reader would see.
+ *
+ * TipTap serializes an untouched document as `<p></p>`, so a plain emptiness check on the
+ * HTML string is not enough. Media-only bodies (an image, a video, an attachment) have no
+ * text but are meaningful, so the check is deliberately structural: strip tags that render
+ * nothing on their own and see whether any markup or text survives.
+ */
+export function isEditorContentEmpty(content: string | null | undefined): boolean {
+  const html = (content ?? '').trim()
+  if (!html) return true
+  const stripped = html
+    .replace(/<(p|div|br|span)\b[^>]*>/gi, '')
+    .replace(/<\/(p|div|span)>/gi, '')
+    .replace(/&nbsp;/gi, ' ')
+    .trim()
+  return stripped.length === 0
+}
+
+/**
  * Pull the human-readable text out of a frappe-ui request error.
  *
  * `frappeRequest`/`call` put the clean `frappe.throw()` text on the error's

--- a/frontend/src/utils/useSyncedField.ts
+++ b/frontend/src/utils/useSyncedField.ts
@@ -1,0 +1,72 @@
+import { computed, ref, toValue, watch, type MaybeRefOrGetter, type Ref } from 'vue'
+import { useFocusWithin } from '@vueuse/core'
+
+export interface SyncedFieldOptions {
+  /** Value the document currently holds for this field. */
+  source: MaybeRefOrGetter<string | null | undefined>
+  /** Identity of the document `source` is read from, usually its `name`. */
+  identity: MaybeRefOrGetter<string | null | undefined>
+  /**
+   * Element wrapping the input. Focus anywhere inside it counts as engagement, so
+   * the value under the cursor never changes while someone is in the field. Leave
+   * it out to rely on edits alone.
+   */
+  target?: MaybeRefOrGetter<HTMLElement | null | undefined>
+}
+
+/**
+ * A local ref for an input, kept in step with a document field until the person
+ * starts working on that field.
+ *
+ * frappe-ui's doc store publishes the same document more than once, asynchronously
+ * and in no fixed order: one publish comes from the IndexedDB cache, another from
+ * the network response. Neither of the obvious approaches works. Copying the
+ * document into the input on every publish eats what is being typed. Copying it
+ * only on the first publish is worse: when the stale cached copy wins the race its
+ * value sticks, the network response is ignored, and saving writes the old text
+ * back over a newer one.
+ *
+ * So the ref keeps following the document until the field is engaged, and stops
+ * for good after that. Engaged means focused or edited. Edited is the part that
+ * matters, because someone can type and then tab away before a late publish lands.
+ * A new `identity` is a different document, which clears the engagement and seeds
+ * the field again.
+ */
+export function useSyncedField(options: SyncedFieldOptions): Ref<string> {
+  const current = ref('')
+  const edited = ref(false)
+  const { focused } = useFocusWithin(computed(() => toValue(options.target) ?? null))
+
+  const value = computed({
+    get: () => current.value,
+    // Only the sync below writes to `current` directly, so every write that arrives
+    // here is the person editing.
+    set: (next: string) => {
+      edited.value = true
+      current.value = next
+    },
+  })
+
+  let syncedIdentity: string | null = null
+
+  watch(
+    // `focused` is tracked to re-run the sync on blur: a publish dropped while the
+    // field held focus has to be picked up once the person leaves it untouched.
+    () => [toValue(options.identity), toValue(options.source), focused.value] as const,
+    ([identity, source]) => {
+      if (!identity) return
+
+      if (identity !== syncedIdentity) {
+        syncedIdentity = identity
+        edited.value = false
+      } else if (edited.value || focused.value) {
+        return
+      }
+
+      current.value = source || ''
+    },
+    { immediate: true },
+  )
+
+  return value
+}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2500,10 +2500,10 @@ framer-motion@^12.25.0:
     motion-utils "^12.39.0"
     tslib "^2.4.0"
 
-frappe-ui@^1.0.0-beta.31:
-  version "1.0.0-beta.31"
-  resolved "https://registry.yarnpkg.com/frappe-ui/-/frappe-ui-1.0.0-beta.31.tgz#99b04bc6547628248737fe1a015ae2f04c0406c2"
-  integrity sha512-5L8qrlfLMo2rKLtJ+IHXHh/NSzU2EQ+/HiZO6v+fzNRtQRV3qVaPgg2gNJYo81gXnHmG+2H6v4fsBxZOuajnjA==
+frappe-ui@1.0.0-beta.34:
+  version "1.0.0-beta.34"
+  resolved "https://registry.yarnpkg.com/frappe-ui/-/frappe-ui-1.0.0-beta.34.tgz#c2c130cc35cd1009ce6fcc103a42bce0a5c27d75"
+  integrity sha512-38E9L2mjz2ayFKuRA692Ao7YSFbotCwTi4gstxskVvb1OgqX/0aCY+NJSrIlCYLLeCtw8+m54D63DKn94KUivA==
   dependencies:
     "@codemirror/lang-css" "^6.3.0"
     "@codemirror/lang-html" "^6.4.9"

--- a/gameplan/api.py
+++ b/gameplan/api.py
@@ -8,7 +8,7 @@ from frappe.query_builder.functions import Count
 from frappe.utils import split_emails, validate_email_address
 
 import gameplan
-from gameplan.realtime import notify_notification_count_changed
+from gameplan.realtime import notify_notification_count_changed, unread_notification_count
 from gameplan.roles import GAMEPLAN_ROLES
 from gameplan.utils import validate_type
 
@@ -161,12 +161,7 @@ def _invite_by_email(emails: str, role: str, projects: list = None):
 
 @frappe.whitelist()
 def unread_notifications():
-	res = frappe.db.get_all(
-		"GP Notification",
-		[{"COUNT": "name", "as": "count"}],
-		{"to_user": frappe.session.user, "read": 0},
-	)
-	return res[0].count
+	return unread_notification_count(frappe.session.user)
 
 
 # Invitation emails open in a browser navigation, so this endpoint must remain GET-reachable.

--- a/gameplan/gameplan/doctype/gp_discussion/patches/set_default_pin_scope.py
+++ b/gameplan/gameplan/doctype/gp_discussion/patches/set_default_pin_scope.py
@@ -3,10 +3,16 @@ from frappe.query_builder import DocType
 
 
 def execute():
-	"""Set pin_scope to Global for all existing pinned discussions"""
+	"""Give every pre-existing pin the community-wide scope.
+
+	This originally wrote "Global", which `rename_global_pin_scope_to_category` (a later
+	entry in patches.txt) then flipped to "Category". "Global" is no longer one of the
+	field's Select options, so it is written as "Category" here directly — the end state
+	is identical on sites that have already run both patches.
+	"""
 	GPDiscussion = DocType("GP Discussion")
 
-	frappe.qb.update(GPDiscussion).set(GPDiscussion.pin_scope, "Global").where(
+	frappe.qb.update(GPDiscussion).set(GPDiscussion.pin_scope, "Category").where(
 		(GPDiscussion.pinned_at.isnotnull())
 		& ((GPDiscussion.pin_scope.isnull()) | (GPDiscussion.pin_scope == ""))
 	).run()

--- a/gameplan/gameplan/doctype/gp_notification/gp_notification.py
+++ b/gameplan/gameplan/doctype/gp_notification/gp_notification.py
@@ -8,8 +8,14 @@ from gameplan.realtime import notify_notification_count_changed
 
 
 class GPNotification(Document):
-	def after_insert(self):
-		notify_notification_count_changed(self.to_user)
+	def on_update(self):
+		# Not `after_insert`: a reaction REUSES the existing row and resets `read` to 0
+		# (see HasReactions.notify_reactions), and the bell's mark-as-read is a PUT that
+		# updates in place. Both are UPDATEs, so an insert-only hook left the unread badge
+		# stale in every open tab until a full reload. `has_value_changed` is True when
+		# there is no doc-before-save, so inserts still announce themselves.
+		if self.has_value_changed("read"):
+			notify_notification_count_changed(self.to_user)
 
 	@staticmethod
 	def clear_notifications(discussion=None, comment=None, poll=None, task=None, user=None):

--- a/gameplan/gameplan/doctype/gp_user_profile/gp_user_profile.py
+++ b/gameplan/gameplan/doctype/gp_user_profile/gp_user_profile.py
@@ -156,6 +156,9 @@ def on_user_update(doc, method=None):
 		profile.enabled = doc.enabled
 		profile.full_name = doc.full_name
 		profile.save(ignore_permissions=True)
+		# A rename changes what *other* sessions render, and their cached user list has
+		# no other reason to refetch.
+		notify_users_changed()
 
 
 @frappe.whitelist()

--- a/gameplan/realtime.py
+++ b/gameplan/realtime.py
@@ -15,7 +15,9 @@ never announces a change that did not happen. Frappe dedupes identical (event, m
 room) triples within a request, so publishing the same event twice for one user emits once.
 """
 
+import frappe
 from frappe import realtime
+from frappe.query_builder.functions import Count
 
 # `realtime.publish_realtime` rather than the newer named helpers (`publish_to_user`,
 # `publish_to_website`): those only exist on frappe develop, and Gameplan is also tested
@@ -39,8 +41,39 @@ def notify_unread_counts_changed(users: str | list[str]):
 
 
 def notify_notification_count_changed(user: str):
-	"""Tell one user that their unread notification count moved."""
-	realtime.publish_realtime(NOTIFICATION_COUNT_CHANGED, user=user, after_commit=True)
+	"""Tell one user that their unread notification count moved, and what it now is.
+
+	The number rides along so a tab can recognise the echo of its own change: this event
+	goes to every session of the user who caused it too, and a tab already showing that
+	number has nothing left to do. Anything else is news.
+
+	Time cannot make that call. Clicking a notification marks it read in the tab and, one
+	navigation later, has the server clear the rest of that thread's notifications
+	(`GPDiscussion.track_visit`), so any window wide enough to cover the echo also swallows
+	the genuine count change arriving right behind it.
+	"""
+	realtime.publish_realtime(
+		NOTIFICATION_COUNT_CHANGED,
+		message={"count": unread_notification_count(user)},
+		user=user,
+		after_commit=True,
+	)
+
+
+def unread_notification_count(user: str) -> int:
+	"""How many unread notifications `user` has right now.
+
+	Shared with `gameplan.api.unread_notifications`, which is what the badge fetches: the
+	pushed number and the fetched one have to be counted the same way, or the client cannot
+	compare them to tell an echo from a change.
+	"""
+	Notification = frappe.qb.DocType("GP Notification")
+	rows = (
+		frappe.qb.from_(Notification)
+		.select(Count(Notification.name))
+		.where((Notification.to_user == user) & (Notification.read == 0))
+	).run()
+	return rows[0][0] if rows else 0
 
 
 def notify_users_changed():

--- a/gameplan/tests/features/test_realtime_events.py
+++ b/gameplan/tests/features/test_realtime_events.py
@@ -32,6 +32,16 @@ def events_named(publish_realtime, event):
 
 
 class TestRealtimeEvents(GameplanTestCase):
+	def notification_for(self, user, read):
+		return frappe.get_doc(
+			doctype="GP Notification",
+			to_user=user.name,
+			from_user=self.member.name,
+			type="Reaction",
+			message="1 person reacted to your post",
+			read=read,
+		).insert(ignore_permissions=True)
+
 	def test_a_new_notification_tells_its_recipient(self):
 		with patch("frappe.realtime.publish_realtime") as publish_realtime:
 			frappe.get_doc(
@@ -44,6 +54,46 @@ class TestRealtimeEvents(GameplanTestCase):
 
 		[call] = events_named(publish_realtime, NOTIFICATION_COUNT_CHANGED)
 		self.assertEqual(call.kwargs.get("user"), self.second_member.name)
+
+	def test_re_lighting_a_cleared_notification_tells_its_recipient_again(self):
+		"""A reaction rewrites the post's existing notification row instead of adding one.
+
+		`HasReactions.notify_reactions` resets `read` on that row, so the count moves on an
+		UPDATE. An insert-only hook left the badge stale in every open tab until a reload.
+		"""
+		notification = self.notification_for(self.second_member, read=1)
+
+		with patch("frappe.realtime.publish_realtime") as publish_realtime:
+			notification.read = 0
+			notification.flags.ignore_permissions = True
+			notification.save()
+
+		[call] = events_named(publish_realtime, NOTIFICATION_COUNT_CHANGED)
+		self.assertEqual(call.kwargs.get("user"), self.second_member.name)
+
+	def test_marking_one_notification_read_tells_that_user(self):
+		"""The bell's per-row mark-as-read is a PUT, so the other tabs only hear about it
+		if updates publish too."""
+		notification = self.notification_for(self.second_member, read=0)
+
+		with patch("frappe.realtime.publish_realtime") as publish_realtime:
+			notification.read = 1
+			notification.flags.ignore_permissions = True
+			notification.save()
+
+		[call] = events_named(publish_realtime, NOTIFICATION_COUNT_CHANGED)
+		self.assertEqual(call.kwargs.get("user"), self.second_member.name)
+
+	def test_an_edit_that_leaves_the_count_alone_announces_nothing(self):
+		"""Re-lighting an already-unread row rewrites its message; the count has not moved."""
+		notification = self.notification_for(self.second_member, read=0)
+
+		with patch("frappe.realtime.publish_realtime") as publish_realtime:
+			notification.message = "2 people reacted to your post"
+			notification.flags.ignore_permissions = True
+			notification.save()
+
+		self.assertEqual(events_named(publish_realtime, NOTIFICATION_COUNT_CHANGED), [])
 
 	def test_clearing_notifications_tells_that_user(self):
 		from gameplan.gameplan.doctype.gp_notification.gp_notification import GPNotification

--- a/gameplan/tests/features/test_realtime_events.py
+++ b/gameplan/tests/features/test_realtime_events.py
@@ -17,6 +17,7 @@ from unittest.mock import patch
 
 import frappe
 
+from gameplan.gameplan.doctype.gp_notification.gp_notification import GPNotification
 from gameplan.realtime import (
 	NOTIFICATION_COUNT_CHANGED,
 	UNREAD_COUNTS_CHANGED,
@@ -95,9 +96,38 @@ class TestRealtimeEvents(GameplanTestCase):
 
 		self.assertEqual(events_named(publish_realtime, NOTIFICATION_COUNT_CHANGED), [])
 
-	def test_clearing_notifications_tells_that_user(self):
-		from gameplan.gameplan.doctype.gp_notification.gp_notification import GPNotification
+	def test_the_notification_event_reports_that_user_s_own_unread_count(self):
+		"""The browser tells its own echo apart from a real change by the count reported.
 
+		A tab that marks a notification read reloads the badge itself, so the echo of that
+		write reports a number the tab already shows and can be dropped. Nothing else can
+		make that call: clicking a notification also navigates, and `track_visit` clears
+		the rest of that thread milliseconds later — a change any time-based guard would
+		swallow along with the echo. So the count has to be the recipient's own, counted
+		after the change.
+		"""
+		self.notification_for(self.second_member, read=0)
+		self.notification_for(self.second_member, read=1)
+		self.notification_for(self.member, read=0)
+
+		with patch("frappe.realtime.publish_realtime") as publish_realtime:
+			self.notification_for(self.second_member, read=0)
+
+		[call] = events_named(publish_realtime, NOTIFICATION_COUNT_CHANGED)
+		self.assertEqual(call.kwargs.get("user"), self.second_member.name)
+		self.assertEqual(call.kwargs.get("message"), {"count": 2})
+
+	def test_clearing_notifications_reports_the_count_left_behind(self):
+		self.notification_for(self.member, read=0)
+		self.notification_for(self.member, read=0)
+
+		with patch("frappe.realtime.publish_realtime") as publish_realtime:
+			GPNotification.clear_notifications(user=self.member.name)
+
+		[call] = events_named(publish_realtime, NOTIFICATION_COUNT_CHANGED)
+		self.assertEqual(call.kwargs.get("message"), {"count": 0})
+
+	def test_clearing_notifications_tells_that_user(self):
 		with patch("frappe.realtime.publish_realtime") as publish_realtime:
 			GPNotification.clear_notifications(user=self.member.name)
 
@@ -116,6 +146,58 @@ class TestRealtimeEvents(GameplanTestCase):
 		[call] = events_named(publish_realtime, USERS_CHANGED)
 		self.assertEqual(call.kwargs.get("room"), frappe.realtime.get_website_room())
 		self.assertIsNone(call.kwargs.get("user"))
+
+	def test_renaming_a_user_reaches_every_session_not_just_their_own(self):
+		"""A rename changes what *other* people render: their avatars, their mention lists,
+		every byline. Those sessions hold a cached user list with no other reason to
+		refetch, so `on_user_update` has to announce the change to all of them.
+		"""
+		user = frappe.get_doc("User", self.member.name)
+
+		with patch("frappe.realtime.publish_realtime") as publish_realtime:
+			user.first_name = "Renamed"
+			user.save(ignore_permissions=True)
+
+		[call] = events_named(publish_realtime, USERS_CHANGED)
+		self.assertEqual(call.kwargs.get("room"), frappe.realtime.get_website_room())
+		self.assertIsNone(call.kwargs.get("user"))
+
+	def test_disabling_a_user_reaches_every_session_not_just_their_own(self):
+		"""A disabled member drops out of the shared user list everyone else renders from,
+		and the session that flipped the switch is usually an admin's, not theirs."""
+		user = frappe.get_doc("User", self.second_member.name)
+
+		with patch("frappe.realtime.publish_realtime") as publish_realtime:
+			user.enabled = 0
+			user.save(ignore_permissions=True)
+
+		[call] = events_named(publish_realtime, USERS_CHANGED)
+		self.assertEqual(call.kwargs.get("room"), frappe.realtime.get_website_room())
+		self.assertIsNone(call.kwargs.get("user"))
+
+	def test_re_enabling_a_user_announces_itself_too(self):
+		"""The way back matters as much as the way out: without this the restored member
+		stays missing from every open session's user list."""
+		user = frappe.get_doc("User", self.second_member.name)
+		user.enabled = 0
+		user.save(ignore_permissions=True)
+
+		with patch("frappe.realtime.publish_realtime") as publish_realtime:
+			user.enabled = 1
+			user.save(ignore_permissions=True)
+
+		[call] = events_named(publish_realtime, USERS_CHANGED)
+		self.assertEqual(call.kwargs.get("room"), frappe.realtime.get_website_room())
+
+	def test_a_user_edit_that_changes_neither_name_nor_enabled_announces_nothing(self):
+		"""`on_user_update` runs on every User save, including ones nobody else can see."""
+		user = frappe.get_doc("User", self.member.name)
+
+		with patch("frappe.realtime.publish_realtime") as publish_realtime:
+			user.bio = "Writes things down"
+			user.save(ignore_permissions=True)
+
+		self.assertEqual(events_named(publish_realtime, USERS_CHANGED), [])
 
 	def test_every_event_is_held_until_the_transaction_commits(self):
 		"""A rolled-back request must not tell the browser about a change that never landed."""


### PR DESCRIPTION
Bugs found while using the app in July. One commit per fix.

## Fixes

**The whole app blanked out.** The shell only rendered while no user-list request was in flight. Any refresh of that list wiped the screen and closed open dialogs. Saving your name did it. So did changing your avatar, which means this happens on `develop` today.

**Posts published with no body.** Type a title, press Enter, paste a body, publish quickly, and the post went out empty. Text typed while a save was in flight was marked as saved but never sent. Happened 3 times out of 3 on `develop`.

**A reaction on an old post stayed buried.** Reactions reuse the existing notification row instead of adding one, so re-lighting a notification never reached the list, never moved to the top, and never appeared in an open tab.

**The notifications page fired four lookups on load.** Three of them asked for nothing and cancelled each other.

**The unread badge double-counted your own clicks.** Marking something read told the server, and the server told this tab about the change it had just made. It now ignores an update that reports the count already on screen.

**Opening Settings broke the page behind it.** Over a discussion or page it threw an error. Over the composer it closed itself immediately. Pages that fix up their own URL now wait their turn instead of dropping the change.

**Edit profile did nothing, and showed a stale name.** The button sat inside a link, so its click went to the link instead. The name came from a copy that stops updating after a rename.

**Empty names resolved to you.** Clearing a task assignee rendered "assigned this to *you*", linked to your own profile, because "no one" and "me" were treated as the same value.

**The comment you were editing sat under the author row.** The sticky header painted over the lines you were typing, worst on mobile.

**Community pins were invisible in their own space.** A post pinned with "Pin to Community" showed up nowhere on the space page. Older pins were backfilled to that scope, so they disappeared too.

**Editing a comment felt different to editing a post.** It was a fixed box with its own scrollbar. It now grows to fit, like the post editor.

**Typing in Settings got eaten.** Your profile loads twice, from cache and from the server, in no fixed order. The late one overwrote what you had typed. Fields now stop syncing once you touch them.

**The comment toolbar was not type checked.** It imported the editor component where it meant the editor itself, so every command call went unchecked. Turning the checks back on found a real crash risk and fixed it.

## Also in here

- **frappe-ui 1.0.0-beta.34.** Ships the insert-menu fix, so the temporary copy Gameplan was carrying is gone.
- **A comment explaining the amber unread chip**, so nobody quietly changes it back. The contrast is a deliberate trade.

## Notes for review

- Every fix was checked against `develop` first, in code and in a browser on two dev servers side by side. Several turned out to already exist on `develop`. One commit was dropped after that check.
- Two CI failures along the way were investigated and are not from this branch: a SQLite lock in the test job (passes on re-run) and a flaky profile test that fails at about the same rate on `develop`. Chasing the flaky one is what found the "typing gets eaten" bug.
- The real cause of that one is upstream: frappe-ui hands the same document to a component twice, and nothing guarantees the fresh copy lands last. Worth fixing there. The guard here is correct either way.
- Backend suite green: 1058 tests.
