### PR TITLE
chore(deps): frappe-ui 1.0.0-beta.50

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,7 @@
     "@tiptap/vue-3": "^3.26.0",
     "@vueuse/core": "^10.1.2",
     "feather-icons": "^4.28.0",
-    "frappe-ui": "1.0.0-beta.45",
+    "frappe-ui": "1.0.0-beta.50",
     "fuzzysort": "^2.0.4",
     "gemoji": "^7.1.0",
     "htmldiff-js": "^1.0.5",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2166,13 +2166,13 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
-echarts@^5.6.0:
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/echarts/-/echarts-5.6.0.tgz#2377874dca9fb50f104051c3553544752da3c9d6"
-  integrity sha512-oTbVTsXfKuEhxftHqL5xprgLoc0k7uScAwtryCgWF6hPYFLRwOUHiFmHGCBKP5NPFNkDVopOieyUqYGH8Fa3kA==
+echarts@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/echarts/-/echarts-6.1.0.tgz#ae0f68590f5ebbd728d900907c27acde7c5456d1"
+  integrity sha512-q0yaFPggC9FUdsWH4blavRWFmxdrIodbkoKNAjJudAI6CA9gNPxHtV2RcZNEepZVlk4yvBYkOkbk6HIVpIyHZA==
   dependencies:
     tslib "2.3.0"
-    zrender "5.6.1"
+    zrender "6.1.0"
 
 electron-to-chromium@^1.5.328:
   version "1.5.365"
@@ -2476,10 +2476,10 @@ framer-motion@^12.25.0:
     motion-utils "^12.39.0"
     tslib "^2.4.0"
 
-frappe-ui@1.0.0-beta.45:
-  version "1.0.0-beta.45"
-  resolved "https://registry.yarnpkg.com/frappe-ui/-/frappe-ui-1.0.0-beta.45.tgz#f61389c42b125dbaf363ba4417cb87cbcc56b6b6"
-  integrity sha512-GaepTB0GrAW2tVYQP3KFOVGp1xxXDmQg1q7suFr30LcUraH2KEGdrRGEurETWGAQnde556Fi9Nf+Pb+I4c8qlQ==
+frappe-ui@1.0.0-beta.50:
+  version "1.0.0-beta.50"
+  resolved "https://registry.yarnpkg.com/frappe-ui/-/frappe-ui-1.0.0-beta.50.tgz#6401a5eb70a779b482c44c5859dd0064dbc1d41a"
+  integrity sha512-SXJtgSvbpMYkXFhx1lDkuT1oBRi4pvdI3id3FDQFiHflnr8Ct3T40WZ2YA4xaK/5/JKMOd9NYa5mKcnR2OrdBA==
   dependencies:
     "@codemirror/lang-css" "^6.3.0"
     "@codemirror/lang-html" "^6.4.9"
@@ -2536,7 +2536,7 @@ frappe-ui@1.0.0-beta.45:
     codemirror "^6.0.1"
     dayjs "^1.11.13"
     dompurify "^3.4.0"
-    echarts "^5.6.0"
+    echarts "^6.1.0"
     es-module-lexer "^1.7.0"
     fuzzysort "^3.1.0"
     highlight.js "^11.11.1"
@@ -4996,9 +4996,9 @@ yauzl@^2.10.0:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.1.0"
 
-zrender@5.6.1:
-  version "5.6.1"
-  resolved "https://registry.yarnpkg.com/zrender/-/zrender-5.6.1.tgz#e08d57ecf4acac708c4fcb7481eb201df7f10a6b"
-  integrity sha512-OFXkDJKcrlx5su2XbzJvj/34Q3m6PvyCZkVPHGYpcCJ52ek4U/ymZyfuV1nKE23AyBJ51E/6Yr0mhZ7xGTO4ag==
+zrender@6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/zrender/-/zrender-6.1.0.tgz#c3ef06e6426d5c28865b7183035680d685e00136"
+  integrity sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ==
   dependencies:
     tslib "2.3.0"


### PR DESCRIPTION
Moves the frappe-ui pin from `1.0.0-beta.45` to `1.0.0-beta.50`.

## What this activates

The editor, mainly:

- **Typing a space at the end of a link ends the link.** Previously the space was pulled inside the `<a>`, and everything typed after it inherited the mark — so a pasted URL followed by more of the sentence left the whole tail underlined and clickable. This is the one that prompted the bump; comments and discussions are where it showed up. ([frappe-ui#1060](https://github.com/frappe/frappe-ui/pull/1060))
- **Media resizes from a bottom-right corner handle** (image, video, embed), with a keyboard path for the embed handle.
- **Video gets a real player control row** — playhead tracks the footage, readable in dark mode, fullscreen fills the screen.
- **Media actions fold into a single menu** with one control style across the chrome.

## Call sites

No changes needed. The only breaking change in `beta.45..beta.50` is `refactor(charts)!`, which parks the v0 Charts family in `frappe-ui/experimental` — gameplan imports no Charts. I checked the rest of the range (32 commits) for API changes touching what gameplan uses and found none.

## Verification

- `yarn install` → lockfile resolves `frappe-ui@1.0.0-beta.50`
- `yarn build` → clean production build, no new warnings
- Confirmed the published tarball actually carries the link fix (`exit-link-on-space-plugin.ts` is in the package source; `beta.49` predates the merge and does not have it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
