### PR TITLE
feat(editor): collapsible sections

### DIFF
--- a/frontend/src/components/editor/collapsible/CollapsibleNodeView.vue
+++ b/frontend/src/components/editor/collapsible/CollapsibleNodeView.vue
@@ -82,26 +82,31 @@ function toggle() {
   transform: rotate(90deg);
 }
 
-.gp-collapsible-body > :deep(summary) {
+/*
+ * Descendant selectors, not direct-child ones: @tiptap/vue-3 injects its own
+ * `div[data-node-view-content-vue]` between the content element and the node's
+ * children, so `>` matches nothing. A nested collapsible picks up the same
+ * rules, which is what we want — and when an outer section is closed its whole
+ * subtree is hidden with it.
+ */
+.gp-collapsible :deep(summary) {
   display: block;
   font-weight: 500;
   cursor: text;
 }
 
 /* Suppress the native disclosure triangle; the gutter button replaces it. */
-.gp-collapsible-body > :deep(summary)::marker,
-.gp-collapsible-body > :deep(summary)::-webkit-details-marker {
+.gp-collapsible :deep(summary)::marker,
+.gp-collapsible :deep(summary)::-webkit-details-marker {
   display: none;
   content: '';
 }
 
-.gp-collapsible[data-open='false']
-  > .gp-collapsible-body
-  > :deep([data-type='collapsible-content']) {
+.gp-collapsible[data-open='false'] :deep([data-type='collapsible-content']) {
   display: none;
 }
 
-.gp-collapsible-body > :deep([data-type='collapsible-content']) {
+.gp-collapsible :deep([data-type='collapsible-content']) {
   margin-top: 0.25rem;
 }
 </style>

--- a/frontend/src/components/editor/collapsible/CollapsibleNodeView.vue
+++ b/frontend/src/components/editor/collapsible/CollapsibleNodeView.vue
@@ -1,0 +1,107 @@
+<template>
+  <NodeViewWrapper class="gp-collapsible my-2 first:mt-0 last:mb-0" :data-open="isOpen">
+    <button
+      type="button"
+      contenteditable="false"
+      class="gp-collapsible-toggle text-ink-gray-5 hover:bg-surface-gray-2 rounded"
+      :aria-expanded="isOpen"
+      :aria-label="isOpen ? 'Collapse section' : 'Expand section'"
+      @click="toggle"
+    >
+      <svg
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        class="h-4 w-4"
+      >
+        <path d="m9 18 6-6-6-6" />
+      </svg>
+    </button>
+    <NodeViewContent class="gp-collapsible-body" />
+  </NodeViewWrapper>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import { NodeViewContent, NodeViewWrapper, nodeViewProps } from '@tiptap/vue-3'
+
+const props = defineProps(nodeViewProps)
+
+/**
+ * Display state is always local, so a reader can collapse a section without the
+ * document changing. Only an editable editor writes the choice back to the
+ * `open` attribute, where it becomes part of the saved HTML and the default the
+ * next reader sees. `editor.isEditable` is a plain property (not reactive), so
+ * it is read at click time rather than tracked.
+ */
+const isOpen = ref<boolean>(props.node.attrs.open !== false)
+
+watch(
+  () => props.node.attrs.open,
+  (open) => {
+    isOpen.value = open !== false
+  },
+)
+
+function toggle() {
+  isOpen.value = !isOpen.value
+  if (props.editor.isEditable) {
+    props.updateAttributes({ open: isOpen.value })
+  }
+}
+</script>
+
+<style scoped>
+.gp-collapsible {
+  position: relative;
+  padding-left: 1.5rem;
+}
+
+/*
+ * The toggle sits in the gutter, aligned to the first line of the title. It is
+ * `contenteditable="false"` so ProseMirror treats it as a widget rather than
+ * text; `user-select: none` keeps it out of a drag-selection of the title.
+ */
+.gp-collapsible-toggle {
+  position: absolute;
+  left: 0;
+  top: 0.125rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 1.25rem;
+  width: 1.25rem;
+  user-select: none;
+  transition: transform 150ms ease;
+}
+
+.gp-collapsible[data-open='true'] > .gp-collapsible-toggle {
+  transform: rotate(90deg);
+}
+
+.gp-collapsible-body > :deep(summary) {
+  display: block;
+  font-weight: 500;
+  cursor: text;
+}
+
+/* Suppress the native disclosure triangle; the gutter button replaces it. */
+.gp-collapsible-body > :deep(summary)::marker,
+.gp-collapsible-body > :deep(summary)::-webkit-details-marker {
+  display: none;
+  content: '';
+}
+
+.gp-collapsible[data-open='false']
+  > .gp-collapsible-body
+  > :deep([data-type='collapsible-content']) {
+  display: none;
+}
+
+.gp-collapsible-body > :deep([data-type='collapsible-content']) {
+  margin-top: 0.25rem;
+}
+</style>

--- a/frontend/src/components/editor/collapsible/CollapsibleNodeView.vue
+++ b/frontend/src/components/editor/collapsible/CollapsibleNodeView.vue
@@ -3,7 +3,7 @@
     <button
       type="button"
       contenteditable="false"
-      class="gp-collapsible-toggle text-ink-gray-5 hover:bg-surface-gray-2 rounded"
+      class="gp-collapsible-toggle text-ink-gray-5 hover:bg-surface-gray-2 active:bg-surface-gray-3 h-6 w-6 rounded-3"
       :aria-expanded="isOpen"
       :aria-label="isOpen ? 'Collapse section' : 'Expand section'"
       @click="toggle"
@@ -15,7 +15,7 @@
         stroke-width="2"
         stroke-linecap="round"
         stroke-linejoin="round"
-        class="h-4 w-4"
+        class="h-3.5 w-3.5"
       >
         <path d="m9 18 6-6-6-6" />
       </svg>
@@ -55,25 +55,35 @@ function toggle() {
 </script>
 
 <style scoped>
+/*
+ * 1.75rem puts the title on the same x as bullet-list and task-list text
+ * (measured in the editor: both land ~28px past the block's left edge), so a
+ * section reads as one more item in the same column rather than a block that
+ * starts somewhere new.
+ */
 .gp-collapsible {
   position: relative;
-  padding-left: 1.5rem;
+  padding-left: 1.75rem;
 }
 
 /*
- * The toggle sits in the gutter, aligned to the first line of the title. It is
+ * A 24px rounded square matching `Button size="xs"` (h-6 w-6 rounded-3), sized
+ * by utility classes on the element itself. Centred in the 28px gutter, which
+ * puts its midpoint on the task-list checkbox's midpoint. It is
  * `contenteditable="false"` so ProseMirror treats it as a widget rather than
  * text; `user-select: none` keeps it out of a drag-selection of the title.
  */
 .gp-collapsible-toggle {
   position: absolute;
   left: 0;
-  top: 0.125rem;
+  /* Centre on the title's first line, whatever its line-height. `1lh` is the
+   * same unit frappe-ui's task list uses; the plain `top: 0` above it is the
+   * fallback where the unit is unsupported. */
+  top: 0;
+  top: calc((1lh - 1.5rem) / 2);
   display: flex;
   align-items: center;
   justify-content: center;
-  height: 1.25rem;
-  width: 1.25rem;
   user-select: none;
   transition: transform 150ms ease;
 }

--- a/frontend/src/components/editor/collapsible/CollapsibleNodeView.vue
+++ b/frontend/src/components/editor/collapsible/CollapsibleNodeView.vue
@@ -85,10 +85,18 @@ function toggle() {
   align-items: center;
   justify-content: center;
   user-select: none;
+}
+
+/*
+ * Only the chevron turns. Rotating the button would spin its hover square with
+ * it, and the `>` keeps an outer section's open state off a nested section's
+ * chevron.
+ */
+.gp-collapsible-toggle > svg {
   transition: transform 150ms ease;
 }
 
-.gp-collapsible[data-open='true'] > .gp-collapsible-toggle {
+.gp-collapsible[data-open='true'] > .gp-collapsible-toggle > svg {
   transform: rotate(90deg);
 }
 

--- a/frontend/src/components/editor/collapsible/CollapsibleNodeView.vue
+++ b/frontend/src/components/editor/collapsible/CollapsibleNodeView.vue
@@ -3,7 +3,7 @@
     <button
       type="button"
       contenteditable="false"
-      class="gp-collapsible-toggle text-ink-gray-5 hover:bg-surface-gray-2 active:bg-surface-gray-3 h-6 w-6 rounded-3"
+      class="gp-collapsible-toggle text-ink-gray-5 hover:bg-surface-gray-2 active:bg-surface-gray-3 aria-expanded:bg-surface-gray-3 h-6 w-6 rounded-3"
       :aria-expanded="isOpen"
       :aria-label="isOpen ? 'Collapse section' : 'Expand section'"
       @click="toggle"
@@ -68,8 +68,12 @@ function toggle() {
 
 /*
  * A 24px rounded square matching `Button size="xs"` (h-6 w-6 rounded-3), sized
- * by utility classes on the element itself. Centred in the 28px gutter, which
- * puts its midpoint on the task-list checkbox's midpoint. It is
+ * by utility classes on the element itself. An expanded section holds the
+ * button in frappe-ui's on-state fill: the toolbar uses
+ * `aria-pressed:bg-surface-gray-3`, and this drives the same shade off
+ * `aria-expanded`, which is the correct attribute for a disclosure control.
+ * Centred in the 28px gutter, which puts its midpoint on the task-list
+ * checkbox's midpoint. It is
  * `contenteditable="false"` so ProseMirror treats it as a widget rather than
  * text; `user-select: none` keeps it out of a drag-selection of the title.
  */

--- a/frontend/src/components/editor/collapsible/CollapsibleNodeView.vue
+++ b/frontend/src/components/editor/collapsible/CollapsibleNodeView.vue
@@ -8,16 +8,24 @@
       :aria-label="isOpen ? 'Collapse section' : 'Expand section'"
       @click="toggle"
     >
+      <!--
+        A solid triangle, the disclosure convention GitHub's <details> and
+        Notion's toggle both use. The same-colour stroke is what rounds the
+        three points: `stroke-linejoin: round` only softens corners that a
+        stroke actually draws, so a fill-only triangle stays sharp. The path is
+        drawn inset to leave room for it, keeping the outer size honest.
+        Arbitrary px because the spacing scale is integers only, so `size-3.25`
+        would silently not compile.
+      -->
       <svg
         viewBox="0 0 24 24"
-        fill="none"
+        fill="currentColor"
         stroke="currentColor"
-        stroke-width="2"
-        stroke-linecap="round"
+        stroke-width="2.5"
         stroke-linejoin="round"
-        class="h-3.5 w-3.5"
+        class="size-[13px]"
       >
-        <path d="m9 18 6-6-6-6" />
+        <path d="M9.5 6.5 L18 12 L9.5 17.5 Z" />
       </svg>
     </button>
     <NodeViewContent class="gp-collapsible-body" />

--- a/frontend/src/components/editor/collapsible/collapsible-extension.ts
+++ b/frontend/src/components/editor/collapsible/collapsible-extension.ts
@@ -169,7 +169,13 @@ export const Collapsible = Node.create({
       new InputRule({
         // Notion's `>` is already blockquote in the starter kit, so the toggle
         // takes `>>`. Anything typed after it on the line becomes the title.
-        find: /^>>\s$/,
+        //
+        // `»` is not an alternative spelling — it is what the user's `>>` has
+        // already become. The Typography extension (loaded by RichTextKit, not
+        // by CommentKit) rewrites `>>` to a guillemet on the second keystroke,
+        // before the space that triggers this rule. Matching both is what makes
+        // the same trigger work in a discussion body and in a comment.
+        find: /^(?:>>|»)\s$/,
         handler: ({ state, range }) => {
           const $start = state.doc.resolve(range.from)
           const paragraph = $start.parent

--- a/frontend/src/components/editor/collapsible/collapsible-extension.ts
+++ b/frontend/src/components/editor/collapsible/collapsible-extension.ts
@@ -11,9 +11,10 @@ import CollapsibleNodeView from './CollapsibleNodeView.vue'
  * Serialized as semantic `<details open><summary>…</summary><div
  * data-type="collapsible-content">…</div></details>` so it still collapses
  * natively wherever the stored HTML is rendered without the editor — email
- * digests, search previews. `<summary>` is not in frappe's `acceptable_elements`,
- * so `gameplan/utils/sanitizer.py` adds it to the allowed tag list; without that
- * bleach escapes the tag on save.
+ * digests, search previews. `details`, `summary` and the `open` attribute are all
+ * in frappe's sanitizer allowlist, so this shape survives a save untouched;
+ * `gameplan/tests/platform/test_collapsible_html.py` pins that, since a dropped
+ * tag or attribute fails silently rather than raising.
  *
  * The three nodes are separate on purpose: `collapsible` owns the open/closed
  * attribute and the node view, `collapsibleSummary` is a one-line inline

--- a/frontend/src/components/editor/collapsible/collapsible-extension.ts
+++ b/frontend/src/components/editor/collapsible/collapsible-extension.ts
@@ -1,0 +1,255 @@
+import { InputRule, Node, mergeAttributes } from '@tiptap/core'
+import { TextSelection } from '@tiptap/pm/state'
+import { Fragment } from '@tiptap/pm/model'
+import { VueNodeViewRenderer } from '@tiptap/vue-3'
+import CollapsibleNodeView from './CollapsibleNodeView.vue'
+
+/**
+ * A collapsible ("toggle") section: a click-to-expand title with arbitrary block
+ * content underneath.
+ *
+ * Serialized as semantic `<details open><summary>…</summary><div
+ * data-type="collapsible-content">…</div></details>` so it still collapses
+ * natively wherever the stored HTML is rendered without the editor — email
+ * digests, search previews. `<summary>` is not in frappe's `acceptable_elements`,
+ * so `gameplan/utils/sanitizer.py` adds it to the allowed tag list; without that
+ * bleach escapes the tag on save.
+ *
+ * The three nodes are separate on purpose: `collapsible` owns the open/closed
+ * attribute and the node view, `collapsibleSummary` is a one-line inline
+ * container (so Enter can mean "go to the body" instead of "new paragraph"), and
+ * `collapsibleContent` holds normal blocks — including nested collapsibles.
+ */
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    collapsible: {
+      /** Insert an empty collapsible section and put the caret in its title. */
+      setCollapsible: () => ReturnType
+      /** Unwrap the collapsible around the caret, keeping title and body as blocks. */
+      unsetCollapsible: () => ReturnType
+      /** Expand or collapse the section around the caret. */
+      toggleCollapsibleOpen: () => ReturnType
+    }
+  }
+}
+
+export const CollapsibleSummary = Node.create({
+  name: 'collapsibleSummary',
+  content: 'inline*',
+  defining: true,
+  selectable: false,
+
+  parseHTML() {
+    return [{ tag: 'summary' }]
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['summary', mergeAttributes(HTMLAttributes), 0]
+  },
+})
+
+export const CollapsibleContent = Node.create({
+  name: 'collapsibleContent',
+  content: 'block+',
+  defining: true,
+  selectable: false,
+
+  parseHTML() {
+    return [{ tag: 'div[data-type="collapsible-content"]' }]
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['div', mergeAttributes(HTMLAttributes, { 'data-type': 'collapsible-content' }), 0]
+  },
+})
+
+export const Collapsible = Node.create({
+  name: 'collapsible',
+  group: 'block',
+  content: 'collapsibleSummary collapsibleContent',
+  defining: true,
+  // Keeps a select-all / drag from merging a collapsible into a neighbouring
+  // block and leaving a half-built section behind.
+  isolating: true,
+
+  addAttributes() {
+    return {
+      open: {
+        default: true,
+        parseHTML: (element) => element.hasAttribute('open'),
+        // The HTML boolean attribute: present means open, absent means closed.
+        renderHTML: (attributes) => (attributes.open ? { open: '' } : {}),
+      },
+    }
+  },
+
+  parseHTML() {
+    return [{ tag: 'details' }]
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['details', mergeAttributes(HTMLAttributes), 0]
+  },
+
+  addNodeView() {
+    return VueNodeViewRenderer(CollapsibleNodeView)
+  },
+
+  addCommands() {
+    return {
+      setCollapsible:
+        () =>
+        ({ chain, state }) => {
+          const from = state.selection.from
+          return chain()
+            .insertContent({
+              type: this.name,
+              attrs: { open: true },
+              content: [
+                { type: CollapsibleSummary.name },
+                {
+                  type: CollapsibleContent.name,
+                  content: [{ type: 'paragraph' }],
+                },
+              ],
+            })
+            .command(({ tr, dispatch }) => {
+              if (!dispatch) return true
+              // `insertContent` gives no handle on what it inserted, so find the
+              // first summary at or after the original caret and land in it.
+              let target: number | null = null
+              tr.doc.nodesBetween(Math.max(0, from - 1), tr.doc.content.size, (node, pos) => {
+                if (target === null && node.type.name === CollapsibleSummary.name) {
+                  target = pos + 1
+                }
+              })
+              if (target !== null) {
+                tr.setSelection(TextSelection.create(tr.doc, target))
+              }
+              return true
+            })
+            .run()
+        },
+
+      unsetCollapsible:
+        () =>
+        ({ state, tr, dispatch }) => {
+          const found = findCollapsible(state)
+          if (!found) return false
+          if (dispatch) {
+            const summary = found.node.child(0)
+            const content = found.node.child(1)
+            // The title becomes a plain paragraph above the body it used to hide.
+            const paragraph = state.schema.nodes.paragraph.create(null, summary.content)
+            tr.replaceWith(
+              found.pos,
+              found.pos + found.node.nodeSize,
+              Fragment.from(paragraph).append(content.content),
+            )
+          }
+          return true
+        },
+
+      toggleCollapsibleOpen:
+        () =>
+        ({ state, tr, dispatch }) => {
+          const found = findCollapsible(state)
+          if (!found) return false
+          if (dispatch) {
+            tr.setNodeAttribute(found.pos, 'open', !found.node.attrs.open)
+          }
+          return true
+        },
+    }
+  },
+
+  addInputRules() {
+    return [
+      new InputRule({
+        // Notion's `>` is already blockquote in the starter kit, so the toggle
+        // takes `>>`. Anything typed after it on the line becomes the title.
+        find: /^>>\s$/,
+        handler: ({ state, range }) => {
+          const $start = state.doc.resolve(range.from)
+          const paragraph = $start.parent
+          if (paragraph.type.name !== 'paragraph') return null
+
+          const paragraphStart = $start.start()
+          const rest = paragraph.content.cut(range.to - paragraphStart)
+          const { schema } = state
+          // `state` here is tiptap's chainable state, so `state.tr` is the one
+          // transaction the input-rule plugin applies — not a fresh one.
+          const tr = state.tr
+          const node = schema.nodes[this.name].create({ open: true }, [
+            schema.nodes[CollapsibleSummary.name].create(null, rest),
+            schema.nodes[CollapsibleContent.name].create(null, schema.nodes.paragraph.create()),
+          ])
+
+          tr.replaceWith(paragraphStart - 1, $start.end() + 1, node)
+          // Caret at the end of the text that moved into the title.
+          tr.setSelection(TextSelection.create(tr.doc, paragraphStart + 1 + rest.size))
+        },
+      }),
+    ]
+  },
+
+  addKeyboardShortcuts() {
+    return {
+      // Enter in the title moves into the body rather than splitting the title,
+      // which the schema (`collapsibleSummary` is a single node) forbids anyway.
+      Enter: ({ editor }) => {
+        const { state } = editor
+        if (!state.selection.empty) return false
+        const found = findCollapsible(state)
+        if (!found || !isInSummary(state)) return false
+
+        const contentStart = found.pos + 1 + found.node.child(0).nodeSize + 1
+        return editor
+          .chain()
+          .command(({ tr, dispatch }) => {
+            // Entering a collapsed section would type into hidden content.
+            if (!found.node.attrs.open && dispatch) {
+              tr.setNodeAttribute(found.pos, 'open', true)
+            }
+            return true
+          })
+          .setTextSelection(contentStart + 1)
+          .run()
+      },
+
+      // Backspace at the very start of an empty title unwraps the section, the
+      // same escape hatch a blockquote or list item gives.
+      Backspace: ({ editor }) => {
+        const { state } = editor
+        if (!state.selection.empty || !isInSummary(state)) return false
+        const found = findCollapsible(state)
+        if (!found) return false
+        if (state.selection.from !== found.pos + 2) return false
+        return editor.commands.unsetCollapsible()
+      },
+    }
+  },
+})
+
+function findCollapsible(state: { selection: { $from: any } }) {
+  const { $from } = state.selection
+  for (let depth = $from.depth; depth > 0; depth--) {
+    const node = $from.node(depth)
+    if (node.type.name === Collapsible.name) {
+      return { node, pos: $from.before(depth) }
+    }
+  }
+  return null
+}
+
+function isInSummary(state: { selection: { $from: any } }) {
+  const { $from } = state.selection
+  for (let depth = $from.depth; depth > 0; depth--) {
+    if ($from.node(depth).type.name === CollapsibleSummary.name) return true
+  }
+  return false
+}
+
+/** The three nodes always load together — the parent's schema requires both children. */
+export const collapsibleExtensions = () => [Collapsible, CollapsibleSummary, CollapsibleContent]

--- a/frontend/src/components/editor/collapsible/collapsible-menu.ts
+++ b/frontend/src/components/editor/collapsible/collapsible-menu.ts
@@ -1,0 +1,77 @@
+import { SlashCommands, type MenuItem } from 'frappe-ui/editor'
+import type { AnyExtension, Editor, Range } from '@tiptap/core'
+
+const LABEL = 'Collapsible section'
+const ICON = 'lucide-chevron-right'
+
+const hasCollapsible = (editor: Editor) => 'collapsible' in editor.schema.nodes
+
+/** Toolbar / floating-menu entry. Hides itself when the node isn't loaded. */
+export const CollapsibleSection: MenuItem = {
+  label: LABEL,
+  icon: ICON,
+  action: (editor) => {
+    editor.chain().focus().setCollapsible().run()
+  },
+  isActive: (editor) => editor.isActive('collapsible'),
+  isAvailable: hasCollapsible,
+}
+
+type SlashItemsProps = { query: string; editor: Editor }
+type SlashCommandsOptions = {
+  suggestion?: {
+    items?: (props: SlashItemsProps) => SlashItem[] | Promise<SlashItem[]>
+    [key: string]: unknown
+  }
+  [key: string]: unknown
+}
+type SlashItem = {
+  title: string
+  icon: string
+  group?: string
+  isAvailable?: (editor: Editor) => boolean
+  command: (props: { editor: Editor; range: Range }) => void
+}
+
+const collapsibleSlashItem: SlashItem = {
+  title: LABEL,
+  icon: ICON,
+  // Matches the last group in frappe-ui's built-in registry, so the item lands
+  // under the existing "Insert" header instead of starting a stray second one.
+  group: 'Insert',
+  isAvailable: hasCollapsible,
+  command: ({ editor, range }) => {
+    editor.chain().focus().deleteRange(range).setCollapsible().run()
+  },
+}
+
+/**
+ * frappe-ui's slash-command registry is a closed list built inside the
+ * extension, so a gameplan-only command is added by wrapping its `items`
+ * resolver rather than editing the library. Kept local because this node is
+ * gameplan-only; if the node ever moves into frappe-ui, the command moves with
+ * it and this wrapper goes away.
+ */
+export function slashCommandsWithCollapsible(): AnyExtension {
+  return SlashCommands.extend({
+    // `this.parent()` is the library's own addOptions, so the built-in registry
+    // is read through tiptap's inheritance rather than off a frozen `.options`.
+    addOptions() {
+      const parent = this.parent?.() as SlashCommandsOptions
+      const baseItems = parent?.suggestion?.items
+      return {
+        ...parent,
+        suggestion: {
+          ...parent?.suggestion,
+          items: async (props: SlashItemsProps) => {
+            const base = baseItems ? await baseItems(props) : []
+            if (!hasCollapsible(props.editor)) return base
+            const query = props.query.toLowerCase()
+            if (query && !LABEL.toLowerCase().includes(query)) return base
+            return [...base, collapsibleSlashItem]
+          },
+        },
+      }
+    },
+  }) as AnyExtension
+}

--- a/frontend/src/components/editor/collapsible/index.ts
+++ b/frontend/src/components/editor/collapsible/index.ts
@@ -1,0 +1,7 @@
+export {
+  Collapsible,
+  CollapsibleSummary,
+  CollapsibleContent,
+  collapsibleExtensions,
+} from './collapsible-extension'
+export { CollapsibleSection, slashCommandsWithCollapsible } from './collapsible-menu'

--- a/frontend/src/components/editor/commentExtensions.ts
+++ b/frontend/src/components/editor/commentExtensions.ts
@@ -1,6 +1,5 @@
 import {
   CommentKit,
-  SlashCommands,
   TaskList,
   TaskItem,
   Iframe,
@@ -10,6 +9,7 @@ import {
   Highlight,
 } from 'frappe-ui/editor'
 import { gameplanHeadingLevels, suggestionConfig, richQuoteExtensions } from './config'
+import { collapsibleExtensions, slashCommandsWithCollapsible } from './collapsible'
 import { CustomEmojiExtension } from './customEmojiExtension'
 import type { RichQuoteController } from '@/components/RichQuoteExtension/useRichQuotes'
 
@@ -53,7 +53,10 @@ export function commentExtensions(
     Color,
     Highlight,
     CustomEmojiExtension,
-    SlashCommands.configure({}),
+    // Collapsible sections load here too, so a section written in a discussion
+    // body still renders and edits when that body is reopened in CommentEditor.
+    ...collapsibleExtensions(),
+    slashCommandsWithCollapsible(),
     ...richQuoteExtensions(opts.controller, opts.sourceId),
   ]
 }

--- a/frontend/src/components/editor/richTextExtensions.ts
+++ b/frontend/src/components/editor/richTextExtensions.ts
@@ -1,5 +1,6 @@
 import { RichTextKit } from 'frappe-ui/editor'
 import { gameplanHeadingLevels, suggestionConfig, richQuoteExtensions } from './config'
+import { collapsibleExtensions, slashCommandsWithCollapsible } from './collapsible'
 
 /**
  * The rich extension stack (articles, pages, discussion bodies, task descriptions):
@@ -14,8 +15,13 @@ export function richTextExtensions(opts: { suggestions?: boolean } = {}) {
   return [
     RichTextKit.configure({
       heading: { levels: [...gameplanHeadingLevels] },
+      // The kit's stock slash registry is replaced by the same registry plus the
+      // gameplan-only "Collapsible section" command.
+      slashCommands: false,
       ...suggestionConfig(opts.suggestions ?? true),
     }),
+    slashCommandsWithCollapsible(),
+    ...collapsibleExtensions(),
     ...richQuoteExtensions(),
   ]
 }

--- a/frontend/src/components/editor/toolbars.ts
+++ b/frontend/src/components/editor/toolbars.ts
@@ -24,6 +24,7 @@ import {
   Redo,
   type MenuItem,
 } from 'frappe-ui/editor'
+import { CollapsibleSection } from './collapsible'
 
 // The predefined items ship their own default icons from frappe-ui, so this is
 // just composition — no per-item icon plumbing.
@@ -56,6 +57,7 @@ export const gameplanToolbar: MenuItem[] = [
   Blockquote,
   InlineCode,
   HorizontalRule,
+  CollapsibleSection,
   Separator,
   InsertTable,
   Separator,
@@ -94,4 +96,5 @@ export const gameplanFloatingToolbar: MenuItem[] = [
   Blockquote,
   InlineCode,
   HorizontalRule,
+  CollapsibleSection,
 ]

--- a/gameplan/tests/platform/test_collapsible_html.py
+++ b/gameplan/tests/platform/test_collapsible_html.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# MIT License. See license.txt
+
+"""The stored HTML contract for editor collapsible sections.
+
+A collapsible section is saved as `<details open><summary>title</summary><div
+data-type="collapsible-content">…</div></details>`. Every part of that shape has
+to survive sanitization and a real save, because each one fails silently if it
+does not: a dropped `<summary>` loses the title, a dropped `open` reopens every
+collapsed section on reload, and a dropped `data-type` leaves the body outside
+the node so the section can no longer close.
+
+The tags come from frappe's `acceptable_elements`, so these tests also pin a
+dependency contract: if a future frappe drops `details`, `summary` or the `open`
+attribute, this fails here instead of quietly mangling saved documents.
+"""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from gameplan.tests.base import GameplanTestCase
+from gameplan.tests.fixtures import create_community, create_discussion, create_space
+from gameplan.utils.sanitizer import sanitize_content
+
+OPEN_SECTION = (
+	"<details open><summary>Deploy steps</summary>"
+	'<div data-type="collapsible-content"><p>ssh in</p></div></details>'
+)
+
+CLOSED_SECTION = (
+	"<details><summary>Deploy steps</summary>"
+	'<div data-type="collapsible-content"><p>ssh in</p></div></details>'
+)
+
+
+class TestCollapsibleSanitization(FrappeTestCase):
+	def test_open_section_survives_unchanged(self):
+		self.assertEqual(sanitize_content(OPEN_SECTION), OPEN_SECTION)
+
+	def test_closed_section_keeps_its_collapsed_state(self):
+		# The absence of `open` is the closed state, so an added attribute is as
+		# wrong as a dropped one.
+		self.assertEqual(sanitize_content(CLOSED_SECTION), CLOSED_SECTION)
+
+	def test_title_marks_are_kept(self):
+		html = (
+			"<details open><summary>Deploy <strong>now</strong></summary>"
+			'<div data-type="collapsible-content"><p>ssh in</p></div></details>'
+		)
+		self.assertEqual(sanitize_content(html), html)
+
+	def test_nested_section_survives(self):
+		html = (
+			"<details open><summary>Outer</summary>"
+			f'<div data-type="collapsible-content">{OPEN_SECTION}</div></details>'
+		)
+		self.assertEqual(sanitize_content(html), html)
+
+	def test_script_inside_a_title_is_still_neutralized(self):
+		# Allowing the tag must not open a hole inside it.
+		out = sanitize_content("<details open><summary>t<script>alert(1)</script></summary></details>")
+		self.assertNotIn("<script>", out)
+
+	def test_event_handler_on_a_section_is_stripped(self):
+		out = sanitize_content('<details open onclick="alert(1)"><summary>t</summary></details>')
+		self.assertNotIn("onclick", out)
+
+
+class TestCollapsibleRoundTrip(GameplanTestCase):
+	def setUp(self):
+		super().setUp()
+		community = create_community("Collapsible Community")
+		self.space = create_space("Collapsible Space", community)
+
+	def _reloaded_content(self, discussion):
+		return frappe.db.get_value("GP Discussion", discussion.name, "content")
+
+	def test_discussion_keeps_an_open_section(self):
+		discussion = create_discussion("With a section", self.space, content=OPEN_SECTION)
+		self.assertEqual(self._reloaded_content(discussion), OPEN_SECTION)
+
+	def test_discussion_keeps_a_closed_section(self):
+		discussion = create_discussion("With a closed section", self.space, content=CLOSED_SECTION)
+		self.assertEqual(self._reloaded_content(discussion), CLOSED_SECTION)
+
+	def test_editing_a_discussion_keeps_the_section(self):
+		# validate() and before_save() both sanitize, so a second save is a second
+		# pass over already-sanitized content — it must be a fixed point.
+		discussion = create_discussion("Edited", self.space, content=OPEN_SECTION)
+		discussion.content = CLOSED_SECTION
+		discussion.save(ignore_permissions=True)
+		self.assertEqual(self._reloaded_content(discussion), CLOSED_SECTION)

--- a/gameplan/utils/sanitizer.py
+++ b/gameplan/utils/sanitizer.py
@@ -73,11 +73,15 @@ def sanitize_content(html):
 	if not isinstance(html, str):
 		return html
 
+	# frappe's acceptable_elements has "details" but not "summary", so a collapsible
+	# section written in the editor would lose its title on save. "summary" carries
+	# no script or URL surface, so allowing it adds no XSS risk.
+	# TODO: drop once frappe adds "summary" to acceptable_elements upstream.
 	tags = (
 		list(acceptable_elements)
 		+ list(svg_elements)
 		+ list(mathml_elements)
-		+ ["html", "head", "meta", "link", "body", "style", "o:p", "iframe"]
+		+ ["html", "head", "meta", "link", "body", "style", "o:p", "iframe", "summary"]
 	)
 
 	def attributes_filter(tag, name, value):

--- a/gameplan/utils/sanitizer.py
+++ b/gameplan/utils/sanitizer.py
@@ -73,15 +73,11 @@ def sanitize_content(html):
 	if not isinstance(html, str):
 		return html
 
-	# frappe's acceptable_elements has "details" but not "summary", so a collapsible
-	# section written in the editor would lose its title on save. "summary" carries
-	# no script or URL surface, so allowing it adds no XSS risk.
-	# TODO: drop once frappe adds "summary" to acceptable_elements upstream.
 	tags = (
 		list(acceptable_elements)
 		+ list(svg_elements)
 		+ list(mathml_elements)
-		+ ["html", "head", "meta", "link", "body", "style", "o:p", "iframe", "summary"]
+		+ ["html", "head", "meta", "link", "body", "style", "o:p", "iframe"]
 	)
 
 	def attributes_filter(tag, name, value):


### PR DESCRIPTION
Adds a collapsible ("toggle") section to the editor: a title that expands and collapses a block of content.

Insert it three ways: the `/` menu, the toolbar button, or type `>>` then space. Loaded in both the rich and the comment stacks, so a section written in a discussion body still renders and edits when that body is reopened as a comment.

## Design

**Three schema nodes, not one.** `collapsible` owns the open attribute and the node view, `collapsibleSummary` is a one-line inline title, `collapsibleContent` holds normal blocks including nested sections. The title therefore keeps full rich-text marks, and Enter can mean "go to the body" because the schema already forbids splitting the title.

**Open state has two owners.** While editing it is a document attribute that saves. While reading it is local component state, so a reader collapsing a section never dirties the document.

**Stored as semantic HTML:**

```html
<details open>
  <summary>Deploy steps</summary>
  <div data-type="collapsible-content"><p>Run the migration first</p></div>
</details>
```

That still collapses natively where the HTML renders without the editor, such as email digests.

## No backend change

`details`, `summary` and the `open` attribute are already in frappe's sanitizer allowlist, so this shape survives a save untouched. An earlier revision of this PR added `summary` to `gameplan/utils/sanitizer.py`; that was a no-op and is reverted. frappe added the tag in [066f7c66de](https://github.com/frappe/frappe/commit/066f7c66de) (Nov 2024), present on `version-15`, `version-16` and `develop`.

## Appearance

The section aligns with the lists around it: the title sits on the same x as bullet-list and task-list text, and the toggle's midpoint sits on the task-list checkbox's midpoint. The toggle is a 24px rounded square matching `Button size="xs"`, filled while the section is expanded, with a rounded solid triangle that rotates on open.

## Tests

`gameplan/tests/platform/test_collapsible_html.py`, 9 tests:

- sanitizer: open state, closed state, title marks, nesting, and two XSS guards (`<script>` inside a title, `onclick` on the section)
- round trip: discussion save-and-reload for both states, plus a re-save, since `validate()` and `before_save()` both sanitize and the shape has to be a fixed point

Each of these fails silently rather than raising, which is why they are pinned: a dropped `<summary>` loses the title, a dropped `open` reopens every collapsed section on reload, a dropped `data-type` unlinks the body from the node. They also pin the dependency contract, so a future frappe dropping any of those tags fails here instead of mangling saved documents.

Editor behaviour is still verified by hand: toolbar, `/` menu and `>>` all insert; Enter moves into the body; Backspace at the start of the title unwraps without losing text; nested sections collapse independently; a reader toggling a saved discussion leaves `modified` untouched. A Cypress spec covering insert to publish to reload to reader-toggle would close that gap.
