### PR TITLE
fix: stop a late document publish overwriting what was typed

### DIFF
--- a/frontend/src/components/ProfileBento/boundFields/ProfileBoundNameField.vue
+++ b/frontend/src/components/ProfileBento/boundFields/ProfileBoundNameField.vue
@@ -1,49 +1,56 @@
 <template>
   <div class="space-y-3">
-    <TextInput
-      label="First name"
-      class="w-full"
-      data-profile-panel-field="first_name"
-      :model-value="firstName"
-      @update:model-value="firstName = $event"
-      @blur="saveName"
-      @keydown.enter.prevent="saveName"
-    />
-    <TextInput
-      label="Last name"
-      class="w-full"
-      data-profile-panel-field="last_name"
-      :model-value="lastName"
-      @update:model-value="lastName = $event"
-      @blur="saveName"
-      @keydown.enter.prevent="saveName"
-    />
+    <div ref="firstNameField">
+      <TextInput
+        label="First name"
+        class="w-full"
+        data-profile-panel-field="first_name"
+        :model-value="firstName"
+        @update:model-value="firstName = $event"
+        @blur="saveName"
+        @keydown.enter.prevent="saveName"
+      />
+    </div>
+    <div ref="lastNameField">
+      <TextInput
+        label="Last name"
+        class="w-full"
+        data-profile-panel-field="last_name"
+        :model-value="lastName"
+        @update:model-value="lastName = $event"
+        @blur="saveName"
+        @keydown.enter.prevent="saveName"
+      />
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from 'vue'
+import { useTemplateRef } from 'vue'
 import { TextInput } from 'frappe-ui'
 import { useBoundFieldSave } from './useBoundFieldSave'
+import { useSyncedField } from '@/utils/useSyncedField'
 import type { ProfileFieldEditor } from '../types'
 
 const props = defineProps<{ fieldEditor: ProfileFieldEditor }>()
 
 const { saving, commit } = useBoundFieldSave(() => props.fieldEditor)
 
-const firstName = ref('')
-const lastName = ref('')
+const firstNameField = useTemplateRef<HTMLElement>('firstNameField')
+const lastNameField = useTemplateRef<HTMLElement>('lastNameField')
 
-// The stored value only changes once a write lands and the profile reloads, so
-// this never clobbers what is being typed.
-watch(
-  () => [props.fieldEditor.firstName, props.fieldEditor.lastName] as const,
-  ([storedFirst, storedLast]) => {
-    firstName.value = storedFirst || ''
-    lastName.value = storedLast || ''
-  },
-  { immediate: true },
-)
+// See useSyncedField for why the doc store publishes a document more than once
+// and why a plain watcher cannot tell a fresh value from a stale one.
+const firstName = useSyncedField({
+  source: () => props.fieldEditor.firstName,
+  identity: () => props.fieldEditor.userId,
+  target: firstNameField,
+})
+const lastName = useSyncedField({
+  source: () => props.fieldEditor.lastName,
+  identity: () => props.fieldEditor.userId,
+  target: lastNameField,
+})
 
 function saveName() {
   if (saving.value) return

--- a/frontend/src/components/ProfileBento/boundFields/ProfileBoundTextField.vue
+++ b/frontend/src/components/ProfileBento/boundFields/ProfileBoundTextField.vue
@@ -1,24 +1,27 @@
 <template>
-  <Textarea
-    :label="spec.title"
-    class="w-full"
-    :data-profile-panel-field="spec.field"
-    :rows="4"
-    :maxlength="profileBioLimit"
-    :model-value="draft"
-    :placeholder="spec.emptyPrompt"
-    @update:model-value="draft = $event"
-    @blur="saveText"
-    @keydown.meta.enter.prevent="saveText"
-    @keydown.ctrl.enter.prevent="saveText"
-  >
-    <template #description>{{ charactersLeft }} characters left</template>
-  </Textarea>
+  <div ref="textField">
+    <Textarea
+      :label="spec.title"
+      class="w-full"
+      :data-profile-panel-field="spec.field"
+      :rows="4"
+      :maxlength="profileBioLimit"
+      :model-value="draft"
+      :placeholder="spec.emptyPrompt"
+      @update:model-value="draft = $event"
+      @blur="saveText"
+      @keydown.meta.enter.prevent="saveText"
+      @keydown.ctrl.enter.prevent="saveText"
+    >
+      <template #description>{{ charactersLeft }} characters left</template>
+    </Textarea>
+  </div>
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed, useTemplateRef } from 'vue'
 import { Textarea } from 'frappe-ui'
+import { useSyncedField } from '@/utils/useSyncedField'
 import { useBoundFieldSave } from './useBoundFieldSave'
 import {
   profileBioLimit,
@@ -35,16 +38,17 @@ const props = defineProps<{
 
 const { saving, commit } = useBoundFieldSave(() => props.fieldEditor)
 
-const draft = ref('')
-const charactersLeft = computed(() => profileBioLimit - draft.value.length)
+const textField = useTemplateRef<HTMLElement>('textField')
 
-watch(
-  () => [props.card.id, props.card.text] as const,
-  () => {
-    draft.value = props.card.text || ''
-  },
-  { immediate: true },
-)
+// See useSyncedField for why the doc store publishes a document more than once
+// and why a plain watcher cannot tell a fresh value from a stale one. The card
+// id is part of the identity because one panel edits whichever card is selected.
+const draft = useSyncedField({
+  source: () => props.card.text,
+  identity: () => `${props.fieldEditor.userId}/${props.card.id}`,
+  target: textField,
+})
+const charactersLeft = computed(() => profileBioLimit - draft.value.length)
 
 function saveText() {
   if (saving.value || draft.value === (props.card.text || '')) return

--- a/frontend/src/components/ProfileBento/types.ts
+++ b/frontend/src/components/ProfileBento/types.ts
@@ -44,6 +44,12 @@ export type ProfileFieldUpdate =
  * that knows which document each bound field actually lives on.
  */
 export interface ProfileFieldEditor {
+  /**
+   * `User` name of the profile being edited. Editors sync their inputs against
+   * it, so a switch to another profile reseeds them instead of carrying a draft
+   * across.
+   */
+  userId: string
   /** `User.first_name` / `User.last_name`, for the two-input full-name editor. */
   firstName: string
   lastName: string

--- a/frontend/src/components/ProfileBento/useProfileFieldEditing.ts
+++ b/frontend/src/components/ProfileBento/useProfileFieldEditing.ts
@@ -98,6 +98,7 @@ export function useProfileFieldEditing(options: {
   return computed(() => {
     if (!options.enabled()) return undefined
     return {
+      userId: userResource.doc?.name || options.userId(),
       firstName: userResource.doc?.first_name || '',
       lastName: userResource.doc?.last_name || '',
       save,

--- a/frontend/src/pages/Page.vue
+++ b/frontend/src/pages/Page.vue
@@ -58,7 +58,7 @@
         <span class="text-sm text-ink-gray-5 sm:hidden">
           Updated {{ dayjsLocal(page.doc.modified).format('lll') }}
         </span>
-        <div class="mb-3 md:px-[70px]">
+        <div class="mb-3 md:px-[70px]" ref="titleField">
           <input
             class="w-full border-0 p-0 pt-4 text-5xl-semibold focus:outline-none focus:ring-0 bg-surface-base text-ink-gray-8"
             type="text"
@@ -70,19 +70,21 @@
             placeholder="Title"
           />
         </div>
-        <PageEditor
-          editor-class="rounded-b-lg max-w-[unset] prose-v3 pb-[50vh] md:px-[70px]"
-          :content="content"
-          :editable="canEditPage"
-          @change="
-            (value) => {
-              content = value
-              autosave()
-            }
-          "
-          placeholder="Start writing here..."
-          ref="textEditor"
-        />
+        <div ref="contentField">
+          <PageEditor
+            editor-class="rounded-b-lg max-w-[unset] prose-v3 pb-[50vh] md:px-[70px]"
+            :content="content"
+            :editable="canEditPage"
+            @change="
+              (value) => {
+                content = value
+                autosave()
+              }
+            "
+            placeholder="Start writing here..."
+            ref="textEditor"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -113,6 +115,7 @@ import { useSessionUser } from '@/data/users'
 import { canDeleteContent, canEditContent } from '@/utils/permissions'
 import { useCommandPaletteCommands } from '@/components/CommandPalette/registry'
 import { useOwnedRouteWrites } from '@/composables/useOwnedRouteWrites'
+import { useSyncedField } from '@/utils/useSyncedField'
 const props = defineProps<{
   communityId?: string
   pageId: string
@@ -131,20 +134,38 @@ const runWhenOwned = useOwnedRouteWrites(() => route.name === 'SpacePage' || rou
 
 const titleInput = useTemplateRef('titleInput')
 const textEditor = useTemplateRef('textEditor')
-
-const title = ref('')
-const content = ref('')
+const titleField = useTemplateRef<HTMLElement>('titleField')
+const contentField = useTemplateRef<HTMLElement>('contentField')
 
 const page = useDoc<GPPage>({
   doctype: 'GP Page',
   name: () => props.pageId,
 })
 
-page.onSuccess((doc) => {
-  title.value = doc.title || ''
-  content.value = doc.content || ''
+// Read from the document, not from the fetch response. The body renders as soon
+// as `page.doc` arrives, which can be the cached copy the doc store publishes
+// before the network one. Seeding only on the response left the inputs rendered
+// and empty until it landed, and overwrote anything typed in that gap.
+// See useSyncedField for how the two publishes are told apart.
+const title = useSyncedField({
+  source: () => page.doc?.title,
+  identity: () => page.doc?.name,
+  target: titleField,
+})
+const content = useSyncedField({
+  source: () => page.doc?.content,
+  identity: () => page.doc?.name,
+  target: contentField,
+})
+
+page.onSuccess(() => {
   updateUrlSlug()
-  titleInput.value?.focus()
+  // Only when nobody is working yet: on a slow response the body has been
+  // interactive since the cached copy rendered, and pulling focus to the title
+  // would yank someone out of the editor mid-sentence.
+  if (!document.activeElement || document.activeElement === document.body) {
+    titleInput.value?.focus()
+  }
 })
 
 const isDirty = computed(() => {


### PR DESCRIPTION
Three places where a document arriving late replaced text the user had already typed. All the same defect, the one `useSyncedField` was written for.

## Why it happens

frappe-ui's doc store hands a document to a component twice: once from its IndexedDB cache, once from the network. Nothing orders the two. A component that copies the document into an input on every publish loses whatever was typed between the two.

The library side of this is frappe/frappe-ui#921, which makes the two publishes arrive in order. That fixes the stale-overwrites-fresh half. It does not fix the half where a perfectly correct second publish lands while someone is typing, which is what these three do.

## The three

**Name fields on the profile panel.** The watcher copied the stored name into both inputs every time it ran, and it ran on every publish. Its source was a fresh array literal over `fieldEditor`, a computed that rebuilds its object on each evaluation, so `Object.is` never short-circuited it. The comment above the watcher claimed the opposite.

**Bio field on the profile panel.** Same shape. The card id was in the watch source but never compared, so every publish reset the textarea.

**Page title and content.** Different route to the same outcome. The page body renders on `v-if="page.doc"`, and `page.doc` can be the cached copy, which arrives first. But `title` and `content` were seeded in `onSuccess`, which only fires on the network response. So both inputs were on screen, editable, and empty until the response landed, and it replaced anything typed in that window. They now read from `page.doc`, which gets both publishes.

Focus also changed here. The title was focused on every successful response. On a slow one, the page has been interactive since the cached copy rendered, so that pulled someone out of the editor mid-sentence. It now only takes focus when nothing else has it.

`ProfileFieldEditor` gained a `userId` field. `useSyncedField` needs to know which document it is following so switching profiles reseeds the inputs instead of carrying a draft across.

## Checks

- `yarn build` clean, `vue-tsc` reports nothing on the touched files
- Cypress against `gameplan-demo.test`: 15 passing across `profile-bento-cards`, `profile-card-editing`, `profile-settings` and `create-page`. That includes `shows the new bio after the bio is edited`, the spec that had been flaking.
- Run against the published `frappe-ui` beta.34, so these fixes stand on their own without the library change.
