### PR TITLE
fix(notifications): show a loading skeleton instead of the empty state

### DIFF
--- a/frontend/cypress/e2e/notifications/notifications.cy.ts
+++ b/frontend/cypress/e2e/notifications/notifications.cy.ts
@@ -65,4 +65,20 @@ describe('Notifications', () => {
     cy.get('button[aria-label="Notifications, 1 unread"]').should('not.exist')
     cy.get('button[aria-label="Notifications"]').should('exist')
   })
+
+  it('shows a loading skeleton, not the empty state, while the list loads', () => {
+    cy.loginAs('member')
+    // Hold the list response so the in-flight window is observable.
+    cy.intercept('GET', '**/api/v2/document/GP%20Notification*', (req) => {
+      req.continue((res) => res.setDelay(600))
+    }).as('notificationList')
+
+    cy.visit('/g/notifications')
+    cy.get('[role="status"][aria-label="Loading notification"]').should('be.visible')
+    cy.contains("You're caught up").should('not.exist')
+
+    cy.wait('@notificationList')
+    cy.contains("You're caught up").should('be.visible')
+    cy.get('[aria-label="Loading notification"]').should('not.exist')
+  })
 })

--- a/frontend/src/components/DiscussionList.vue
+++ b/frontend/src/components/DiscussionList.vue
@@ -16,10 +16,11 @@
     </div>
 
     <template v-if="isInitialLoading">
-      <DiscussionRowSkeleton
+      <ListRowSkeleton
         v-for="index in skeletonRowCount"
         :key="index"
         :show-separator="index < skeletonRowCount"
+        label="Loading discussion"
       />
     </template>
 
@@ -55,7 +56,7 @@ import type { OrderBy } from 'frappe-ui'
 import { List } from 'frappe-ui/list'
 import { UseDiscussionOptions, useDiscussions } from '@/data/discussions'
 import DiscussionRow from './DiscussionRow.vue'
-import DiscussionRowSkeleton from './DiscussionRowSkeleton.vue'
+import ListRowSkeleton from './ListRowSkeleton.vue'
 import EmptyStateBox from './EmptyStateBox.vue'
 import Pin from './icons/Pin.vue'
 

--- a/frontend/src/components/ListRowSkeleton.vue
+++ b/frontend/src/components/ListRowSkeleton.vue
@@ -2,7 +2,7 @@
   <div
     class="relative block h-[68px] select-none sm:h-15 sm:rounded-[10px]"
     role="status"
-    aria-label="Loading discussion"
+    :aria-label="label"
   >
     <div class="flex h-[68px] items-center overflow-hidden px-4 py-2 sm:h-full sm:px-3">
       <div class="flex items-center space-x-3">
@@ -24,7 +24,11 @@
 </template>
 
 <script setup lang="ts">
-defineProps<{
-  showSeparator?: boolean
-}>()
+withDefaults(
+  defineProps<{
+    showSeparator?: boolean
+    label?: string
+  }>(),
+  { label: 'Loading' },
+)
 </script>

--- a/frontend/src/pages/Notifications.vue
+++ b/frontend/src/pages/Notifications.vue
@@ -16,7 +16,19 @@
       </Button>
     </div>
 
-    <List v-if="notifications?.length" class="max-sm:list-gap-3 sm:list-gap-4 max-sm:list-row-px-4">
+    <template v-if="isInitialLoading">
+      <ListRowSkeleton
+        v-for="index in skeletonRowCount"
+        :key="index"
+        :show-separator="index < skeletonRowCount"
+        label="Loading notification"
+      />
+    </template>
+
+    <List
+      v-else-if="notifications?.length"
+      class="max-sm:list-gap-3 sm:list-gap-4 max-sm:list-row-px-4"
+    >
       <ListRow
         v-for="notification in notifications"
         :key="notification.name"
@@ -146,6 +158,7 @@ import {
   usePageMeta,
 } from 'frappe-ui'
 import { List, ListRow, ListCell } from 'frappe-ui/list'
+import ListRowSkeleton from '@/components/ListRowSkeleton.vue'
 import ReactionFaceIcon from '@/components/ReactionFaceIcon.vue'
 import UserAvatarWithHover from '@/components/UserAvatarWithHover.vue'
 import { getCommunity } from '@/data/communities'
@@ -231,6 +244,16 @@ const tabOptions: { value: ActiveTab; label: ActiveTab }[] = [
 const notifications = computed(() =>
   activeTab.value === 'Unread' ? unreadNotificationList.data : readNotificationList.data,
 )
+
+// Same guard as DiscussionList: without it the fetch's empty window renders the
+// "You're caught up" box, which contradicts the unread badge that brought the user here.
+// A cached list (`cacheKey`) fills `data` before the request settles, so the skeleton
+// only shows on a genuinely cold load.
+const skeletonRowCount = 3
+const activeList = computed(() =>
+  activeTab.value === 'Unread' ? unreadNotificationList : readNotificationList,
+)
+const isInitialLoading = computed(() => activeList.value.loading && !activeList.value.data?.length)
 
 const emptyStateTitle = computed(() =>
   activeTab.value === 'Unread' ? "You're caught up" : 'No read notifications',


### PR DESCRIPTION
Originates from a bug report in the Raven-gameplan channel.

## What was broken

Open the notifications page while the list request is in flight. The page shows the "You're caught up" empty state for a few seconds, right under an unread badge. The list then replaces it.

## Root cause

`Notifications.vue` chose between list and empty state with only `notifications?.length`. During the first fetch, `useList` has no data yet, so the empty branch rendered. Nothing represented the loading window.

## What changed

- `Notifications.vue` now shows skeleton rows while the active tab's list is loading and has no data. This is the same guard `DiscussionList.vue` already uses (`loading && !data?.length`). A cached list (`cacheKey`) still renders instantly; the skeleton only covers a cold load.
- `DiscussionRowSkeleton` renamed to `ListRowSkeleton` with an `aria-label` prop, since two pages now share it.
- New Cypress test: delay the `GP Notification` list response, assert the skeleton shows and the empty state does not, then assert the settled state.

## Verification

Cypress against the demo site, run by agents from this branch:

```
✔  notifications/notifications.cy.ts        00:14        2        2        -        -        -
✔  discussions/feeds.cy.ts                  00:10        3        3        -        -        -
✔  All specs passed!                        00:25        5        5        -        -        -
```

Red/green check: with the fix reverted, the new test fails (`Expected to find element: [role="status"][aria-label="Loading notification"], but never found it`). With the fix, it passes.

Type check (`vue-tsc`): no new errors in changed files; the three reported in `Notifications.vue` predate this change. Prettier passes on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)