### PR TITLE
fix(a11y): add alt text to images missing it

### DIFF
--- a/frontend/src/components/CoverImage.vue
+++ b/frontend/src/components/CoverImage.vue
@@ -6,6 +6,7 @@
         :class="{ 'animate-pulse': loading }"
         :style="{ objectPosition }"
         :src="validatedImageUrl"
+        alt="Cover image"
         @load="loading = false"
       />
       <div

--- a/frontend/src/components/ImagePreview.vue
+++ b/frontend/src/components/ImagePreview.vue
@@ -11,7 +11,7 @@
         class="flex h-full items-center justify-center"
         @click.self="$emit('update:show', false)"
       >
-        <img :src="imageUrl" class="max-h-[80%] object-contain" />
+        <img :src="imageUrl" alt="Enlarged image preview" class="max-h-[80%] object-contain" />
       </div>
     </div>
   </teleport>

--- a/frontend/src/components/UnsplashImageBrowser.vue
+++ b/frontend/src/components/UnsplashImageBrowser.vue
@@ -31,7 +31,10 @@
             class="h-[50px] w-[200px] overflow-hidden rounded-4 hover:opacity-80"
             @click="$emit('select', image.urls.raw)"
           >
-            <img :src="image.urls.raw + '&w=200&h=50&fit=crop&crop=entropy,faces,focalpoint'" />
+            <img
+              :src="image.urls.raw + '&w=200&h=50&fit=crop&crop=entropy,faces,focalpoint'"
+              :alt="image.alt_description || 'Unsplash photo'"
+            />
           </button>
         </div>
         <div class="mt-2 text-center text-sm text-ink-gray-4">


### PR DESCRIPTION
## Problem

Three images had no `alt` attribute.

## Fix

- `CoverImage.vue` / `ImagePreview.vue`: a generic-but-accurate description — neither component has access to what the image is actually a cover/preview of.
- `UnsplashImageBrowser.vue`: Unsplash's own `alt_description` field per photo, falling back to a generic description for photos that don't have one.
