### PR TITLE
fix(router): stop legacy /g/<name> URLs from landing on 404

### DIFF
--- a/frontend/src/router.ts
+++ b/frontend/src/router.ts
@@ -63,6 +63,23 @@ function redirectOldSpacesRoute(to: RouteLocationNormalized): RouteLocationRaw {
   return getHomeRoute()
 }
 
+/**
+ * `/:teamId` is the legacy single-segment community URL. It matches anything, so a stale
+ * link such as `/g/teams` (the app lived at `/teams` before it moved to `/g`) used to be
+ * read as a community id and land on the 404 page. Only redirect when the community really
+ * exists; send everything else home.
+ */
+async function redirectLegacyTeamRoute(to: RouteLocationNormalized): Promise<RouteLocationRaw> {
+  await ensureCommunityDataLoaded()
+
+  const communityId = routeParam(to.params.teamId)
+  if (!communityId || !getCommunity(communityId)) {
+    return getHomeRoute()
+  }
+
+  return { name: 'Discussions', params: { communityId } }
+}
+
 const routes: RouteRecordRaw[] = [
   {
     path: '/',
@@ -552,35 +569,21 @@ const routes: RouteRecordRaw[] = [
   {
     path: '/:teamId',
     name: 'TeamLayout',
-    redirect: { name: 'Team' },
+    redirect: (to) => ({ name: 'Team', params: { teamId: routeParam(to.params.teamId) } }),
     props: true,
     children: [
       {
         name: 'Team',
         path: '',
-        redirect: (to) => ({
-          name: 'Discussions',
-          params: { communityId: routeParam(to.params.teamId) },
-        }),
+        component: RouteGuard,
         props: true,
-        children: [
-          {
-            name: 'TeamOverview',
-            path: '',
-            redirect: (to) => ({
-              name: 'Discussions',
-              params: { communityId: routeParam(to.params.teamId) },
-            }),
-          },
-          {
-            name: 'TeamDiscussions',
-            path: 'discussions',
-            redirect: (to) => ({
-              name: 'Discussions',
-              params: { communityId: routeParam(to.params.teamId) },
-            }),
-          },
-        ],
+        beforeEnter: redirectLegacyTeamRoute,
+      },
+      {
+        name: 'TeamDiscussions',
+        path: 'discussions',
+        component: RouteGuard,
+        beforeEnter: redirectLegacyTeamRoute,
       },
       {
         name: 'ProjectLayout',


### PR DESCRIPTION
## Problem

`/g/teams` redirects to `/g/404`.

The legacy `/:teamId` route matches any single-segment path. It redirected to the
community discussions page with that segment as the community id. The global
route guard then rejected the unknown community and sent the user to `/404`.

Any stale one-segment link hits this: an old bookmark, a browser history entry,
or a cached redirect. `/g/teams` is the common one, because the app lived at
`/teams` before it moved to `/g`.

## Fix

Resolve the community before the redirect. Send the user home when it does not
exist.

`redirect` callbacks are synchronous, so they cannot wait for the community
store. The two legacy alias routes now use `beforeEnter`, the same pattern the
`/`, `/home` and `/discussions` routes already use. This also removes the
`TeamOverview` child, an empty path nested in an empty path.

## Verified in the browser

| URL | Before | After |
| --- | --- | --- |
| `/g/teams` | `/g/404` | home discussions |
| `/g/<community>` | discussions | unchanged |
| `/g/<community>/discussions` | discussions | unchanged |
| `/g/<community>/projects/<id>` | space | unchanged |

No new console warnings.

## Note

The `/g/teams` URL itself comes from stale site data, not from code. On one dev
site `Portal Settings.default_portal_home` is still `/teams`, set by hand in
2022. No Gameplan code has ever written that field, and fresh sites leave it
empty, so this PR adds no patch for it. The router fix protects against every
stale `/g/<name>` link regardless.