### PR TITLE
fix(reactions): restore the tooltip on reaction pills

### DIFF
--- a/frontend/src/components/AboutDialog.vue
+++ b/frontend/src/components/AboutDialog.vue
@@ -12,10 +12,7 @@
               <template v-else>{{ appVersion.tag }}</template>
             </div>
 
-            <Tooltip
-              :text="`${appVersion.commit_message} - ${appVersion.commit_date}`"
-              placement="top"
-            >
+            <Tooltip :text="`${appVersion.commit_message} - ${appVersion.commit_date}`" side="top">
               <span class="lucide-info size-3.5 text-ink-gray-8 ml-1" />
             </Tooltip>
           </div>

--- a/frontend/src/components/ColorPicker.vue
+++ b/frontend/src/components/ColorPicker.vue
@@ -1,31 +1,27 @@
 <template>
-  <Popover transition="default">
-    <template #target="{ togglePopover, isOpen }">
-      <button @click="togglePopover()">
-        <slot v-bind="{ isOpen }">
+  <Popover>
+    <template #trigger="{ open }">
+      <button>
+        <slot v-bind="{ open }">
           <span class="text-base"> {{ modelValue || '' }} </span>
         </slot>
       </button>
     </template>
-    <template #body>
-      <div class="left-1/2 mt-3 max-w-max -translate-x-1/2 transform px-4 sm:px-0">
-        <div
-          class="relative max-h-96 overflow-y-auto rounded-6 bg-surface-elevation-2 p-2 shadow-lg ring-1 ring-black ring-opacity-5"
-        >
-          <div class="grid grid-cols-11 place-items-center gap-1">
-            <button
-              class="h-4 w-4 rounded-full"
-              :style="{ backgroundColor: color }"
-              v-for="color in colors"
-              :key="color"
-              @click="$emit('update:modelValue', color)"
-              :title="color"
-              :aria-label="color"
-              :aria-pressed="color === modelValue"
-            >
-              &nbsp;
-            </button>
-          </div>
+    <template #default>
+      <div class="max-h-96 max-w-max overflow-y-auto p-2">
+        <div class="grid grid-cols-11 place-items-center gap-1">
+          <button
+            class="h-4 w-4 rounded-full"
+            :style="{ backgroundColor: color }"
+            v-for="color in colors"
+            :key="color"
+            @click="$emit('update:modelValue', color)"
+            :title="color"
+            :aria-label="color"
+            :aria-pressed="color === modelValue"
+          >
+            &nbsp;
+          </button>
         </div>
       </div>
     </template>

--- a/frontend/src/components/CoverImage.vue
+++ b/frontend/src/components/CoverImage.vue
@@ -40,8 +40,8 @@
             }
           "
         >
-          <template v-slot="{ togglePopover }">
-            <Button variant="outline" @click="togglePopover()"> Change Image </Button>
+          <template v-slot>
+            <Button variant="outline"> Change Image </Button>
           </template>
         </UnsplashImageBrowser>
         <Button v-if="editable" variant="outline" @click="beginReposition"> Reposition </Button>
@@ -62,8 +62,8 @@
           }
         "
       >
-        <template v-slot="{ togglePopover }">
-          <Button variant="outline" @click="togglePopover()"> Click to set cover image </Button>
+        <template v-slot>
+          <Button variant="outline"> Click to set cover image </Button>
         </template>
       </UnsplashImageBrowser>
     </div>

--- a/frontend/src/components/ReactionsDesktop.vue
+++ b/frontend/src/components/ReactionsDesktop.vue
@@ -38,33 +38,35 @@
         </div>
       </div>
     </HoverCard>
-    <Tooltip v-for="(reactions, emoji) in reactionsCount" :key="emoji">
-      <button
-        class="flex items-center justify-center rounded-full px-2 py-1 text-sm transition"
-        :class="[
-          reactions.userReacted
-            ? 'bg-surface-amber-2 text-amber-700 hover:bg-amber-200'
-            : 'bg-surface-gray-2 text-ink-gray-6 hover:bg-surface-gray-3',
-        ]"
-        @click="toggleReaction(emoji)"
-      >
-        <img v-if="isImageEmoji(emoji)" :src="emoji" alt="" class="mr-1 size-4 object-contain" />
-        <template v-else>{{ emoji }}&nbsp;</template>
-        {{ reactions.count }}
-      </button>
-      <template #body>
-        <div
-          class="max-w-[30ch] rounded-4 bg-surface-gray-10 px-2 py-1 text-center text-p-xs text-ink-base shadow-xl"
+    <!-- One provider for the whole row: after the first tooltip opens, moving
+         along the pills shows the next reactor list with no re-delay. -->
+    <TooltipProvider>
+      <Tooltip v-for="(reactions, emoji) in reactionsCount" :key="emoji">
+        <button
+          class="flex items-center justify-center rounded-full px-2 py-1 text-sm transition"
+          :class="[
+            reactions.userReacted
+              ? 'bg-surface-amber-2 text-amber-700 hover:bg-amber-200'
+              : 'bg-surface-gray-2 text-ink-gray-6 hover:bg-surface-gray-3',
+          ]"
+          @click="toggleReaction(emoji)"
         >
-          {{ toolTipText(reactions) }}
-        </div>
-      </template>
-    </Tooltip>
+          <img v-if="isImageEmoji(emoji)" :src="emoji" alt="" class="mr-1 size-4 object-contain" />
+          <template v-else>{{ emoji }}&nbsp;</template>
+          {{ reactions.count }}
+        </button>
+        <template #content>
+          <div class="max-w-[30ch] text-center text-p-xs">
+            {{ toolTipText(reactions) }}
+          </div>
+        </template>
+      </Tooltip>
+    </TooltipProvider>
   </div>
 </template>
 <script setup lang="ts">
 import { ref } from 'vue'
-import { Button, HoverCard, Tooltip } from 'frappe-ui'
+import { Button, HoverCard, Tooltip, TooltipProvider } from 'frappe-ui'
 import { isImageEmoji } from '@/utils/emoji'
 
 const props = defineProps<{

--- a/frontend/src/components/UnsplashImageBrowser.vue
+++ b/frontend/src/components/UnsplashImageBrowser.vue
@@ -1,46 +1,42 @@
 <template>
-  <Popover transition="default">
-    <template #target="{ isOpen, togglePopover }" class="flex w-full">
-      <slot v-bind="{ isOpen, togglePopover }"></slot>
+  <Popover>
+    <template #trigger="{ open }">
+      <slot v-bind="{ open }"></slot>
     </template>
-    <template #body>
-      <div
-        class="absolute left-1/2 mt-3 max-w-sm -translate-x-1/2 transform rounded-6 bg-surface-base px-4 sm:px-0 lg:max-w-3xl"
-      >
-        <div class="overflow-hidden rounded-6 p-3 shadow-2xl ring-1 ring-black ring-opacity-5">
-          <div class="flex items-center space-x-2">
-            <div class="flex-1">
-              <TextInput
-                type="text"
-                placeholder="search by keyword"
-                v-model="search"
-                :debounce="300"
-              />
-            </div>
-            <ImageUploader kind="cover" @success="(file) => $emit('select', file.file_url)">
-              <template v-slot="{ file, progress, uploading, openFileSelector }">
-                <div class="w-full text-center">
-                  <Button @click="openFileSelector" :loading="uploading">
-                    {{ uploading ? `Uploading ${progress}%` : 'Upload Image' }}
-                  </Button>
-                </div>
-              </template>
-            </ImageUploader>
+    <template #default>
+      <div class="p-3">
+        <div class="flex items-center space-x-2">
+          <div class="flex-1">
+            <TextInput
+              type="text"
+              placeholder="search by keyword"
+              v-model="search"
+              :debounce="300"
+            />
           </div>
-          <div class="relative mt-2 grid w-[25.5rem] gap-2 bg-surface-base lg:grid-cols-2">
-            <button
-              v-for="image in $resources.images.data"
-              :key="image.id"
-              class="h-[50px] w-[200px] overflow-hidden rounded-4 hover:opacity-80"
-              @click="$emit('select', image.urls.raw)"
-            >
-              <img :src="image.urls.raw + '&w=200&h=50&fit=crop&crop=entropy,faces,focalpoint'" />
-            </button>
-          </div>
-          <div class="mt-2 text-center text-sm text-ink-gray-4">
-            Image search powered by
-            <a class="underline" target="_blank" href="https://unsplash.com"> Unsplash </a>
-          </div>
+          <ImageUploader kind="cover" @success="(file) => $emit('select', file.file_url)">
+            <template v-slot="{ file, progress, uploading, openFileSelector }">
+              <div class="w-full text-center">
+                <Button @click="openFileSelector" :loading="uploading">
+                  {{ uploading ? `Uploading ${progress}%` : 'Upload Image' }}
+                </Button>
+              </div>
+            </template>
+          </ImageUploader>
+        </div>
+        <div class="relative mt-2 grid w-[25.5rem] gap-2 lg:grid-cols-2">
+          <button
+            v-for="image in $resources.images.data"
+            :key="image.id"
+            class="h-[50px] w-[200px] overflow-hidden rounded-4 hover:opacity-80"
+            @click="$emit('select', image.urls.raw)"
+          >
+            <img :src="image.urls.raw + '&w=200&h=50&fit=crop&crop=entropy,faces,focalpoint'" />
+          </button>
+        </div>
+        <div class="mt-2 text-center text-sm text-ink-gray-4">
+          Image search powered by
+          <a class="underline" target="_blank" href="https://unsplash.com"> Unsplash </a>
         </div>
       </div>
     </template>


### PR DESCRIPTION
## Problem

The tooltip that lists who reacted stopped appearing on hover.

`Tooltip` took its content in a `#body` slot. frappe-ui `1.0.0-beta.39` removed that slot and kept `#content` only, and the bubble renders only when `text` or `#content` is supplied. An unmatched slot name is silent in Vue, so the tooltip mounted nothing and nothing reported an error. The break arrived with the bump to `1.0.0-beta.50`.

The same commit dropped the v0 `Popover` API. Four more call sites still used it.

## Changes

**`fix(reactions)`**
- `#body` -> `#content`.
- Drop the hand-rolled bubble shell. `TooltipBubble` draws the background, radius, padding, shadow and arrow. Only the width cap and centring stay.
- Group the pills under one `TooltipProvider`, so moving along the row shows the next reactor list without a second hover delay.

**`refactor(overlays)`**
- `AboutDialog`: `placement` -> `side`.
- `UnsplashImageBrowser`, `ColorPicker`: `#target`/`#body` -> `#trigger`/`#default`. Drop the hand-rolled panel shell and the absolute centring; reka portals and positions the panel, and `PopoverPanel` draws the shell.
- `CoverImage`: drop `@click="togglePopover()"`. `PopoverTrigger` is as-child, so click, keyboard and aria wire themselves.

The frontend now has no remaining hits for the removed API.

## Verification

In the running app, signed in on a discussion with three reactions:

- Reactions tooltip shows `Member, Second Member, Administrator`.
- About dialog tooltip shows the commit message and date.
- Provider is shared: of 21 tooltips on the page, 18 resolve to the `Passthrough` (a parent provider was found) and 3 unrelated ones still mount their own.
- Row layout unchanged: `display: flex`, `gap: 6px`, 3 children, pills on the same top edge.

`ColorPicker` and `UnsplashImageBrowser` are unreachable through the UI, so they were mounted directly in the running page. Both open a real panel with the library shell.

**Not verified:** the skip-delay timing itself. Reka marks the pointer as "in transit" when it leaves a trigger, and synthetic pointer events never clear that state, so the instant second open needs real mouse input. The wiring was verified instead.

**Not done:** `ColorPicker.vue`, `UnsplashImageBrowser.vue` and `CoverImage.vue` have no callers. They are migrated rather than deleted, to keep deletion a separate decision.