### PR TITLE
chore(deps): upgrade frappe-ui to 1.0.0-beta.45

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,7 @@
     "@tiptap/vue-3": "^3.26.0",
     "@vueuse/core": "^10.1.2",
     "feather-icons": "^4.28.0",
-    "frappe-ui": "1.0.0-beta.43",
+    "frappe-ui": "1.0.0-beta.45",
     "fuzzysort": "^2.0.4",
     "gemoji": "^7.1.0",
     "htmldiff-js": "^1.0.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,7 @@
     "@tiptap/vue-3": "^3.26.0",
     "@vueuse/core": "^10.1.2",
     "feather-icons": "^4.28.0",
-    "frappe-ui": "1.0.0-beta.36",
+    "frappe-ui": "1.0.0-beta.43",
     "fuzzysort": "^2.0.4",
     "gemoji": "^7.1.0",
     "htmldiff-js": "^1.0.5",
@@ -53,6 +53,7 @@
   },
   "resolutions": {
     "@tiptap/core": "3.26.0",
+    "@tiptap/markdown": "3.26.0",
     "@tiptap/pm": "3.26.0",
     "@tiptap/vue-3": "3.26.0"
   }

--- a/frontend/src/.tokens-v2-ink-shift
+++ b/frontend/src/.tokens-v2-ink-shift
@@ -1,0 +1,3 @@
+The ink scale shift (tokens-v2 --ink-shift, #1016) ran here on 2026-08-10T18:53:13.918Z.
+A second run would double-shift every chromatic ink token.
+Delete this file only to re-run the shift on purpose.

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -22,7 +22,7 @@ import { loadRouteLocation, useRoute, useRouter } from 'vue-router'
 import { FrappeUIProvider } from 'frappe-ui'
 import { users, usersReady } from '@/data/users'
 import { session } from '@/data/session'
-import { useScreenSize } from 'frappe-ui'
+import { useIsMobile } from '@/utils/useIsMobile'
 import { useTheme } from '@/utils/useTheme'
 import { useCursorStyle } from '@/utils/useCursorStyle'
 import NewTaskDialog from './components/NewTaskDialog/NewTaskDialog.vue'
@@ -30,7 +30,7 @@ import SettingsDialog from './components/Settings/SettingsDialog.vue'
 import { settingsBackgroundPath } from './components/Settings'
 import { getHomeRoute } from '@/router'
 
-const screenSize = useScreenSize()
+const isMobileViewport = useIsMobile()
 const route = useRoute()
 const router = useRouter()
 useTheme()
@@ -43,7 +43,7 @@ const DevUserSwitcher = import.meta.env.DEV
 const MobileLayout = defineAsyncComponent(() => import('./components/MobileLayout.vue'))
 const DesktopLayout = defineAsyncComponent(() => import('./components/DesktopLayout.vue'))
 const Layout = computed(() => {
-  if (screenSize.width < 640) {
+  if (isMobileViewport.value) {
     return MobileLayout
   } else {
     return DesktopLayout

--- a/frontend/src/components/AboutDialog.vue
+++ b/frontend/src/components/AboutDialog.vue
@@ -26,7 +26,7 @@
         <a
           v-for="link in links"
           :key="link.label"
-          class="flex py-2 px-2 hover:bg-surface-gray-1 rounded cursor-pointer"
+          class="flex py-2 px-2 hover:bg-surface-gray-1 rounded-4 cursor-pointer"
           target="_blank"
           :href="link.url"
         >

--- a/frontend/src/components/AppRail/CustomizeSidebarDialog.vue
+++ b/frontend/src/components/AppRail/CustomizeSidebarDialog.vue
@@ -28,7 +28,7 @@
                   :key="community.name"
                   data-sortable-section="shown"
                   :data-sortable-id="community.name"
-                  class="group relative flex min-h-8 w-full touch-none cursor-grab select-none items-center gap-2 rounded px-1.5 py-0.5 text-left text-ink-gray-8 hover:bg-surface-gray-1"
+                  class="group relative flex min-h-8 w-full touch-none cursor-grab select-none items-center gap-2 rounded-4 px-1.5 py-0.5 text-left text-ink-gray-8 hover:bg-surface-gray-1"
                   :class="getCommunityRowClasses(community.name)"
                   :style="getItemStyle(community.name, 'shown')"
                   @pointerdown="startPointerDrag($event, community.name, 'shown')"
@@ -84,7 +84,7 @@
                 :key="community.name"
                 data-sortable-section="hidden"
                 :data-sortable-id="community.name"
-                class="group relative flex min-h-8 w-full touch-none cursor-grab select-none items-center gap-2 rounded-md px-1.5 py-0.5 text-left text-ink-gray-8 hover:bg-surface-gray-1"
+                class="group relative flex min-h-8 w-full touch-none cursor-grab select-none items-center gap-2 rounded-5 px-1.5 py-0.5 text-left text-ink-gray-8 hover:bg-surface-gray-1"
                 :class="getCommunityRowClasses(community.name)"
                 :style="getItemStyle(community.name, 'hidden')"
                 @pointerdown="startPointerDrag($event, community.name, 'hidden')"
@@ -292,7 +292,7 @@ function getCommunityRowClasses(communityName: string) {
 
 function getCommunityListClasses(section: SidebarSection) {
   return [
-    'min-h-16 rounded-lg border border-outline-gray-2 px-1.5 py-2 transition-colors',
+    'min-h-16 rounded-6 border border-outline-gray-2 px-1.5 py-2 transition-colors',
     activeSection.value === section ? 'border-outline-gray-4' : '',
   ]
 }

--- a/frontend/src/components/AppSelector.vue
+++ b/frontend/src/components/AppSelector.vue
@@ -4,7 +4,7 @@
       v-for="app in installedApps.data"
       :key="app.name"
       :href="app.route"
-      class="flex items-center gap-2 rounded p-1.5 hover:bg-surface-gray-2"
+      class="flex items-center gap-2 rounded-4 p-1.5 hover:bg-surface-gray-2"
     >
       <img class="h-6 w-6" :src="app.logo" :alt="app.title" />
       <span class="w-full truncate">

--- a/frontend/src/components/AppSidebarLink.vue
+++ b/frontend/src/components/AppSidebarLink.vue
@@ -2,7 +2,7 @@
   <AppLink
     :to="to"
     :isActive="isActive"
-    class="flex items-center rounded px-2 py-1 transition h-7"
+    class="flex items-center rounded-4 px-2 py-1 transition h-7"
     activeClass="bg-surface-elevation-3 shadow-sm text-ink-gray-8"
     inactiveClass="hover:bg-surface-gray-2 text-ink-gray-6"
   >

--- a/frontend/src/components/AvatarCropper.vue
+++ b/frontend/src/components/AvatarCropper.vue
@@ -101,7 +101,7 @@ const renderedSize = computed(() => {
   }
 })
 const frameClass = computed(() => [
-  'relative aspect-square w-full overflow-hidden rounded-lg bg-surface-gray-2 touch-none select-none',
+  'relative aspect-square w-full overflow-hidden rounded-6 bg-surface-gray-2 touch-none select-none',
   dragState.value ? 'cursor-grabbing' : 'cursor-grab',
 ])
 const imageWrapStyle = computed(() => ({

--- a/frontend/src/components/ColorPicker.vue
+++ b/frontend/src/components/ColorPicker.vue
@@ -10,7 +10,7 @@
     <template #body>
       <div class="left-1/2 mt-3 max-w-max -translate-x-1/2 transform px-4 sm:px-0">
         <div
-          class="relative max-h-96 overflow-y-auto rounded-lg bg-surface-elevation-2 p-2 shadow-lg ring-1 ring-black ring-opacity-5"
+          class="relative max-h-96 overflow-y-auto rounded-6 bg-surface-elevation-2 p-2 shadow-lg ring-1 ring-black ring-opacity-5"
         >
           <div class="grid grid-cols-11 place-items-center gap-1">
             <button

--- a/frontend/src/components/CommandPalette/CommandPalette.vue
+++ b/frontend/src/components/CommandPalette/CommandPalette.vue
@@ -57,7 +57,7 @@
                 :id="getCommandPaletteItemElementId(item)"
                 @click="onSelection(item)"
                 @mousemove="onItemMouseMove(item, $event)"
-                class="rounded"
+                class="rounded-4"
                 :class="[item.isActive ? 'bg-surface-gray-3' : '']"
                 role="option"
                 :aria-selected="item.isActive ? 'true' : 'false'"

--- a/frontend/src/components/CommandPalette/Item.vue
+++ b/frontend/src/components/CommandPalette/Item.vue
@@ -1,5 +1,7 @@
 <template>
-  <div class="flex w-full min-w-0 items-center rounded px-2 py-2 text-base-medium text-ink-gray-7">
+  <div
+    class="flex w-full min-w-0 items-center rounded-4 px-2 py-2 text-base-medium text-ink-gray-7"
+  >
     <span
       v-if="typeof item.icon === 'string'"
       :class="[item.icon, 'mr-3 h-4 w-4 shrink-0 text-ink-gray-6']"

--- a/frontend/src/components/CommandPalette/ItemProject.vue
+++ b/frontend/src/components/CommandPalette/ItemProject.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex w-full min-w-0 items-center rounded px-2 py-2 text-base" v-if="space">
+  <div class="flex w-full min-w-0 items-center rounded-4 px-2 py-2 text-base" v-if="space">
     <SpaceIcon :icon="space.icon" class="mr-3 size-4 shrink-0 text-ink-gray-6" />
     <span
       v-if="community && !item.hideCommunity"

--- a/frontend/src/components/Comment.vue
+++ b/frontend/src/components/Comment.vue
@@ -2,7 +2,7 @@
   <div class="relative" :data-id="comment.name">
     <div
       v-if="highlight"
-      class="absolute inset-0 translate-y- z-[5] rounded border-2 -mx-4 -mb-4 mt-11 pointer-events-none"
+      class="absolute inset-0 translate-y- z-[5] rounded-4 border-2 -mx-4 -mb-4 mt-11 pointer-events-none"
     />
     <!--
       The author row is opaque, so while it is sticky it paints over the top of
@@ -42,7 +42,7 @@
           <span v-if="isUpdating" class="italic text-ink-gray-5"> &nbsp;&middot; Sending... </span>
           <div v-if="updateError">
             &nbsp;&middot;
-            <span class="text-ink-red-8"> Error</span>
+            <span class="text-ink-red-7"> Error</span>
           </div>
         </div>
       </div>
@@ -64,7 +64,7 @@
       </div>
       <div
         :class="{
-          'w-full rounded-lg border bg-surface-base p-4 focus-within:border-outline-gray-3':
+          'w-full rounded-6 border bg-surface-base p-4 focus-within:border-outline-gray-3':
             isEditing,
         }"
         @keydown.ctrl.enter.capture.stop="updateComment()"

--- a/frontend/src/components/CommentsArea.vue
+++ b/frontend/src/components/CommentsArea.vue
@@ -168,7 +168,10 @@
               </span>
               <div class="hidden sm:block">
                 <TabButtons
-                  :buttons="[{ label: 'Comment' }, { label: 'Poll' }]"
+                  :options="[
+                    { value: 'Comment', label: 'Comment' },
+                    { value: 'Poll', label: 'Poll' },
+                  ]"
                   v-model="newCommentType"
                 />
               </div>
@@ -214,7 +217,10 @@
             >
               <template #actions-left>
                 <TabButtons
-                  :buttons="[{ label: 'Comment' }, { label: 'Poll' }]"
+                  :options="[
+                    { value: 'Comment', label: 'Comment' },
+                    { value: 'Poll', label: 'Poll' },
+                  ]"
                   v-model="newCommentType"
                 />
               </template>
@@ -233,7 +239,10 @@
             >
               <template #actions-left>
                 <TabButtons
-                  :buttons="[{ label: 'Comment' }, { label: 'Poll' }]"
+                  :options="[
+                    { value: 'Comment', label: 'Comment' },
+                    { value: 'Poll', label: 'Poll' },
+                  ]"
                   v-model="newCommentType"
                 />
               </template>

--- a/frontend/src/components/CommentsArea.vue
+++ b/frontend/src/components/CommentsArea.vue
@@ -95,13 +95,13 @@
           <div v-if="!showCommentBox" class="sm:-mx-3">
             <button
               type="button"
-              class="flex w-full items-center gap-3 text-left sm:gap-0 sm:rounded-lg sm:bg-surface-elevation-2 sm:px-2 sm:py-2 sm:text-base sm:text-ink-gray-5 sm:hover:bg-surface-elevation-3 sm:shadow-md"
+              class="flex w-full items-center gap-3 text-left sm:gap-0 sm:rounded-6 sm:bg-surface-elevation-2 sm:px-2 sm:py-2 sm:text-base sm:text-ink-gray-5 sm:hover:bg-surface-elevation-3 sm:shadow-md"
               @click="openCommentBox"
             >
               <UserAvatar class="sm:hidden" :user="$user().name" size="xl" />
               <UserAvatar class="mr-3 hidden sm:inline-block" :user="$user().name" size="sm" />
               <span
-                class="flex h-8 min-w-0 flex-1 items-center rounded-md bg-surface-gray-2 px-3 text-md text-ink-gray-5 sm:hidden"
+                class="flex h-8 min-w-0 flex-1 items-center rounded-5 bg-surface-gray-2 px-3 text-md text-ink-gray-5 sm:hidden"
               >
                 Add a comment
               </span>
@@ -110,7 +110,7 @@
           </div>
           <div
             v-else-if="composerMinimized"
-            class="flex cursor-pointer items-center gap-3 text-left focus:outline-none sm:-mx-3 sm:gap-0 sm:rounded-lg sm:bg-surface-elevation-2 sm:py-1 sm:pl-2 sm:pr-1 sm:text-base sm:text-ink-gray-5 sm:shadow-md sm:hover:bg-surface-elevation-3 sm:focus:bg-surface-elevation-3"
+            class="flex cursor-pointer items-center gap-3 text-left focus:outline-none sm:-mx-3 sm:gap-0 sm:rounded-6 sm:bg-surface-elevation-2 sm:py-1 sm:pl-2 sm:pr-1 sm:text-base sm:text-ink-gray-5 sm:shadow-md sm:hover:bg-surface-elevation-3 sm:focus:bg-surface-elevation-3"
             role="button"
             tabindex="0"
             @click="restoreComposer"
@@ -120,7 +120,7 @@
             <UserAvatar class="sm:hidden" :user="$user().name" size="xl" />
             <UserAvatar class="mr-3 hidden sm:inline-block" :user="$user().name" size="sm" />
             <span
-              class="flex h-8 min-w-0 flex-1 items-center truncate rounded-md bg-surface-gray-2 px-3 text-md text-ink-gray-5 sm:h-auto sm:bg-transparent sm:px-0 sm:text-base sm:text-ink-gray-6"
+              class="flex h-8 min-w-0 flex-1 items-center truncate rounded-5 bg-surface-gray-2 px-3 text-md text-ink-gray-5 sm:h-auto sm:bg-transparent sm:px-0 sm:text-base sm:text-ink-gray-6"
             >
               {{ minimizedLabel }}
             </span>
@@ -140,7 +140,7 @@
             :class="
               isComposerFullscreen
                 ? 'flex h-full flex-col'
-                : 'border-t border-outline-gray-2 sm:rounded-lg sm:border-t-0'
+                : 'border-t border-outline-gray-2 sm:rounded-6 sm:border-t-0'
             "
             :aria-busy="isDraftLoading"
             :inert="isDraftLoading"

--- a/frontend/src/components/CommentsArea.vue
+++ b/frontend/src/components/CommentsArea.vue
@@ -266,8 +266,7 @@ import Activity from './Activity.vue'
 import PollEditor from './PollEditor.vue'
 import Poll from './Poll.vue'
 import UserAvatar from './UserAvatar.vue'
-import { getScrollContainer } from 'frappe-ui'
-import { dialog } from 'frappe-ui'
+import { dialog, shellScrollContainer } from 'frappe-ui'
 import { subscribeToDoc, useSocket, type NewActivityEvent } from '@/socket'
 import { GPActivity, GPComment, GPPoll } from '@/types/doctypes'
 import type { Editor } from '@tiptap/vue-3'
@@ -277,7 +276,7 @@ import { useRichQuotes } from '@/components/RichQuoteExtension/useRichQuotes'
 import { useDraftSync } from '@/data/useDraftSync'
 import { useSessionUser } from '@/data/users'
 import type { Space } from '@/data/spaces'
-import { useIsMobile } from 'frappe-ui'
+import { useIsMobile } from '@/utils/useIsMobile'
 import { needsMobileCommentGap } from '@/utils/commentTimeline'
 
 interface Props {
@@ -672,7 +671,7 @@ async function scrollToEnd() {
   await wait(50)
   _scrollToEnd()
   await wait(100)
-  const scrollContainer = getScrollContainer()
+  const scrollContainer = shellScrollContainer.value
   if (!scrollContainer) return
   if (scrollContainer.scrollTop < scrollContainer.scrollHeight) {
     _scrollToEnd()
@@ -680,7 +679,7 @@ async function scrollToEnd() {
 }
 
 function _scrollToEnd() {
-  const scrollContainer = getScrollContainer()
+  const scrollContainer = shellScrollContainer.value
   if (!scrollContainer) return
   scrollContainer.scrollTop = scrollContainer.scrollHeight
 }
@@ -712,7 +711,7 @@ async function scrollToElement($el: HTMLElement) {
   await wait(50)
   let top = _scrollToElement($el)
   await wait(100)
-  const scrollContainer = getScrollContainer()
+  const scrollContainer = shellScrollContainer.value
   if (!scrollContainer) return
   if (scrollContainer.scrollTop != top) {
     _scrollToElement($el)
@@ -720,7 +719,7 @@ async function scrollToElement($el: HTMLElement) {
 }
 
 function _scrollToElement($el: HTMLElement) {
-  const scrollContainer = getScrollContainer()
+  const scrollContainer = shellScrollContainer.value
   if (!scrollContainer) return 0
   const headerHeight = 64
   const top = $el.offsetTop - scrollContainer.scrollTop - headerHeight

--- a/frontend/src/components/CommentsList.vue
+++ b/frontend/src/components/CommentsList.vue
@@ -111,7 +111,7 @@ import CommentEditor from '@/components/editor/CommentEditor.vue'
 import Comment from './Comment.vue'
 import Activity from './Activity.vue'
 import UserAvatar from './UserAvatar.vue'
-import { getScrollContainer } from 'frappe-ui'
+import { shellScrollContainer } from 'frappe-ui'
 import { needsMobileCommentGap } from '@/utils/commentTimeline'
 import { dialog } from 'frappe-ui'
 import { subscribeToDoc, useSocket, type NewActivityEvent } from '@/socket'
@@ -347,7 +347,7 @@ async function scrollToItem(item) {
 }
 
 function scrollToElement($el: HTMLElement) {
-  const scrollContainer = getScrollContainer()
+  const scrollContainer = shellScrollContainer.value
   if (!scrollContainer) return
   const headerHeight = 64
   const top = $el.offsetTop - scrollContainer.scrollTop - headerHeight
@@ -355,7 +355,7 @@ function scrollToElement($el: HTMLElement) {
 }
 
 function scrollToEnd() {
-  const scrollContainer = getScrollContainer()
+  const scrollContainer = shellScrollContainer.value
   if (!scrollContainer) return
   scrollContainer.scrollTop = scrollContainer.scrollHeight
 }

--- a/frontend/src/components/CommentsList.vue
+++ b/frontend/src/components/CommentsList.vue
@@ -60,7 +60,7 @@
         </div>
         <div class="relative w-full" v-show="!showCommentBox">
           <button
-            class="flex w-full items-center rounded-md border px-2 py-2 text-left text-base text-ink-gray-5 hover:border-outline-gray-3"
+            class="flex w-full items-center rounded-5 border px-2 py-2 text-left text-base text-ink-gray-5 hover:border-outline-gray-3"
             @click.stop="openCommentBox"
           >
             Add a comment
@@ -68,7 +68,7 @@
         </div>
         <div
           v-show="showCommentBox"
-          class="w-full rounded-lg border bg-surface-base p-4 focus-within:border-outline-gray-3"
+          class="w-full rounded-6 border bg-surface-base p-4 focus-within:border-outline-gray-3"
           @keydown.ctrl.enter.capture.stop="submitComment"
           @keydown.meta.enter.capture.stop="submitComment"
         >

--- a/frontend/src/components/CommunityDropdown.vue
+++ b/frontend/src/components/CommunityDropdown.vue
@@ -3,7 +3,7 @@
     <template #default="{ open }">
       <button
         type="button"
-        class="flex w-full min-w-0 items-center justify-between rounded px-2 py-1 text-ink-gray-7 transition"
+        class="flex w-full min-w-0 items-center justify-between rounded-4 px-2 py-1 text-ink-gray-7 transition"
         :class="open ? 'bg-surface-elevation-2 shadow-sm' : 'hover:bg-surface-gray-2'"
         :title="community?.title"
       >

--- a/frontend/src/components/CoverImage.vue
+++ b/frontend/src/components/CoverImage.vue
@@ -18,7 +18,7 @@
         @pointercancel="endDrag"
       >
         <div class="pointer-events-none text-center">
-          <div class="rounded-md py-1 text-xl text-ink-base">Drag image up or down</div>
+          <div class="rounded-5 py-1 text-xl text-ink-base">Drag image up or down</div>
           <div class="pointer-events-auto" data-cover-control @pointerdown.stop>
             <Button class="mt-2" @click="savePosition">Save position</Button>
             <Button class="ml-2 mt-2" @click="cancelReposition">Cancel</Button>

--- a/frontend/src/components/DevUserSwitcher.vue
+++ b/frontend/src/components/DevUserSwitcher.vue
@@ -27,7 +27,7 @@
         @open-auto-focus.prevent
       >
         <div
-          class="flex max-h-[70vh] w-80 max-w-[calc(100vw-1.5rem)] flex-col overflow-hidden rounded-lg bg-surface-elevation-2 shadow-2xl ring-1 ring-outline-gray-2"
+          class="flex max-h-[70vh] w-80 max-w-[calc(100vw-1.5rem)] flex-col overflow-hidden rounded-6 bg-surface-elevation-2 shadow-2xl ring-1 ring-outline-gray-2"
           style="transform-origin: var(--reka-popover-content-transform-origin)"
         >
           <div class="flex items-center justify-between gap-2 px-3 pt-3">
@@ -44,7 +44,7 @@
               v-for="user in filteredUsers"
               :key="user.name"
               type="button"
-              class="flex w-full items-center gap-2.5 rounded px-2 py-1.5 text-left hover:bg-surface-gray-2 disabled:opacity-60"
+              class="flex w-full items-center gap-2.5 rounded-4 px-2 py-1.5 text-left hover:bg-surface-gray-2 disabled:opacity-60"
               :disabled="Boolean(switchingTo)"
               @click="switchTo(user.name)"
             >

--- a/frontend/src/components/DiscussionRowSkeleton.vue
+++ b/frontend/src/components/DiscussionRowSkeleton.vue
@@ -9,11 +9,11 @@
         <div class="size-10 shrink-0 animate-pulse rounded-full bg-surface-gray-3" />
       </div>
       <div class="mx-3 min-w-0 flex-1 sm:ml-4 sm:mr-4">
-        <div class="h-4 w-4/5 max-w-80 animate-pulse rounded bg-surface-gray-3" />
-        <div class="mt-2 h-3.5 w-full max-w-[24rem] animate-pulse rounded bg-surface-gray-2" />
+        <div class="h-4 w-4/5 max-w-80 animate-pulse rounded-4 bg-surface-gray-3" />
+        <div class="mt-2 h-3.5 w-full max-w-[24rem] animate-pulse rounded-4 bg-surface-gray-2" />
       </div>
       <div class="ml-auto flex shrink-0 flex-col items-end">
-        <div class="h-3 w-10 animate-pulse rounded bg-surface-gray-2" />
+        <div class="h-3 w-10 animate-pulse rounded-4 bg-surface-gray-2" />
         <div class="mt-2 h-4 w-6 animate-pulse rounded-full bg-surface-gray-2" />
       </div>
     </div>

--- a/frontend/src/components/DiscussionView.vue
+++ b/frontend/src/components/DiscussionView.vue
@@ -346,7 +346,8 @@ import { useGroupedSpaceOptions } from '@/data/groupedSpaces'
 import { useDiscussion } from '@/data/discussions'
 import { useDraftSync } from '@/data/useDraftSync'
 import { tags } from '@/data/tags'
-import { useScrollContainer, useIsMobile } from 'frappe-ui'
+import { shellScrollContainer, useShellScrolled } from 'frappe-ui'
+import { useIsMobile } from '@/utils/useIsMobile'
 import { provideRichQuotes } from '@/components/RichQuoteExtension/useRichQuotes'
 import QuoteBacklinksPopover from '@/components/RichQuoteExtension/QuoteBacklinksPopover.vue'
 import { refreshUnreadCountForProjects } from '@/data/unreadCount'
@@ -372,7 +373,11 @@ const postEditor = useTemplateRef<{ editor: Editor | null }>('postEditor')
 const mainPostContentEl = ref<HTMLElement | null>(null)
 const postTitleEl = useTemplateRef<HTMLElement>('postTitleEl')
 
-const { isScrolled, scrollToTop, el: scrollContainerEl } = useScrollContainer()
+const isScrolled = useShellScrolled()
+const scrollContainerEl = shellScrollContainer
+function scrollToTop() {
+  shellScrollContainer.value?.scrollTo({ top: 0, behavior: 'smooth' })
+}
 const discussion = useDiscussion(() => props.postId)
 // In-app navigation skips the router's server canonicalization for speed, so a stale link to a
 // discussion deleted or moved out of reach after local data loaded would otherwise render a blank

--- a/frontend/src/components/DiscussionView.vue
+++ b/frontend/src/components/DiscussionView.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="relative flex h-full flex-col" v-if="postId">
     <PageHeaderMobile class="sm:hidden" :title="mobileHeaderTitle">
-      <template #left>
+      <template #prefix>
         <PageHeaderBackButton :to="backRoute" />
       </template>
     </PageHeaderMobile>

--- a/frontend/src/components/DiscussionView.vue
+++ b/frontend/src/components/DiscussionView.vue
@@ -45,7 +45,7 @@
       <template v-else-if="discussion.doc">
         <div
           :class="{
-            'rounded-lg border mt-14 py-4 px-3 sm:px-5 -mx-3 sm:-mx-5 focus-within:border-outline-gray-3':
+            'rounded-6 border mt-14 py-4 px-3 sm:px-5 -mx-3 sm:-mx-5 focus-within:border-outline-gray-3':
               editingPost,
           }"
           @keydown.ctrl.enter.capture.stop="updatePost"

--- a/frontend/src/components/EmojiPicker.vue
+++ b/frontend/src/components/EmojiPicker.vue
@@ -32,7 +32,7 @@
               v-for="custom in filteredCustomEmojis"
               :key="custom.name"
               type="button"
-              class="flex h-8 w-8 items-center justify-center rounded-md p-1 hover:bg-surface-gray-2 focus:outline-none focus:ring-2 focus:ring-outline-gray-3"
+              class="flex h-8 w-8 items-center justify-center rounded-5 p-1 hover:bg-surface-gray-2 focus:outline-none focus:ring-2 focus:ring-outline-gray-3"
               :title="custom.title"
               @click="selectEmoji(custom.image, close)"
             >
@@ -51,7 +51,7 @@
               v-for="emoji in emojis"
               :key="emoji.description"
               type="button"
-              class="h-8 w-8 rounded-md p-1 text-4xl hover:bg-surface-gray-2 focus:outline-none focus:ring-2 focus:ring-outline-gray-3"
+              class="h-8 w-8 rounded-5 p-1 text-4xl hover:bg-surface-gray-2 focus:outline-none focus:ring-2 focus:ring-outline-gray-3"
               :title="emoji.description"
               @click="selectEmoji(emoji.emoji, close)"
             >

--- a/frontend/src/components/EmptyStateBox.vue
+++ b/frontend/src/components/EmptyStateBox.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="flex flex-col items-center rounded-lg border-2 border-dashed py-8 text-base text-ink-gray-5"
+    class="flex flex-col items-center rounded-6 border-2 border-dashed py-8 text-base text-ink-gray-5"
   >
     <slot />
   </div>

--- a/frontend/src/components/IconPicker.vue
+++ b/frontend/src/components/IconPicker.vue
@@ -16,7 +16,7 @@
         @open-auto-focus.prevent
       >
         <div
-          class="max-w-[calc(100vw-2rem)] overflow-hidden rounded-lg bg-surface-elevation-2 text-base shadow-2xl ring-1 ring-black ring-opacity-5"
+          class="max-w-[calc(100vw-2rem)] overflow-hidden rounded-6 bg-surface-elevation-2 text-base shadow-2xl ring-1 ring-black ring-opacity-5"
           style="transform-origin: var(--reka-popover-content-transform-origin)"
         >
           <div class="relative">
@@ -27,7 +27,7 @@
                   :key="icon.class"
                   type="button"
                   role="option"
-                  class="flex size-8 items-center justify-center rounded text-ink-gray-7 hover:bg-surface-gray-2"
+                  class="flex size-8 items-center justify-center rounded-4 text-ink-gray-7 hover:bg-surface-gray-2"
                   :class="icon.class === modelValue ? 'bg-surface-gray-3 text-ink-gray-9' : ''"
                   :title="icon.label"
                   :aria-label="icon.label"

--- a/frontend/src/components/ImageUploader.vue
+++ b/frontend/src/components/ImageUploader.vue
@@ -1,7 +1,8 @@
 <template>
   <FileUploader
     :fileTypes="fileTypes"
-    :uploadArgs="uploadArgs"
+    :private="uploadOptions.private"
+    :optimize="uploadOptions.optimize"
     :validateFile="validateFile"
     @success="(file: UploadedFile) => emit('success', file)"
     @failure="(error: unknown) => emit('failure', error)"
@@ -18,14 +19,14 @@
  *
  * It exists so privacy, optimization and accepted file types are decided once per
  * kind of image (see `utils/imageUpload.ts`) rather than at each call site. `kind`
- * is required and there is no `uploadArgs` escape hatch, so a new upload site
- * cannot quietly inherit whichever default its upload primitive happens to have.
+ * is required and there is no escape hatch for raw upload options, so a new upload
+ * site cannot quietly inherit whichever default its upload primitive happens to have.
  */
 import { computed } from 'vue'
 import { FileUploader, type FileUploaderSlotProps, type UploadedFile } from 'frappe-ui'
 import {
   imageFileTypes,
-  imageUploadArgs,
+  imageUploadOptions,
   validateImageFile,
   type ImageUploadKind,
 } from '@/utils/imageUpload'
@@ -44,7 +45,7 @@ defineSlots<{
 }>()
 
 const fileTypes = computed(() => imageFileTypes(props.kind))
-const uploadArgs = computed(() => imageUploadArgs(props.kind))
+const uploadOptions = computed(() => imageUploadOptions(props.kind))
 
 function validateFile(file: File) {
   return validateImageFile(props.kind, file)

--- a/frontend/src/components/KeyboardShortcut.vue
+++ b/frontend/src/components/KeyboardShortcut.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     class="inline-flex items-center gap-0.5 text-sm"
-    :class="{ 'bg-surface-gray-2 rounded-sm text-ink-gray-5 p-0.5': bg, 'text-ink-gray-4': !bg }"
+    :class="{ 'bg-surface-gray-2 rounded-1 text-ink-gray-5 p-0.5': bg, 'text-ink-gray-4': !bg }"
   >
     <span v-if="ctrl"><span class="lucide-command w-3 h-3" /></span>
     <span v-if="shift"><span class="lucide-shift w-3 h-3" /></span>

--- a/frontend/src/components/LastPostReminder.vue
+++ b/frontend/src/components/LastPostReminder.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="shouldShowReminder">
-    <div class="border flex rounded-md p-3 border-outline-gray-2 dark:bg-gray-900">
+    <div class="border flex rounded-5 p-3 border-outline-gray-2 dark:bg-gray-900">
       <div class="flex-1">
         <div class="flex items-center">
           <span class="lucide-alert-triangle size-4 shrink-0 mr-2.5 text-ink-gray-8" />

--- a/frontend/src/components/MobileMoreMenu.vue
+++ b/frontend/src/components/MobileMoreMenu.vue
@@ -28,7 +28,7 @@
         <div class="mb-2 pl-[18px] text-lg-medium text-ink-gray-5">
           {{ group.label }}
         </div>
-        <nav class="overflow-hidden rounded-xl bg-surface-base">
+        <nav class="overflow-hidden rounded-7 bg-surface-base">
           <button
             v-for="(item, index) in group.items"
             :key="item.label"

--- a/frontend/src/components/Poll.vue
+++ b/frontend/src/components/Poll.vue
@@ -2,7 +2,7 @@
   <div class="relative">
     <div
       v-if="highlight"
-      class="absolute inset-0 translate-y- z-[5] rounded border-2 -mx-4 -mb-4 mt-11 pointer-events-none"
+      class="absolute inset-0 translate-y- z-[5] rounded-4 border-2 -mx-4 -mb-4 mt-11 pointer-events-none"
     />
     <!-- Mirrors the comment header (Comment.vue). Two parts matter and both were missing:
          `z-[1]`, or the option rows (positioned so the result bar can fill behind them)
@@ -65,12 +65,12 @@
       <div
         v-for="option in _poll.options"
         :key="option.idx"
-        class="relative -mx-2 overflow-hidden rounded"
+        class="relative -mx-2 overflow-hidden rounded-4"
         :data-poll-option="option.title"
       >
         <div
           v-if="showResults"
-          class="absolute inset-y-0 left-0 rounded transition-[width] duration-500 ease-out"
+          class="absolute inset-y-0 left-0 rounded-4 transition-[width] duration-500 ease-out"
           :class="isVotedByUser(option.title) ? 'bg-surface-gray-4' : 'bg-surface-gray-2'"
           :style="{ width: `${option.percentage || 0}%` }"
           aria-hidden="true"

--- a/frontend/src/components/ProfileBento/ProfileBentoCard.vue
+++ b/frontend/src/components/ProfileBento/ProfileBentoCard.vue
@@ -4,7 +4,7 @@
        swallows every space typed into an inline editor inside the card. -->
   <article
     ref="cardElement"
-    class="group relative block w-full min-w-0 overflow-hidden rounded-xl text-left outline-none transition focus:outline-none focus-visible:outline-none"
+    class="group relative block w-full min-w-0 overflow-hidden rounded-7 text-left outline-none transition focus:outline-none focus-visible:outline-none"
     :class="[flow ? '' : 'h-full', cardChromeClass, cardShellClass, dragClass]"
     :style="rootStyle"
     :data-profile-card-id="card.id"
@@ -141,10 +141,10 @@
               @pointerdown.stop
             >
               <div
-                class="grid size-10 place-items-center rounded-lg border border-dashed bg-surface-base"
+                class="grid size-10 place-items-center rounded-6 border border-dashed bg-surface-base"
                 :class="
                   error
-                    ? 'border-outline-red-2 text-ink-red-3'
+                    ? 'border-outline-red-2 text-ink-red-2'
                     : 'border-outline-gray-3 text-ink-gray-6'
                 "
               >
@@ -156,7 +156,7 @@
                   aria-hidden="true"
                 />
               </div>
-              <div v-if="error" class="text-xs font-medium leading-snug text-ink-red-3 sm:text-sm">
+              <div v-if="error" class="text-xs font-medium leading-snug text-ink-red-2 sm:text-sm">
                 {{ error }}
               </div>
               <div v-else-if="showImageEmptyCopy" class="space-y-0.5">
@@ -173,7 +173,7 @@
           class="flex h-full flex-col items-center justify-center gap-2 p-3 text-center text-ink-gray-5 sm:p-4"
         >
           <div
-            class="grid size-10 place-items-center rounded-lg border border-dashed border-outline-gray-3 bg-surface-base text-ink-gray-6"
+            class="grid size-10 place-items-center rounded-6 border border-dashed border-outline-gray-3 bg-surface-base text-ink-gray-6"
           >
             <span class="lucide-image-plus size-5" aria-hidden="true" />
           </div>

--- a/frontend/src/components/ProfileBento/ProfileBentoEditorPanel.vue
+++ b/frontend/src/components/ProfileBento/ProfileBentoEditorPanel.vue
@@ -95,9 +95,11 @@
               <div class="space-y-1.5">
                 <FormLabel label="Size" size="md" />
                 <TabButtons
-                  :buttons="profileCardSizeButtons"
+                  :options="profileCardSizeOptions"
                   :model-value="card.size"
-                  @update:model-value="(size: ProfileCardSize) => $emit('updateSize', size)"
+                  @update:model-value="
+                    (size: TabValue) => $emit('updateSize', size as ProfileCardSize)
+                  "
                 />
               </div>
 
@@ -108,7 +110,8 @@
                     :options="profileImageRenderingOptions"
                     :model-value="card.imageRendering || 'Cover'"
                     @update:model-value="
-                      (value: ProfileImageRendering) => $emit('updateImageRendering', value)
+                      (value: TabValue) =>
+                        $emit('updateImageRendering', value as ProfileImageRendering)
                     "
                   />
                 </div>
@@ -179,6 +182,7 @@ import {
   TabButtons,
   Textarea,
   TextInput,
+  type TabValue,
 } from 'frappe-ui'
 import ProfileImageField from './ProfileImageField.vue'
 import { profileBoundFieldEditors } from './boundFields'
@@ -231,7 +235,7 @@ const panelStyle = computed(() => {
   return { height: `${shellHeight.value}px` }
 })
 
-const profileCardSizeButtons = profileCardSizes.map((size) => ({ label: size }))
+const profileCardSizeOptions = profileCardSizes.map((size) => ({ value: size, label: size }))
 
 const isContentCard = computed(() => Boolean(props.card) && props.card?.type !== 'Blank')
 /** The spec of the profile field this card is bound to, if it is bound to one. */

--- a/frontend/src/components/ProfileBento/ProfileBentoEditorPanel.vue
+++ b/frontend/src/components/ProfileBento/ProfileBentoEditorPanel.vue
@@ -171,7 +171,7 @@
 import { computed } from 'vue'
 import { useElementSize } from '@vueuse/core'
 import {
-  activeScrollContainer,
+  shellScrollContainer,
   Button,
   Checkbox,
   FormLabel,
@@ -225,7 +225,7 @@ const emit = defineEmits<{
  * that element is exactly the box the sticky panel can occupy, and `100vh`
  * would overshoot it by the header and leave the last control unreachable.
  */
-const { height: shellHeight } = useElementSize(activeScrollContainer)
+const { height: shellHeight } = useElementSize(shellScrollContainer)
 const panelStyle = computed(() => {
   if (!shellHeight.value) return undefined
   return { height: `${shellHeight.value}px` }

--- a/frontend/src/components/ProfileBento/ProfileBentoEditorPanel.vue
+++ b/frontend/src/components/ProfileBento/ProfileBentoEditorPanel.vue
@@ -32,7 +32,7 @@
              below a checklist that is not being used at the time. -->
           <div
             v-if="card"
-            class="rounded-lg border border-outline-gray-2 bg-surface-base p-4 lg:p-5"
+            class="rounded-6 border border-outline-gray-2 bg-surface-base p-4 lg:p-5"
             data-profile-card-editor
           >
             <div class="flex items-center gap-2">
@@ -126,7 +126,7 @@
           <!-- Two sections of one box, not two boxes: picking profile info and
              adding a card are both "what goes on the page", and a gap between
              them would say they were separate decisions. -->
-          <div v-else class="rounded-lg border border-outline-gray-2 bg-surface-base">
+          <div v-else class="rounded-6 border border-outline-gray-2 bg-surface-base">
             <!-- The checklist holds no state of its own: a row is ticked exactly
                when a card bound to that field is in the layout, so removing the
                card in the grid unticks the row. -->

--- a/frontend/src/components/ProfileBento/ProfileImageField.vue
+++ b/frontend/src/components/ProfileBento/ProfileImageField.vue
@@ -16,7 +16,7 @@
             </Button>
             <ErrorMessage
               v-if="error"
-              class="absolute right-0 top-9 z-10 w-52 rounded border border-outline-gray-2 bg-surface-base p-2 shadow-sm"
+              class="absolute right-0 top-9 z-10 w-52 rounded-4 border border-outline-gray-2 bg-surface-base p-2 shadow-sm"
               :message="error"
             />
           </div>

--- a/frontend/src/components/ProfileBento/useProfileBentoDrag.ts
+++ b/frontend/src/components/ProfileBento/useProfileBentoDrag.ts
@@ -1,5 +1,5 @@
 import { computed, nextTick, onUnmounted, ref, type Ref } from 'vue'
-import { activeScrollContainer } from 'frappe-ui'
+import { shellScrollContainer } from 'frappe-ui'
 import { createProfileBentoLayout, type ProfileBentoLayoutRect } from './profileBentoLayout'
 import type { ProfileBentoCard } from './types'
 
@@ -168,7 +168,7 @@ export function useProfileBentoDrag(options: ProfileBentoDragOptions) {
   function autoScrollTick() {
     autoScrollFrame = requestAnimationFrame(autoScrollTick)
 
-    let container = activeScrollContainer.value
+    let container = shellScrollContainer.value
     let velocity = autoScrollVelocity(container)
     if (!container || !velocity) return
 

--- a/frontend/src/components/Reactions.vue
+++ b/frontend/src/components/Reactions.vue
@@ -11,15 +11,15 @@
   </div>
 </template>
 <script setup>
-import { useScreenSize } from 'frappe-ui'
 import { defineAsyncComponent, computed } from 'vue'
 import { useReactions } from '@/data/reactions'
+import { useIsMobile } from '@/utils/useIsMobile'
 
-const screenSize = useScreenSize()
+const isMobileViewport = useIsMobile()
 const ReactionsMobile = defineAsyncComponent(() => import('./ReactionsMobile.vue'))
 const ReactionsDesktop = defineAsyncComponent(() => import('./ReactionsDesktop.vue'))
 const ReactionsUI = computed(() => {
-  if (screenSize.width < 640) {
+  if (isMobileViewport.value) {
     return ReactionsMobile
   } else {
     return ReactionsDesktop

--- a/frontend/src/components/ReactionsDesktop.vue
+++ b/frontend/src/components/ReactionsDesktop.vue
@@ -54,7 +54,7 @@
       </button>
       <template #body>
         <div
-          class="max-w-[30ch] rounded bg-surface-gray-10 px-2 py-1 text-center text-p-xs text-ink-base shadow-xl"
+          class="max-w-[30ch] rounded-4 bg-surface-gray-10 px-2 py-1 text-center text-p-xs text-ink-base shadow-xl"
         >
           {{ toolTipText(reactions) }}
         </div>

--- a/frontend/src/components/ReactionsMobile.vue
+++ b/frontend/src/components/ReactionsMobile.vue
@@ -39,7 +39,7 @@
             as="button"
             v-for="emoji in standardEmojis"
             :key="emoji"
-            class="px-1 py-2 rounded"
+            class="px-1 py-2 rounded-4"
             :class="[
               hasUserReacted(emoji)
                 ? 'bg-surface-amber-2'

--- a/frontend/src/components/RevisionsDialog.vue
+++ b/frontend/src/components/RevisionsDialog.vue
@@ -6,7 +6,7 @@
           <button
             v-for="(revision, index) in orderedRevisions"
             :key="`${revision.creation}-${index}`"
-            class="w-full rounded-md px-3 py-2 text-left last:border-b-0 transition-colors focus:outline-none focus-visible:ring focus-visible:ring-outline-gray-2"
+            class="w-full rounded-5 px-3 py-2 text-left last:border-b-0 transition-colors focus:outline-none focus-visible:ring focus-visible:ring-outline-gray-2"
             role="option"
             :aria-selected="index === currentRevisionIndex"
             :aria-label="`Revision from ${dayjsLocal(revision.creation).format('LLL')}`"
@@ -49,7 +49,7 @@
         <div
           v-if="currentRevision"
           v-html="htmlDiff"
-          class="ProseMirror max-w-none prose prose-v3 rounded-md prose-table:table-fixed prose-th:relative prose-th:border prose-th:border-outline-gray-2 prose-th:bg-surface-gray-2 prose-th:p-2 prose-td:relative prose-td:border prose-td:border-outline-gray-2 prose-td:p-2"
+          class="ProseMirror max-w-none prose prose-v3 rounded-5 prose-table:table-fixed prose-th:relative prose-th:border prose-th:border-outline-gray-2 prose-th:bg-surface-gray-2 prose-th:p-2 prose-td:relative prose-td:border prose-td:border-outline-gray-2 prose-td:p-2"
         />
       </div>
     </div>
@@ -103,9 +103,9 @@
         <div
           v-if="sheetContentReady && currentRevision"
           v-html="htmlDiff"
-          class="ProseMirror max-w-none prose prose-v3 rounded-md prose-table:table-fixed prose-th:relative prose-th:border prose-th:border-outline-gray-2 prose-th:bg-surface-gray-2 prose-th:p-2 prose-td:relative prose-td:border prose-td:border-outline-gray-2 prose-td:p-2"
+          class="ProseMirror max-w-none prose prose-v3 rounded-5 prose-table:table-fixed prose-th:relative prose-th:border prose-th:border-outline-gray-2 prose-th:bg-surface-gray-2 prose-th:p-2 prose-td:relative prose-td:border prose-td:border-outline-gray-2 prose-td:p-2"
         />
-        <div v-else class="h-40 rounded-md bg-surface-gray-1" aria-hidden="true" />
+        <div v-else class="h-40 rounded-5 bg-surface-gray-1" aria-hidden="true" />
       </div>
     </div>
   </BottomSheet>

--- a/frontend/src/components/RichQuoteExtension/QuoteBacklinksPopover.vue
+++ b/frontend/src/components/RichQuoteExtension/QuoteBacklinksPopover.vue
@@ -8,13 +8,13 @@
         align="start"
         :side-offset="4"
         :collision-padding="10"
-        class="z-50 min-w-52 rounded-lg border bg-surface-elevation-2 p-1 shadow-xl"
+        class="z-50 min-w-52 rounded-6 border bg-surface-elevation-2 p-1 shadow-xl"
       >
         <div class="px-2 pb-1 pt-1.5 text-xs text-ink-gray-5">Quoted by</div>
         <button
           v-for="item in store.popover.items"
           :key="item.quotingCommentId + item.creation"
-          class="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left hover:bg-surface-gray-2 focus:outline-none focus-visible:ring focus-visible:ring-outline-gray-3"
+          class="flex w-full items-center gap-2 rounded-4 px-2 py-1.5 text-left hover:bg-surface-gray-2 focus:outline-none focus-visible:ring focus-visible:ring-outline-gray-3"
           @click="select(item)"
         >
           <UserAvatar size="sm" :user="item.author" />

--- a/frontend/src/components/RichQuoteExtension/QuoteReplyButton.vue
+++ b/frontend/src/components/RichQuoteExtension/QuoteReplyButton.vue
@@ -5,7 +5,7 @@
       class="fixed z-20 -translate-x-1/2 -translate-y-full pb-1.5"
       :style="{ left: `${position.x}px`, top: `${position.y}px` }"
     >
-      <div class="rounded-md border bg-surface-elevation-2 p-0.5 shadow-md">
+      <div class="rounded-5 border bg-surface-elevation-2 p-0.5 shadow-md">
         <Button
           variant="ghost"
           icon-left="lucide-text-quote"

--- a/frontend/src/components/Settings/CustomEmojiSettings.vue
+++ b/frontend/src/components/Settings/CustomEmojiSettings.vue
@@ -50,7 +50,7 @@
           <img
             :src="emoji.image"
             :alt="emoji.title"
-            class="size-6 shrink-0 rounded object-contain"
+            class="size-6 shrink-0 rounded-4 object-contain"
           />
           <span class="truncate text-base text-ink-gray-8">{{ emoji.title }}</span>
         </div>
@@ -77,13 +77,13 @@
     <div class="space-y-4">
       <div class="flex items-center gap-3">
         <div
-          class="flex size-10 shrink-0 items-center justify-center rounded border border-outline-gray-2 bg-surface-gray-1"
+          class="flex size-10 shrink-0 items-center justify-center rounded-4 border border-outline-gray-2 bg-surface-gray-1"
         >
           <img
             v-if="form.image"
             :src="form.image"
             alt="Preview"
-            class="h-full w-full rounded-md object-contain"
+            class="h-full w-full rounded-5 object-contain"
           />
           <span v-else class="lucide-image size-5 text-ink-gray-4" />
         </div>

--- a/frontend/src/components/Settings/InvitePeople.vue
+++ b/frontend/src/components/Settings/InvitePeople.vue
@@ -74,7 +74,7 @@
                     pendingInvitations.delete.params.name === invitation.name
                   "
                 >
-                  <span class="text-ink-red-8"> Delete? </span>
+                  <span class="text-ink-red-7"> Delete? </span>
                 </Button>
               </div>
             </Tooltip>

--- a/frontend/src/components/Settings/MembersSettings.vue
+++ b/frontend/src/components/Settings/MembersSettings.vue
@@ -22,7 +22,7 @@
 
       <button
         v-if="pendingInvites.data?.length"
-        class="mt-2 flex w-full items-center justify-between gap-3 rounded bg-surface-gray-2 px-3 py-2 text-left transition-colors hover:bg-surface-gray-3"
+        class="mt-2 flex w-full items-center justify-between gap-3 rounded-4 bg-surface-gray-2 px-3 py-2 text-left transition-colors hover:bg-surface-gray-3"
         @click="showInviteDialog = true"
       >
         <span class="flex items-center gap-2 text-base text-ink-gray-7">

--- a/frontend/src/components/Settings/QuickReactionsEditor.vue
+++ b/frontend/src/components/Settings/QuickReactionsEditor.vue
@@ -25,7 +25,7 @@
           <button
             v-if="emoji"
             type="button"
-            class="flex size-8 items-center justify-center rounded-md border border-outline-gray-1 bg-surface-base text-xl font-[emoji] hover:bg-surface-gray-2"
+            class="flex size-8 items-center justify-center rounded-5 border border-outline-gray-1 bg-surface-base text-xl font-[emoji] hover:bg-surface-gray-2"
           >
             <img
               v-if="isImageEmoji(emoji)"
@@ -39,7 +39,7 @@
           <button
             v-else
             type="button"
-            class="flex size-8 items-center justify-center rounded-md border border-dashed border-outline-gray-2 text-ink-gray-4 hover:border-outline-gray-3 hover:bg-surface-gray-1 hover:text-ink-gray-6"
+            class="flex size-8 items-center justify-center rounded-5 border border-dashed border-outline-gray-2 text-ink-gray-4 hover:border-outline-gray-3 hover:bg-surface-gray-1 hover:text-ink-gray-6"
             aria-label="Add emoji"
           >
             <span class="lucide-plus size-4" aria-hidden="true" />

--- a/frontend/src/components/SpaceTabs.vue
+++ b/frontend/src/components/SpaceTabs.vue
@@ -2,11 +2,11 @@
   <TabButtons :buttons="spaceTabs" :size="tabButtonSize" v-model="currentTab" />
 </template>
 <script setup lang="ts">
-import { useIsMobile } from 'frappe-ui'
 import { computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import type { PillSize } from 'frappe-ui'
 import { TabButtons } from 'frappe-ui'
+import { useIsMobile } from '@/utils/useIsMobile'
 
 const props = defineProps<{
   spaceId: string

--- a/frontend/src/components/SpaceTabs.vue
+++ b/frontend/src/components/SpaceTabs.vue
@@ -1,10 +1,10 @@
 <template>
-  <TabButtons :buttons="spaceTabs" :size="tabButtonSize" v-model="currentTab" />
+  <TabButtons :options="spaceTabs" :size="tabButtonSize" v-model="currentTab" />
 </template>
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import type { PillSize } from 'frappe-ui'
+import type { TabsSize } from 'frappe-ui'
 import { TabButtons } from 'frappe-ui'
 import { useIsMobile } from '@/utils/useIsMobile'
 
@@ -22,7 +22,7 @@ const spaceTabs = [
   { label: 'Tasks', value: 'tasks' },
 ]
 
-const tabButtonSize = computed<PillSize>(() => (isMobileViewport.value ? 'md' : 'sm'))
+const tabButtonSize = computed<TabsSize>(() => (isMobileViewport.value ? 'md' : 'sm'))
 
 const currentTab = computed({
   get() {

--- a/frontend/src/components/TaskDetail.vue
+++ b/frontend/src/components/TaskDetail.vue
@@ -10,7 +10,7 @@
           <input
             type="text"
             placeholder="Title"
-            class="-ml-0.5 w-full rounded-sm border-none p-0.5 text-4xl-semibold bg-surface-base text-ink-gray-8 focus:outline-none focus:ring-2 focus:ring-outline-gray-3"
+            class="-ml-0.5 w-full rounded-1 border-none p-0.5 text-4xl-semibold bg-surface-base text-ink-gray-8 focus:outline-none focus:ring-2 focus:ring-outline-gray-3"
             :readonly="!canEditTask"
             @blur="
               canEditTask
@@ -36,7 +36,7 @@
         </div>
         <TaskDescriptionEditor
           ref="description"
-          editor-class="prose-v3 max-w-none focus-within:ring-2 focus-within:ring-outline-gray-3 rounded-sm p-0.5 -ml-0.5 min-h-[4rem]"
+          editor-class="prose-v3 max-w-none focus-within:ring-2 focus-within:ring-outline-gray-3 rounded-1 p-0.5 -ml-0.5 min-h-[4rem]"
           placeholder="Description"
           :content="task.doc.description"
           :editable="canEditTask"

--- a/frontend/src/components/TaskList.vue
+++ b/frontend/src/components/TaskList.vue
@@ -2,7 +2,7 @@
   <div class="@container" v-if="tasks.data?.length">
     <div v-for="group in groupedTasks" :key="group.title">
       <button
-        class="group flex w-full items-baseline rounded-sm bg-surface-sidebar px-2.5 py-2 text-base transition hover:bg-surface-gray-2"
+        class="group flex w-full items-baseline rounded-1 bg-surface-sidebar px-2.5 py-2 text-base transition hover:bg-surface-gray-2"
         v-if="group.title && group.tasks.length"
         @click="isOpen[group.title] = !isOpen[group.title]"
       >
@@ -29,7 +29,7 @@
                   }
                 : { name: 'Task', params: { taskId: d.name } }
             "
-            class="flex h-15 w-full items-center rounded p-2.5 transition hover:bg-surface-gray-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3 group"
+            class="flex h-15 w-full items-center rounded-4 p-2.5 transition hover:bg-surface-gray-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3 group"
             :class="{
               'pointer-events-none': tasks.delete.loading && tasks.delete.params.name === d.name,
             }"

--- a/frontend/src/components/UnsplashImageBrowser.vue
+++ b/frontend/src/components/UnsplashImageBrowser.vue
@@ -5,9 +5,9 @@
     </template>
     <template #body>
       <div
-        class="absolute left-1/2 mt-3 max-w-sm -translate-x-1/2 transform rounded-lg bg-surface-base px-4 sm:px-0 lg:max-w-3xl"
+        class="absolute left-1/2 mt-3 max-w-sm -translate-x-1/2 transform rounded-6 bg-surface-base px-4 sm:px-0 lg:max-w-3xl"
       >
-        <div class="overflow-hidden rounded-lg p-3 shadow-2xl ring-1 ring-black ring-opacity-5">
+        <div class="overflow-hidden rounded-6 p-3 shadow-2xl ring-1 ring-black ring-opacity-5">
           <div class="flex items-center space-x-2">
             <div class="flex-1">
               <TextInput
@@ -31,7 +31,7 @@
             <button
               v-for="image in $resources.images.data"
               :key="image.id"
-              class="h-[50px] w-[200px] overflow-hidden rounded hover:opacity-80"
+              class="h-[50px] w-[200px] overflow-hidden rounded-4 hover:opacity-80"
               @click="$emit('select', image.urls.raw)"
             >
               <img :src="image.urls.raw + '&w=200&h=50&fit=crop&crop=entropy,faces,focalpoint'" />

--- a/frontend/src/components/UnsplashPicker/UnsplashPicker.vue
+++ b/frontend/src/components/UnsplashPicker/UnsplashPicker.vue
@@ -39,7 +39,7 @@
              found, and then the results. -->
         <div
           v-if="notConfigured"
-          class="rounded border border-outline-gray-2 bg-surface-gray-1 p-4"
+          class="rounded-4 border border-outline-gray-2 bg-surface-gray-1 p-4"
           data-unsplash-not-configured
         >
           <p class="text-base font-medium text-ink-gray-8">Unsplash is not set up</p>
@@ -84,7 +84,7 @@
             <li
               v-for="photo in photos"
               :key="photo.id"
-              class="group relative mb-1 block break-inside-avoid overflow-hidden rounded"
+              class="group relative mb-1 block break-inside-avoid overflow-hidden rounded-4"
             >
               <!-- The tile takes the photo's own proportions up front, so the
                    columns settle once instead of shuffling as each lazy image

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,9 +1,4 @@
 @import 'frappe-ui/style.css';
-/* Editor and list CSS ship as bindingless side-effect imports inside
-   `frappe-ui/editor` / `frappe-ui/list`, which Rolldown tree-shakes out of
-   production builds (dev is unaffected) — so import them explicitly here. */
-@import 'frappe-ui/editor-style.css';
-@import 'frappe-ui/list-style.css';
 
 /*
   Inter OpenType features:

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,7 +1,6 @@
 import { createApp } from 'vue'
 import {
   Button,
-  Input,
   TextInput,
   FormControl,
   ErrorMessage,
@@ -10,8 +9,8 @@ import {
   Badge,
   request,
   frappeRequest,
-  pageMetaPlugin,
   FrappeUI,
+  setConfig,
   useCall,
 } from 'frappe-ui'
 import router from './router'
@@ -26,7 +25,6 @@ import resetDataMixin from './utils/resetDataMixin'
 let globalComponents = {
   Button,
   TextInput,
-  Input,
   FormControl,
   ErrorMessage,
   Dialog,
@@ -34,7 +32,6 @@ let globalComponents = {
   Badge,
 }
 let app = createApp(App)
-app.use(pageMetaPlugin)
 app.use(router)
 app.mixin(resetDataMixin)
 for (let key in globalComponents) {
@@ -68,16 +65,14 @@ if (import.meta.env.DEV) {
 // Runs once boot values are on `window` (inline script in prod, the dev
 // context call above in dev) so frappe-ui gets its full config in one place.
 function setupApp() {
-  app.use(FrappeUI, {
-    call: false,
-    socketio: false,
-    config: {
-      resourceFetcher: frappeRequest,
-      defaultListUrl: 'gameplan.extends.client.get_list',
-      systemTimezone: window.system_timezone || null,
-      maxFileSize: window.max_file_size ? Number(window.max_file_size) : null,
-    },
-  })
+  // `resources: true` keeps the v1 resources Options API installed for
+  // UnsplashImageBrowser.vue and People.vue, the last two components declaring
+  // a `resources` option. Port both to createResource/useList to drop this.
+  app.use(FrappeUI, { resources: true })
+  setConfig('resourceFetcher', frappeRequest)
+  setConfig('defaultListUrl', 'gameplan.extends.client.get_list')
+  setConfig('systemTimezone', window.system_timezone || null)
+  setConfig('maxFileSize', window.max_file_size ? Number(window.max_file_size) : null)
   socket = initSocket()
   app.config.globalProperties.$socket = socket
   app.mount('#app')

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -7,7 +7,6 @@ import {
   Dialog,
   Alert,
   Badge,
-  request,
   frappeRequest,
   FrappeUI,
   setConfig,
@@ -97,7 +96,6 @@ if (import.meta.env.DEV) {
   window.$user = useUser
   window.$users = users
   window.$session = session
-  window.$request = request
   window.$frappeRequest = frappeRequest
   window.$router = router
 }

--- a/frontend/src/pages/Bookmarks.vue
+++ b/frontend/src/pages/Bookmarks.vue
@@ -1,6 +1,6 @@
 <template>
   <PageHeaderMobile class="sm:hidden" title="Bookmarks">
-    <template #left>
+    <template #prefix>
       <PageHeaderBackButton :to="{ name: 'More' }" />
     </template>
   </PageHeaderMobile>

--- a/frontend/src/pages/Configure/CommunityImageUploader.vue
+++ b/frontend/src/pages/Configure/CommunityImageUploader.vue
@@ -28,7 +28,7 @@
         </button>
         <ErrorMessage
           v-if="error || saveError"
-          class="absolute left-0 top-8 z-10 w-48 rounded border bg-surface-base p-2 shadow-sm"
+          class="absolute left-0 top-8 z-10 w-48 rounded-4 border bg-surface-base p-2 shadow-sm"
           :message="saveError || error"
         />
       </div>

--- a/frontend/src/pages/Configure/CommunityMembersList.vue
+++ b/frontend/src/pages/Configure/CommunityMembersList.vue
@@ -77,7 +77,7 @@
     <div class="space-y-4">
       <ul v-if="membersToAdd.length" class="flex flex-wrap gap-2">
         <li
-          class="flex items-center gap-2 rounded bg-surface-gray-2 px-2 py-1.5"
+          class="flex items-center gap-2 rounded-4 bg-surface-gray-2 px-2 py-1.5"
           v-for="user in membersToAdd"
           :key="user.value"
         >

--- a/frontend/src/pages/Configure/ConfigureEmptyState.vue
+++ b/frontend/src/pages/Configure/ConfigureEmptyState.vue
@@ -1,8 +1,8 @@
 <template>
   <div
-    class="flex min-h-64 flex-col items-center justify-center rounded-lg border border-dashed border-outline-gray-2 px-6 py-12 text-center"
+    class="flex min-h-64 flex-col items-center justify-center rounded-6 border border-dashed border-outline-gray-2 px-6 py-12 text-center"
   >
-    <div class="flex size-10 items-center justify-center rounded bg-surface-gray-2">
+    <div class="flex size-10 items-center justify-center rounded-4 bg-surface-gray-2">
       <span :class="[icon, 'size-5 text-ink-gray-5']" />
     </div>
     <h3 class="mt-4 text-lg-medium text-ink-gray-8">{{ title }}</h3>

--- a/frontend/src/pages/Configure/SpaceRow.vue
+++ b/frontend/src/pages/Configure/SpaceRow.vue
@@ -23,7 +23,7 @@
           <input
             v-model="title"
             aria-label="Space title"
-            class="h-7 min-w-0 flex-1 rounded border border-transparent bg-transparent py-0 pl-1 pr-2 text-base text-ink-gray-8 outline-none ring-0 transition-colors hover:border-outline-gray-2 focus:border-outline-gray-3 focus:ring-0 disabled:cursor-not-allowed disabled:text-ink-gray-6 disabled:hover:border-transparent"
+            class="h-7 min-w-0 flex-1 rounded-4 border border-transparent bg-transparent py-0 pl-1 pr-2 text-base text-ink-gray-8 outline-none ring-0 transition-colors hover:border-outline-gray-2 focus:border-outline-gray-3 focus:ring-0 disabled:cursor-not-allowed disabled:text-ink-gray-6 disabled:hover:border-transparent"
             :disabled="!canEditSpace"
             @blur="saveTitle"
             @keydown.enter.prevent="saveTitle"

--- a/frontend/src/pages/Discussions.vue
+++ b/frontend/src/pages/Discussions.vue
@@ -1,6 +1,6 @@
 <template>
   <PageHeaderMobile v-if="communityState.doc" class="sm:hidden" :title="feedTitle">
-    <template #left>
+    <template #prefix>
       <PageHeaderBackButton :to="{ name: 'Home' }" />
     </template>
     <button

--- a/frontend/src/pages/Drafts.vue
+++ b/frontend/src/pages/Drafts.vue
@@ -1,12 +1,12 @@
 <template>
   <PageHeaderMobile class="sm:hidden" title="Drafts">
-    <template #left>
+    <template #prefix>
       <Button v-if="isBulkDeleteMode" variant="ghost" size="md" @click="cancelBulkDelete">
         Cancel
       </Button>
       <PageHeaderBackButton v-else :to="{ name: 'More' }" />
     </template>
-    <template #right>
+    <template #suffix>
       <div class="flex items-center gap-2">
         <template v-if="!isBulkDeleteMode">
           <Button

--- a/frontend/src/pages/MobileHome.vue
+++ b/frontend/src/pages/MobileHome.vue
@@ -1,9 +1,9 @@
 <template>
   <PageHeaderMobile title="Communities">
-    <template #left>
+    <template #prefix>
       <GameplanLogo class="ml-1 size-7 rounded-[7px]" />
     </template>
-    <template #right>
+    <template #suffix>
       <Button
         v-if="manageableCommunities.length"
         variant="ghost"

--- a/frontend/src/pages/MyPages.vue
+++ b/frontend/src/pages/MyPages.vue
@@ -1,10 +1,10 @@
 <template>
   <div>
     <PageHeaderMobile class="sm:hidden" title="Pages">
-      <template #left>
+      <template #prefix>
         <PageHeaderBackButton :to="{ name: 'More' }" />
       </template>
-      <template #right>
+      <template #suffix>
         <Select :options="sortOptions" v-model="orderBy" />
       </template>
     </PageHeaderMobile>

--- a/frontend/src/pages/MyTasks.vue
+++ b/frontend/src/pages/MyTasks.vue
@@ -1,10 +1,10 @@
 <template>
   <div>
     <PageHeaderMobile class="sm:hidden" title="Tasks">
-      <template #left>
+      <template #prefix>
         <PageHeaderBackButton :to="{ name: 'More' }" />
       </template>
-      <template #right>
+      <template #suffix>
         <Button
           variant="ghost"
           size="md"

--- a/frontend/src/pages/MyTasks.vue
+++ b/frontend/src/pages/MyTasks.vue
@@ -22,7 +22,7 @@
     <div class="body-container">
       <div class="flex pt-3 sm:pt-5">
         <TabButtons
-          :buttons="[
+          :options="[
             { label: 'All', value: 'all' },
             { label: 'Assigned to me', value: 'assigned' },
             { label: 'Created by me', value: 'owner' },

--- a/frontend/src/pages/NewDiscussion/DiscussionHeader.vue
+++ b/frontend/src/pages/NewDiscussion/DiscussionHeader.vue
@@ -1,9 +1,9 @@
 <template>
   <PageHeaderMobile class="sm:hidden" :title="mobileTitle">
-    <template #left>
+    <template #prefix>
       <PageHeaderBackButton :to="backRoute" />
     </template>
-    <template #right>
+    <template #suffix>
       <div class="flex items-center gap-1">
         <button
           v-if="sessionUser.name == author.name"

--- a/frontend/src/pages/NewDiscussion/DiscussionHeader.vue
+++ b/frontend/src/pages/NewDiscussion/DiscussionHeader.vue
@@ -8,7 +8,7 @@
         <button
           v-if="sessionUser.name == author.name"
           type="button"
-          class="inline-flex size-8 shrink-0 items-center justify-center rounded text-ink-gray-7 transition hover:bg-surface-gray-2 active:bg-surface-gray-3 disabled:cursor-not-allowed disabled:opacity-50"
+          class="inline-flex size-8 shrink-0 items-center justify-center rounded-4 text-ink-gray-7 transition hover:bg-surface-gray-2 active:bg-surface-gray-3 disabled:cursor-not-allowed disabled:opacity-50"
           aria-label="Delete draft"
           title="Delete draft"
           :disabled="isDraftLoading"
@@ -51,7 +51,7 @@
       <button
         v-if="sessionUser.name == author.name"
         type="button"
-        class="inline-flex size-8 shrink-0 items-center justify-center rounded text-ink-gray-7 transition hover:bg-surface-gray-2 active:bg-surface-gray-3 disabled:cursor-not-allowed disabled:opacity-50"
+        class="inline-flex size-8 shrink-0 items-center justify-center rounded-4 text-ink-gray-7 transition hover:bg-surface-gray-2 active:bg-surface-gray-3 disabled:cursor-not-allowed disabled:opacity-50"
         aria-label="Delete draft"
         title="Delete draft"
         :disabled="isDraftLoading"

--- a/frontend/src/pages/Notifications.vue
+++ b/frontend/src/pages/Notifications.vue
@@ -119,9 +119,9 @@
 
     <div
       v-else
-      class="mx-4 rounded border border-dashed border-outline-gray-2 px-6 py-12 text-center sm:mx-3"
+      class="mx-4 rounded-4 border border-dashed border-outline-gray-2 px-6 py-12 text-center sm:mx-3"
     >
-      <div class="mx-auto grid size-10 place-items-center rounded bg-surface-gray-2">
+      <div class="mx-auto grid size-10 place-items-center rounded-4 bg-surface-gray-2">
         <span class="lucide-bell-check size-5 text-ink-gray-5" aria-hidden="true" />
       </div>
       <div class="mt-3 text-base-medium text-ink-gray-8">{{ emptyStateTitle }}</div>

--- a/frontend/src/pages/Notifications.vue
+++ b/frontend/src/pages/Notifications.vue
@@ -6,7 +6,7 @@
 
   <div class="body-container pt-4 sm:pt-5">
     <div class="mb-3 flex items-center justify-between px-4 sm:px-3 gap-3">
-      <TabButtons :buttons="tabButtons" v-model="activeTab" />
+      <TabButtons :options="tabOptions" v-model="activeTab" />
       <Button
         @click="confirmMarkAllAsRead"
         :loading="markAllAsRead.loading"
@@ -223,7 +223,10 @@ const canMarkAllAsRead = computed(
   () => activeTab.value === 'Unread' && Boolean(unreadNotificationList.data?.length),
 )
 
-const tabButtons: { label: ActiveTab }[] = [{ label: 'Unread' }, { label: 'Read' }]
+const tabOptions: { value: ActiveTab; label: ActiveTab }[] = [
+  { value: 'Unread', label: 'Unread' },
+  { value: 'Read', label: 'Read' },
+]
 
 const notifications = computed(() =>
   activeTab.value === 'Unread' ? unreadNotificationList.data : readNotificationList.data,

--- a/frontend/src/pages/Onboarding.vue
+++ b/frontend/src/pages/Onboarding.vue
@@ -171,7 +171,7 @@
                 </div>
               </div>
               <div class="mt-4">
-                <ErrorMessage :message="onboarding.error" />
+                <ErrorMessage :message="errorMessage" />
               </div>
               <div class="mt-8 flex justify-end">
                 <Button
@@ -287,12 +287,26 @@ const onboarding = useCall<OnboardingResult, OnboardingParams>({
   },
 })
 
-function submit() {
-  onboarding.submit({
-    community: community.value,
-    space: space.title,
-    icon: space.icon,
-    emails: emailInput.value.split(/[\n,]/),
-  })
+// A `beforeSubmit` throw only rejects `submit()`; it no longer lands in
+// `onboarding.error`. Hold the validation message here so the same
+// ErrorMessage can show it.
+const validationError = ref('')
+
+// Validation wins while it is set, because no request runs in that case and
+// `onboarding.error` would still hold the previous failure.
+const errorMessage = computed(() => validationError.value || onboarding.error || undefined)
+
+async function submit() {
+  validationError.value = ''
+  try {
+    await onboarding.submit({
+      community: community.value,
+      space: space.title,
+      icon: space.icon,
+      emails: emailInput.value.split(/[\n,]/),
+    })
+  } catch (error) {
+    validationError.value = error instanceof Error ? error.message : String(error)
+  }
 }
 </script>

--- a/frontend/src/pages/Onboarding.vue
+++ b/frontend/src/pages/Onboarding.vue
@@ -24,7 +24,7 @@
             class="relative flex size-7 items-center justify-center rounded-[7px] bg-surface-gray-4"
           >
             <span
-              class="absolute -left-[11px] top-1/2 h-7 w-1 -translate-y-1/2 rounded-r bg-surface-gray-8"
+              class="absolute -left-[11px] top-1/2 h-7 w-1 -translate-y-1/2 rounded-r-4 bg-surface-gray-8"
             />
             <span class="text-2xs-medium uppercase text-ink-gray-7">{{ communityInitials }}</span>
           </span>
@@ -68,7 +68,7 @@
           <div class="flex h-7 items-center pl-2 text-base text-ink-gray-5">Spaces</div>
           <div class="mt-0.5">
             <div
-              class="flex h-7 items-center rounded bg-surface-elevation-3 pl-2 text-ink-gray-8 shadow-sm"
+              class="flex h-7 items-center rounded-4 bg-surface-elevation-3 pl-2 text-ink-gray-8 shadow-sm"
             >
               <SpaceIcon v-if="space.icon" :icon="space.icon" class="size-4 shrink-0" />
               <span v-else class="lucide-hash size-4 shrink-0 text-ink-gray-5" />

--- a/frontend/src/pages/Page.vue
+++ b/frontend/src/pages/Page.vue
@@ -1,10 +1,10 @@
 <template>
   <div>
     <PageHeaderMobile class="sm:hidden" :title="pageTitle">
-      <template #left>
+      <template #prefix>
         <PageHeaderBackButton :to="backRoute" :label="isSpacePage ? 'Pages' : 'My Pages'" />
       </template>
-      <template v-if="page.doc && canEditPage" #right>
+      <template v-if="page.doc && canEditPage" #suffix>
         <DropdownMoreOptions align="end" :options="pageActions" />
       </template>
     </PageHeaderMobile>

--- a/frontend/src/pages/Page.vue
+++ b/frontend/src/pages/Page.vue
@@ -72,7 +72,7 @@
         </div>
         <div ref="contentField">
           <PageEditor
-            editor-class="rounded-b-lg max-w-[unset] prose-v3 pb-[50vh] md:px-[70px]"
+            editor-class="rounded-b-6 max-w-[unset] prose-v3 pb-[50vh] md:px-[70px]"
             :content="content"
             :editable="canEditPage"
             @change="

--- a/frontend/src/pages/PageGrid.vue
+++ b/frontend/src/pages/PageGrid.vue
@@ -26,7 +26,7 @@
       >
         <section class="group">
           <div
-            class="aspect-[37/50] cursor-pointer overflow-hidden rounded-md dark:bg-gray-900 border border-gray-50 dark:border-outline-gray-1 p-3 shadow-lg transition-shadow hover:shadow-xl"
+            class="aspect-[37/50] cursor-pointer overflow-hidden rounded-5 dark:bg-gray-900 border border-gray-50 dark:border-outline-gray-1 p-3 shadow-lg transition-shadow hover:shadow-xl"
           >
             <div class="overflow-hidden text-ellipsis whitespace-nowrap">
               <div

--- a/frontend/src/pages/People.vue
+++ b/frontend/src/pages/People.vue
@@ -235,6 +235,7 @@ import {
   Input,
   Select,
   TextInput,
+  usePageMeta,
 } from 'frappe-ui'
 import { List, ListCell, ListHeader, ListHeaderCell, ListRow } from 'frappe-ui/list'
 import { showSettingsDialog } from '@/components/Settings'
@@ -269,6 +270,7 @@ export default {
     }
   },
   setup() {
+    usePageMeta(() => ({ title: 'People' }))
     return {
       showSettingsDialog,
       isAdmin: computed(() => isGameplanAdmin()),
@@ -337,11 +339,6 @@ export default {
       }
       return url
     },
-  },
-  pageMeta() {
-    return {
-      title: 'People',
-    }
   },
 }
 </script>

--- a/frontend/src/pages/People.vue
+++ b/frontend/src/pages/People.vue
@@ -3,10 +3,10 @@
     <div class="flex flex-1">
       <div class="w-full">
         <PageHeaderMobile class="sm:hidden" title="People">
-          <template #left>
+          <template #prefix>
             <PageHeaderBackButton :to="{ name: 'More' }" />
           </template>
-          <template #right>
+          <template #suffix>
             <Button
               v-if="isAdmin"
               variant="ghost"

--- a/frontend/src/pages/People.vue
+++ b/frontend/src/pages/People.vue
@@ -232,7 +232,6 @@ import {
   Breadcrumbs,
   Badge,
   Button,
-  Input,
   Select,
   TextInput,
   usePageMeta,
@@ -249,7 +248,6 @@ export default {
   components: {
     Badge,
     Button,
-    Input,
     TextInput,
     Select,
     Breadcrumbs,

--- a/frontend/src/pages/PersonProfile.vue
+++ b/frontend/src/pages/PersonProfile.vue
@@ -23,7 +23,11 @@
     <div class="mx-auto w-full max-w-[860px] px-3 py-4 sm:px-5 sm:py-6">
       <div class="mb-4 flex items-center justify-between gap-3">
         <TabButtons
-          :buttons="[{ label: 'Profile' }, { label: 'Posts' }, { label: 'Replies' }]"
+          :options="[
+            { value: 'Profile', label: 'Profile' },
+            { value: 'Posts', label: 'Posts' },
+            { value: 'Replies', label: 'Replies' },
+          ]"
           v-model="activeTab"
         />
         <!-- Hidden below `md`, where the customize page refuses to open anyway. -->

--- a/frontend/src/pages/PersonProfileProfile.vue
+++ b/frontend/src/pages/PersonProfileProfile.vue
@@ -2,10 +2,10 @@
   <div class="pb-16">
     <!-- Mirrors the rendered layout: one column below `sm`, four above. -->
     <div v-if="!bentoCardsLoaded" class="grid grid-cols-1 gap-3 sm:grid-cols-4">
-      <Skeleton class="aspect-[4/1] rounded-xl sm:col-span-4" />
-      <Skeleton class="aspect-square rounded-xl sm:col-span-1" />
-      <Skeleton class="aspect-square rounded-xl sm:col-span-1" />
-      <Skeleton class="aspect-[2/1] rounded-xl sm:col-span-2" />
+      <Skeleton class="aspect-[4/1] rounded-7 sm:col-span-4" />
+      <Skeleton class="aspect-square rounded-7 sm:col-span-1" />
+      <Skeleton class="aspect-square rounded-7 sm:col-span-1" />
+      <Skeleton class="aspect-[2/1] rounded-7 sm:col-span-2" />
     </div>
     <!-- Both branches wait for the cards, so the empty state never flashes. It
          replaces the grid rather than sitting under it: a lone name card above

--- a/frontend/src/pages/ProfileCustomize.vue
+++ b/frontend/src/pages/ProfileCustomize.vue
@@ -103,7 +103,7 @@
 
         <p
           v-if="cards.length === 0"
-          class="rounded-lg border border-dashed border-outline-gray-2 p-6 text-sm leading-5 text-ink-gray-6"
+          class="rounded-6 border border-dashed border-outline-gray-2 p-6 text-sm leading-5 text-ink-gray-6"
           data-profile-empty-layout-notice
         >
           Nothing is selected, so your profile page will be empty.

--- a/frontend/src/pages/Search.vue
+++ b/frontend/src/pages/Search.vue
@@ -29,7 +29,7 @@
                     v-if="query"
                     @click="clearSearch"
                     aria-label="Clear search"
-                    class="p-1 size-6 grid place-content-center focus:outline-none focus:ring focus:ring-outline-gray-3 rounded"
+                    class="p-1 size-6 grid place-content-center focus:outline-none focus:ring focus:ring-outline-gray-3 rounded-4"
                   >
                     <span class="lucide-x w-4 text-ink-gray-7" />
                   </button>

--- a/frontend/src/pages/Space.vue
+++ b/frontend/src/pages/Space.vue
@@ -11,16 +11,16 @@
         @click="menuOpen = true"
       >
         <PageHeaderMobileTitle :title="space?.title || 'Space'">
-          <template #icon>
+          <template #prefix>
             <SpaceIcon :icon="space?.icon" class="size-5 text-ink-gray-6" />
           </template>
         </PageHeaderMobileTitle>
         <span class="size-4 shrink-0 text-ink-gray-5 lucide-chevron-down" aria-hidden="true" />
       </button>
-      <template #left>
+      <template #prefix>
         <PageHeaderBackButton :to="{ name: 'Discussions', params: { communityId } }" />
       </template>
-      <template #right>
+      <template #suffix>
         <Button
           v-if="route.name === 'SpaceDiscussions' && canStartDiscussion"
           variant="ghost"

--- a/frontend/src/pages/Task.vue
+++ b/frontend/src/pages/Task.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <PageHeaderMobile class="sm:hidden" :title="taskTitle">
-      <template #left>
+      <template #prefix>
         <PageHeaderBackButton :to="backRoute" />
       </template>
     </PageHeaderMobile>

--- a/frontend/src/router.ts
+++ b/frontend/src/router.ts
@@ -14,7 +14,7 @@ import { spaces, getSpace } from './data/spaces'
 import type { Space } from './data/spaces'
 import { communityState } from './data/communityState'
 import { settingsBackgroundPath } from './components/Settings'
-import { getScrollContainer, scrollTo } from 'frappe-ui'
+import { shellScrollContainer } from 'frappe-ui'
 
 declare const __FRONTEND_ROUTE__: string
 
@@ -721,13 +721,13 @@ const router = createRouter({
 const scrollPositions: Record<string, number> = {}
 
 function saveAndRestoreScrollPosition(to: RouteLocationNormalized, from: RouteLocationNormalized) {
-  let scrollContainer = getScrollContainer()
+  let scrollContainer = shellScrollContainer.value
   if (scrollContainer) {
     scrollPositions[from.path] = scrollContainer.scrollTop
   }
   if (scrollPositions[to.path] !== undefined && to.path !== from.path) {
     setTimeout(() => {
-      scrollTo({ top: scrollPositions[to.path] })
+      shellScrollContainer.value?.scrollTo({ top: scrollPositions[to.path] })
     }, 0)
   }
 }

--- a/frontend/src/utils/imageUpload.ts
+++ b/frontend/src/utils/imageUpload.ts
@@ -3,11 +3,11 @@ import { useFileUpload, type UploadOptions, type UploadedFile } from 'frappe-ui'
 /**
  * Every kind of image Gameplan uploads, and how it should be stored.
  *
- * There is no default. A new upload site has to name its kind, because the two
- * upload primitives disagree about what happens when you say nothing: frappe-ui's
- * `FileUploader` uploads private, `useFileUpload()` uploads public. Leaving that
- * to the call site is how the same avatar ended up private on one screen and
- * public on another.
+ * There is no default. A new upload site has to name its kind, because both
+ * upload primitives store a file privately when you say nothing, and a public
+ * image that silently becomes private only breaks where nobody is logged in.
+ * Leaving that to the call site is how the same avatar ended up private on one
+ * screen and public on another.
  *
  * `private: true` does not mean "only the uploader can see it". A private File is
  * readable by anyone who can read the document it is attached to, so for those
@@ -77,8 +77,10 @@ const MIME_TYPES: Record<string, string> = {
   webp: 'image/webp',
 }
 
-/** Upload options for a kind, in the shape `FileUploader`'s `uploadArgs` expects. */
-export function imageUploadArgs(kind: ImageUploadKind): UploadOptions {
+/** Storage options for a kind, shared by `FileUploader`'s props and `useFileUpload`. */
+export function imageUploadOptions(
+  kind: ImageUploadKind,
+): Required<Pick<UploadOptions, 'private' | 'optimize'>> {
   const spec = IMAGE_UPLOAD_KINDS[kind]
   return { private: spec.private, optimize: spec.optimize }
 }
@@ -120,6 +122,6 @@ export function useImageUpload() {
   return {
     ...upload,
     upload: (file: File, kind: ImageUploadKind): Promise<UploadedFile> =>
-      upload.upload(file, imageUploadArgs(kind)),
+      upload.upload(file, imageUploadOptions(kind)),
   }
 }

--- a/frontend/src/utils/useIsMobile.ts
+++ b/frontend/src/utils/useIsMobile.ts
@@ -1,0 +1,18 @@
+import { useMediaQuery } from '@vueuse/core'
+import type { Ref } from 'vue'
+
+/** Viewport below Tailwind's `sm` breakpoint (640px). */
+const MOBILE_QUERY = '(max-width: 639.98px)'
+
+/**
+ * Whether the viewport is narrower than Tailwind's `sm` breakpoint, which is
+ * where the app swaps between the mobile and desktop layouts.
+ *
+ * Local because frappe-ui stopped exporting `useIsMobile`/`useScreenSize` in
+ * 1.0.0. A media query beats a resize listener here: the browser evaluates it
+ * and only notifies on a breakpoint crossing, so a drag-resize does not wake
+ * every consumer on each frame.
+ */
+export function useIsMobile(): Ref<boolean> {
+  return useMediaQuery(MOBILE_QUERY)
+}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2476,10 +2476,10 @@ framer-motion@^12.25.0:
     motion-utils "^12.39.0"
     tslib "^2.4.0"
 
-frappe-ui@1.0.0-beta.43:
-  version "1.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/frappe-ui/-/frappe-ui-1.0.0-beta.43.tgz#fd4db2dccc7b9e9a203f73cf371da0ac64b7b6d4"
-  integrity sha512-zml/VU4pst/f20FgvHjHP6VaDtjOnHjGtGh/FeulPjFqFUTIhTP+kAmmEqx4wv/+rAXc1DNRRGwcS5sBFkwMlw==
+frappe-ui@1.0.0-beta.45:
+  version "1.0.0-beta.45"
+  resolved "https://registry.yarnpkg.com/frappe-ui/-/frappe-ui-1.0.0-beta.45.tgz#f61389c42b125dbaf363ba4417cb87cbcc56b6b6"
+  integrity sha512-GaepTB0GrAW2tVYQP3KFOVGp1xxXDmQg1q7suFr30LcUraH2KEGdrRGEurETWGAQnde556Fi9Nf+Pb+I4c8qlQ==
   dependencies:
     "@codemirror/lang-css" "^6.3.0"
     "@codemirror/lang-html" "^6.4.9"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -508,7 +508,7 @@
   dependencies:
     "@floating-ui/utils" "^0.2.11"
 
-"@floating-ui/dom@^1.0.0", "@floating-ui/dom@^1.6.13", "@floating-ui/dom@^1.7.0", "@floating-ui/dom@^1.7.4", "@floating-ui/dom@^1.7.6":
+"@floating-ui/dom@^1.0.0", "@floating-ui/dom@^1.6.13", "@floating-ui/dom@^1.7.4", "@floating-ui/dom@^1.7.6":
   version "1.7.6"
   resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.7.6.tgz#f915bba5abbb177e1f227cacee1b4d0634b187bf"
   integrity sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==
@@ -550,11 +550,6 @@
     "@antfu/install-pkg" "^1.1.0"
     "@iconify/types" "^2.0.0"
     import-meta-resolve "^4.2.0"
-
-"@interactjs/types@1.10.27":
-  version "1.10.27"
-  resolved "https://registry.yarnpkg.com/@interactjs/types/-/types-1.10.27.tgz#10afd71cef2498e2b5192cf0d46f937d8ceb767f"
-  integrity sha512-BUdv0cvs4H5ODuwft2Xp4eL8Vmi3LcihK42z0Ft/FbVJZoRioBsxH+LlsBdK4tAie7PqlKGy+1oyOncu1nQ6eA==
 
 "@internationalized/date@^3.5.0":
   version "3.12.2"
@@ -619,11 +614,6 @@
   dependencies:
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
-
-"@juggle/resize-observer@^3.4.0":
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/@juggle/resize-observer/-/resize-observer-3.4.0.tgz#08d6c5e20cf7e4cc02fd181c4b0c225cd31dbb60"
-  integrity sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==
 
 "@lezer/common@^1.0.0", "@lezer/common@^1.0.2", "@lezer/common@^1.1.0", "@lezer/common@^1.2.0", "@lezer/common@^1.2.1", "@lezer/common@^1.3.0", "@lezer/common@^1.5.0":
   version "1.5.2"
@@ -762,7 +752,7 @@
   resolved "https://registry.yarnpkg.com/@oxc-project/types/-/types-0.133.0.tgz#2e282ef9e1d26e06b68ccd14b73f310a3b2cf7f8"
   integrity sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==
 
-"@popperjs/core@^2.11.2", "@popperjs/core@^2.9.0":
+"@popperjs/core@^2.9.0":
   version "2.11.8"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"
   integrity sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==
@@ -1147,10 +1137,10 @@
   resolved "https://registry.yarnpkg.com/@tiptap/extensions/-/extensions-3.26.0.tgz#0b3445bfdc37e8c307b3c0d23c117e9bf89ace27"
   integrity sha512-4wajuqnO2X0+LVvsBjW/xk3/tmdb16bNL939QhicAay4YYqXITeV2v3XJsryzmG4L5GkK1yLxvRGk4aLoxWrnA==
 
-"@tiptap/markdown@^3.26.0":
-  version "3.28.0"
-  resolved "https://registry.yarnpkg.com/@tiptap/markdown/-/markdown-3.28.0.tgz#3b57916c879bb48a3e79bbfbcf7bdfeea968d050"
-  integrity sha512-AefLVBgpjmBDbGDx8i0UDr4KyPxfsDnpIGYROTDSyGJswovGZDzCm3YjMGm8roxP31Opw4UCtts4WkFzWPI0og==
+"@tiptap/markdown@3.26.0", "@tiptap/markdown@^3.26.0":
+  version "3.26.0"
+  resolved "https://registry.yarnpkg.com/@tiptap/markdown/-/markdown-3.26.0.tgz#af3378bbf158b10c586527e282bdd53abb584a52"
+  integrity sha512-jg5xrwl1gTXUl5JA3+g8YYfhOzplM9CVecwKZeFtlYtPLyxLCmIDvqV/vULoGu57HwtY4819nNpMZwY6jBNtrw==
   dependencies:
     marked "^17.0.1"
 
@@ -1292,20 +1282,6 @@
   integrity sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==
   dependencies:
     "@types/node" "*"
-
-"@vexip-ui/hooks@^2.8.0":
-  version "2.9.4"
-  resolved "https://registry.yarnpkg.com/@vexip-ui/hooks/-/hooks-2.9.4.tgz#fbae097129ab5d14832bd403c220d54d6c939a30"
-  integrity sha512-dGUiBAeHIsnSVigGSPHcuHBVqrSGW8LV+zGohvOpBfXs8Ynn5ZcSmybIWJ3G826NsicPu9rqwcJG8uvSgG4k4Q==
-  dependencies:
-    "@floating-ui/dom" "^1.7.0"
-    "@juggle/resize-observer" "^3.4.0"
-    "@vexip-ui/utils" "2.16.4"
-
-"@vexip-ui/utils@2.16.4", "@vexip-ui/utils@^2.16.1":
-  version "2.16.4"
-  resolved "https://registry.yarnpkg.com/@vexip-ui/utils/-/utils-2.16.4.tgz#3429376a8f9e88040e969c21f14e70fe25d36127"
-  integrity sha512-KX+Q4EsuwDp6ZlRJ7OAkiYxu52D5CVM8zpqQz/FXYV+JUtzl9T3dvxgtA8gQ0wm5Sh/xT6jp8Wo4X7tLAzRh/A==
 
 "@vitejs/plugin-vue-jsx@^5.1.5":
   version "5.1.5"
@@ -2500,10 +2476,10 @@ framer-motion@^12.25.0:
     motion-utils "^12.39.0"
     tslib "^2.4.0"
 
-frappe-ui@1.0.0-beta.36:
-  version "1.0.0-beta.36"
-  resolved "https://registry.yarnpkg.com/frappe-ui/-/frappe-ui-1.0.0-beta.36.tgz#7333e2e3c22f7f5c4f8c0e1ddbd01e8f1b40385a"
-  integrity sha512-KFGqXfqn3vg2OtT3d3NBCrrTUSFHKcqctWy+3H2mAuHSbiPixMu1JPo78Aio5XlAFdFH6topZ1NoM1O017Mqrg==
+frappe-ui@1.0.0-beta.43:
+  version "1.0.0-beta.43"
+  resolved "https://registry.yarnpkg.com/frappe-ui/-/frappe-ui-1.0.0-beta.43.tgz#fd4db2dccc7b9e9a203f73cf371da0ac64b7b6d4"
+  integrity sha512-zml/VU4pst/f20FgvHjHP6VaDtjOnHjGtGh/FeulPjFqFUTIhTP+kAmmEqx4wv/+rAXc1DNRRGwcS5sBFkwMlw==
   dependencies:
     "@codemirror/lang-css" "^6.3.0"
     "@codemirror/lang-html" "^6.4.9"
@@ -2517,7 +2493,6 @@ frappe-ui@1.0.0-beta.36:
     "@codemirror/lang-yaml" "^6.1.3"
     "@floating-ui/dom" "^1.7.4"
     "@headlessui/vue" "^1.7.14"
-    "@popperjs/core" "^2.11.2"
     "@tailwindcss/forms" "^0.5.3"
     "@tailwindcss/line-clamp" "^0.4.4"
     "@tailwindcss/typography" "^0.5.16"
@@ -2563,9 +2538,7 @@ frappe-ui@1.0.0-beta.36:
     dompurify "^3.4.0"
     echarts "^5.6.0"
     es-module-lexer "^1.7.0"
-    feather-icons "^4.28.0"
     fuzzysort "^3.1.0"
-    grid-layout-plus "^1.1.0"
     highlight.js "^11.11.1"
     idb-keyval "^6.2.0"
     lowlight "^3.3.0"
@@ -2742,15 +2715,6 @@ graceful-fs@^4.1.15, graceful-fs@^4.1.6, graceful-fs@^4.2.0:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
 
-grid-layout-plus@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/grid-layout-plus/-/grid-layout-plus-1.1.1.tgz#129f1dd6ba555a1d319d73e415821ae4fb6c35c8"
-  integrity sha512-7CWehJubrVC8Ps5QFUlnDsp0kiREvKfi3Pdjp21EyY8BNzSusqI3Utcxvu1Y9UUKe3YExvbhJzIxHK6rorbRaQ==
-  dependencies:
-    "@vexip-ui/hooks" "^2.8.0"
-    "@vexip-ui/utils" "^2.16.1"
-    interactjs "^1.10.27"
-
 has-flag@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
@@ -2859,13 +2823,6 @@ ini@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ini/-/ini-2.0.0.tgz#e5fd556ecdd5726be978fa1001862eacb0a94bc5"
   integrity sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==
-
-interactjs@^1.10.27:
-  version "1.10.27"
-  resolved "https://registry.yarnpkg.com/interactjs/-/interactjs-1.10.27.tgz#16499aba4987a5ccfdaddca7d1ba7bb1118e14d0"
-  integrity sha512-y/8RcCftGAF24gSp76X2JS3XpHiUvDQyhF8i7ujemBz77hwiHDuJzftHx7thY8cxGogwGiPJ+o97kWB6eAXnsA==
-  dependencies:
-    "@interactjs/types" "1.10.27"
 
 is-binary-path@~2.1.0:
   version "2.1.0"


### PR DESCRIPTION
Upgrades frappe-ui from `1.0.0-beta.36` to `1.0.0-beta.43` — 501 upstream commits, ~50 of them breaking.

One branch, eight atomic commits, one per fix.

## Breaking changes handled

| Area | Change |
|---|---|
| Tokens | Radius aliases removed. `rounded-sm/md/lg/xl` become numbered `rounded-1/5/6/7/8` (51 files, 88 renames) |
| Tokens | Chromatic ink scales shift one level. Four sites; `ink-gray` does not shift |
| CSS | `frappe-ui/editor-style.css` and `frappe-ui/list-style.css` subpaths removed; the barrels self-import |
| Composables | `useIsMobile`, `useScreenSize`, `ScreenSize` un-exported |
| Composables | Nine scroll members collapse into `shellScrollContainer` and `useShellScrolled` |
| Bootstrap | `pageMetaPlugin` deleted; plugin `config`/`call`/`socketio` options removed; resources API no longer installs by default |
| Components | `FileUploader` `uploadArgs` blob becomes flat props, and uploads now default to private |
| Components | `TabButtons` `buttons` becomes `options`, and the model value no longer falls back to `label` |
| Components | `PageHeaderMobile` `#left`/`#right` become `#prefix`/`#suffix`; `PageHeaderMobileTitle` `#icon` becomes `#prefix` |
| Components | `Input` and `request` no longer exported |

## The two silent ones

Most of the above fail loudly. Two do not, and both were caught by reading the upstream diff rather than by the compiler.

**`TabButtons` model payload.** beta.36 resolved a tab's value as `value ?? label ?? index`, so `{ label: 'Comment' }` silently became the string `'Comment'`. beta.43 reads `value` only. Renaming the prop alone compiles, renders, and then matches nothing. Every item now states the payload it already resolved to, so existing refs, routes and drafts keep matching.

**`useCall` validation errors.** beta.36 kept a separate `beforeSubmitError` and merged it into the returned `error`. beta.43 dropped it, so a throwing `beforeSubmit` rejects `submit()` instead of surfacing. Onboarding's two client-side checks throw from `beforeSubmit`, so a blank community or space name showed no message at all and left an unhandled rejection.

## Also

- `@tiptap/markdown` pinned to 3.26.0. beta.43 pulls it in at 3.28.0, which demands an exact 3.28.0 core and breaks the install against the existing pins.
- `resources: true` is now passed explicitly. `UnsplashImageBrowser.vue` and `People.vue` still declare an Options-API `resources` option, and such a component throws under the new default. Both should be ported to `createResource`/`useList` so the flag can go.

## Testing

- `yarn build` clean. Verified the editor and list stylesheets still ship after dropping the explicit CSS imports: 127 ProseMirror and 38 list rules in the built output.
- Cypress on `gameplan-demo.test`: all 37 specs, 126 tests, 0 failures.