### PR TITLE
fix(mobile): center More menu rows on iOS Safari

### DIFF
--- a/frontend/src/components/MobileMoreMenu.vue
+++ b/frontend/src/components/MobileMoreMenu.vue
@@ -33,25 +33,33 @@
             v-for="(item, index) in group.items"
             :key="item.label"
             type="button"
-            class="flex min-h-14 w-full text-left transition active:bg-surface-gray-2"
+            class="block w-full text-left transition active:bg-surface-gray-2"
             @click="onItemClick(item)"
           >
-            <span class="flex w-14 shrink-0 items-center justify-center py-3">
-              <span :class="[item.icon, 'size-5 text-ink-gray-8']" aria-hidden="true" />
-            </span>
-            <span class="relative flex min-w-0 flex-1 items-center gap-3 py-3 pr-4">
-              <span
-                v-if="index > 0"
-                class="pointer-events-none absolute left-0 right-4 top-0 border-t"
-                aria-hidden="true"
-              />
-              <span class="min-w-0 flex-1 truncate text-lg text-ink-gray-9">
-                {{ item.label }}
+            <!--
+              The flex layout lives on this inner wrapper, not the <button>. iOS Safari
+              (WebKit) wraps a button's children in an anonymous box, so making the button
+              itself a flex container leaves the rows top-aligned instead of vertically
+              centered. Same pattern as MobileListRow.vue.
+            -->
+            <span class="flex min-h-14 w-full items-stretch">
+              <span class="flex w-14 shrink-0 items-center justify-center py-3">
+                <span :class="[item.icon, 'size-5 text-ink-gray-8']" aria-hidden="true" />
               </span>
-              <span v-if="item.value" class="shrink-0 text-md text-ink-gray-5">
-                {{ item.value }}
+              <span class="relative flex min-w-0 flex-1 items-center gap-3 py-3 pr-4">
+                <span
+                  v-if="index > 0"
+                  class="pointer-events-none absolute left-0 right-4 top-0 border-t"
+                  aria-hidden="true"
+                />
+                <span class="min-w-0 flex-1 truncate text-lg text-ink-gray-9">
+                  {{ item.label }}
+                </span>
+                <span v-if="item.value" class="shrink-0 text-md text-ink-gray-5">
+                  {{ item.value }}
+                </span>
+                <span class="size-4 shrink-0 text-ink-gray-4 lucide-chevron-right" />
               </span>
-              <span class="size-4 shrink-0 text-ink-gray-4 lucide-chevron-right" />
             </span>
           </button>
         </nav>


### PR DESCRIPTION
Fixes a bug report from the Raven-gameplan channel: rows in the mobile More menu (Drafts, Bookmarks, Pages, Tasks, People, Settings) are not vertically centered on older iPhones. Icon, label, and chevron sit about 7px above the row midline.

## Root cause

Each row is a `<button>` styled `flex min-h-14`. WebKit wraps a button's children in an anonymous inner box ([Flexbug #9](https://github.com/philipwalton/flexbugs), [WebKit #169700](https://bugs.webkit.org/show_bug.cgi?id=169700)). On older iOS Safari the children do not stretch to the button's `min-height`. They keep their natural height and stick to the top. Modern Safari and Chrome are unaffected, so the bug only shows on old devices.

The same bug was already fixed for `MobileListRow` in 6b998cb2. The More menu rows have their own markup and never got that fix.

## Change

Move the flex layout onto an inner wrapper `<span>` inside the button. The button becomes a plain block. Same pattern as `MobileListRow.vue`. Classes and metrics are unchanged, so modern browsers render the exact same pixels.

## Verification

- Measured the row geometry at a 375×667 viewport (headless Chrome, CDP): all 8 rows are 56px tall, and icon/text/chevron centers sit at the row midpoint (offset 0 ± 0.01px).
- Cypress specs that drive this menu, run against the demo site with this branch's frontend:

```
✔  more-pages.cy.ts        00:18   4 passing
✔  community-home.cy.ts    00:08   3 passing
```

- Prettier passes on the changed file.
- Not verified on a physical old-iOS device (none available). The fix mirrors the wrapper pattern that resolved the identical report for `MobileListRow` on device.

Not done: the label row still uses flex `gap-3`, which old iOS Safari (< 14.5) ignores; on such devices the Theme row's value text touches the chevron. Cosmetic, left out of this fix (also present in `MobileListRow`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)