### PR TITLE
fix(polls): give composer errors and checkbox options room to breathe

### DIFF
--- a/frontend/src/components/CommentsArea.vue
+++ b/frontend/src/components/CommentsArea.vue
@@ -225,7 +225,7 @@
                 />
               </template>
             </CommentEditor>
-            <ErrorMessage :message="comments.insert.error" />
+            <ErrorMessage class="mt-2" :message="comments.insert.error" />
             <PollEditor
               v-show="newCommentType == 'Poll'"
               v-model:poll="newPoll"
@@ -247,7 +247,7 @@
                 />
               </template>
             </PollEditor>
-            <ErrorMessage :message="polls.insert.error" />
+            <ErrorMessage class="mt-2" :message="polls.insert.error" />
           </div>
         </div>
       </div>

--- a/frontend/src/components/PollEditor.vue
+++ b/frontend/src/components/PollEditor.vue
@@ -16,20 +16,22 @@
         @update:modelValue="(val) => onOptionChange(option, val)"
       />
     </div>
-    <FormControl
-      type="checkbox"
-      label="Anonymous"
-      v-model="poll.anonymous"
-      :disabled="poll.multiple_answers"
-      @change="$emit('update:poll', poll)"
-    />
-    <FormControl
-      type="checkbox"
-      label="Multiple answers"
-      v-model="poll.multiple_answers"
-      :disabled="poll.anonymous"
-      @change="$emit('update:poll', poll)"
-    />
+    <div class="flex gap-2">
+      <FormControl
+        type="checkbox"
+        label="Anonymous"
+        v-model="poll.anonymous"
+        :disabled="poll.multiple_answers"
+        @change="$emit('update:poll', poll)"
+      />
+      <FormControl
+        type="checkbox"
+        label="Multiple answers"
+        v-model="poll.multiple_answers"
+        :disabled="poll.anonymous"
+        @change="$emit('update:poll', poll)"
+      />
+    </div>
     <div class="flex items-center justify-between gap-2">
       <div class="sm:hidden">
         <slot name="actions-left" />


### PR DESCRIPTION
## Summary
- Add `mt-2` on the discussion composer `ErrorMessage`, so a poll (or comment) validation error is no longer flush against Discard / Submit.
- Group the Anonymous and Multiple answers checkboxes with `flex gap-2` so they aren't cramped.

Fixes #551

## Test plan
- [x] Open a discussion, switch the composer to Poll, submit with duplicate option text, and confirm a gap between the buttons and `ValidationError: Duplicate options not allowed`.
- [x] Confirm Anonymous and Multiple answers sit side by side with a small gap, and that checking one still disables the other.
- [x] Trigger a comment insert error and confirm it also has spacing below the action row.

## Evidence
<img width="872" height="415" alt="Fixed - Gameplan Poll error spacing UI bug" src="https://github.com/user-attachments/assets/840b5dd4-dddb-4678-9ea4-aad5c4868ca8" />