### PR TITLE
chore(deps): frappe-ui 1.0.0-beta.51

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,7 @@
     "@tiptap/vue-3": "^3.26.0",
     "@vueuse/core": "^10.1.2",
     "feather-icons": "^4.28.0",
-    "frappe-ui": "1.0.0-beta.50",
+    "frappe-ui": "1.0.0-beta.51",
     "fuzzysort": "^2.0.4",
     "gemoji": "^7.1.0",
     "htmldiff-js": "^1.0.5",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2476,10 +2476,10 @@ framer-motion@^12.25.0:
     motion-utils "^12.39.0"
     tslib "^2.4.0"
 
-frappe-ui@1.0.0-beta.50:
-  version "1.0.0-beta.50"
-  resolved "https://registry.yarnpkg.com/frappe-ui/-/frappe-ui-1.0.0-beta.50.tgz#6401a5eb70a779b482c44c5859dd0064dbc1d41a"
-  integrity sha512-SXJtgSvbpMYkXFhx1lDkuT1oBRi4pvdI3id3FDQFiHflnr8Ct3T40WZ2YA4xaK/5/JKMOd9NYa5mKcnR2OrdBA==
+frappe-ui@1.0.0-beta.51:
+  version "1.0.0-beta.51"
+  resolved "https://registry.yarnpkg.com/frappe-ui/-/frappe-ui-1.0.0-beta.51.tgz#27a101e64b833f8483f5cfe37ac4399f422417a2"
+  integrity sha512-DH0/ft6pNiJsGWSZLnfJ/Of14ZxMmqeERKHJywh/BDTZLg2W6JrRp6Q4Ru+N3z/98b5VpJoLjnPBqv+07Inleg==
   dependencies:
     "@codemirror/lang-css" "^6.3.0"
     "@codemirror/lang-html" "^6.4.9"


### PR DESCRIPTION
Moves the pin from 1.0.0-beta.50. One change:

- Solid red `Button` uses white text (`text-ink-base`) in light mode. It was dark red (`ink-red-9`) on a red-600 fill, which read as low contrast. Dark mode is unchanged. Destructive buttons in Gameplan (delete discussion, remove member) pick this up.

Upstream PR: frappe/frappe-ui#1063