### PR TITLE
feat(communities): join or leave a community from Settings

### DIFF
--- a/frontend/cypress/e2e/communities/join-leave.cy.ts
+++ b/frontend/cypress/e2e/communities/join-leave.cy.ts
@@ -86,5 +86,8 @@ describe('Joining and leaving a community', () => {
     cy.contains('button', 'New community').should('be.visible')
     cy.get('button[aria-label="Alpha Community Options"]:visible').should('be.visible')
     cy.get('button[aria-label="Leave Alpha"]:visible').should('be.visible')
+    // Two header buttons do not fit, so this one drops its text for the icon.
+    cy.get('button[aria-label="Customize sidebar"]:visible').should('be.visible')
+    cy.contains('button', 'Customize sidebar').should('not.exist')
   })
 })

--- a/frontend/cypress/e2e/communities/join-leave.cy.ts
+++ b/frontend/cypress/e2e/communities/join-leave.cy.ts
@@ -60,6 +60,25 @@ describe('Joining and leaving a community', () => {
     cy.contains('[role="dialog"]', 'Shown in sidebar').should('be.visible')
   })
 
+  it('offers no space management to a member who manages none', () => {
+    cy.visit('/g/settings/communities/alpha/spaces')
+    cy.contains('button:visible', 'Spaces').should('be.visible')
+
+    cy.contains('button', 'New space').should('not.exist')
+    cy.get('button[aria-label="Alpha Space Space Options"]').should('not.exist')
+    // Renaming a space is a write on GP Project, which the backend refuses here.
+    cy.get('input[aria-label="Space title"]:visible').first().should('be.disabled')
+  })
+
+  it('keeps the space management actions for an admin', () => {
+    cy.loginAs('admin')
+    cy.visit('/g/settings/communities/alpha/spaces')
+
+    cy.contains('button:visible', 'New space').should('be.visible')
+    cy.get('button[aria-label="Alpha Space Space Options"]:visible').should('be.visible')
+    cy.get('input[aria-label="Space title"]:visible').first().should('be.enabled')
+  })
+
   it('keeps the management actions for an admin, alongside join and leave', () => {
     cy.loginAs('admin')
     openCommunitiesSettings()

--- a/frontend/cypress/e2e/communities/join-leave.cy.ts
+++ b/frontend/cypress/e2e/communities/join-leave.cy.ts
@@ -1,0 +1,64 @@
+// Joining a community is what puts it and its public spaces in the sidebar. The
+// Communities settings tab is where a member browses for one, so it is open to
+// everyone and shows only the actions that user can take.
+import { resetData } from '../../support/seed'
+
+describe('Joining and leaving a community', () => {
+  beforeEach(() => {
+    resetData('two_communities')
+    // The outsider persona belongs to no community, so every row starts on "Join".
+    cy.loginAs('outsider')
+  })
+
+  const openCommunitiesSettings = () => {
+    cy.visit('/g/settings/communities')
+    cy.contains('h2:visible', 'Communities').should('be.visible')
+  }
+
+  const railItem = (title: string) => cy.get(`button[aria-label="${title}"]:visible`)
+
+  it('joins a public community and lists it in the rail', () => {
+    openCommunitiesSettings()
+    railItem('Alpha').should('not.exist')
+
+    cy.get('button[aria-label="Join Alpha"]:visible').click()
+
+    cy.get('button[aria-label="Leave Alpha"]:visible').should('be.visible')
+    railItem('Alpha').should('be.visible')
+    // Joining one community leaves the others alone.
+    cy.get('button[aria-label="Join Beta"]:visible').should('be.visible')
+  })
+
+  it('leaves after confirming and drops it from the rail', () => {
+    openCommunitiesSettings()
+    cy.get('button[aria-label="Join Alpha"]:visible').click()
+    cy.get('button[aria-label="Leave Alpha"]:visible').click()
+
+    cy.contains('[role="dialog"]', 'Leave "Alpha"?')
+      .should('be.visible')
+      .within(() => {
+        cy.contains('button', 'Leave').click()
+      })
+
+    cy.get('button[aria-label="Join Alpha"]:visible').should('be.visible')
+    railItem('Alpha').should('not.exist')
+  })
+
+  it('offers no community management to a member who manages none', () => {
+    openCommunitiesSettings()
+
+    cy.contains('button', 'New community').should('not.exist')
+    cy.get('button[aria-label="Alpha Community Options"]').should('not.exist')
+    // The image on a row is a plain avatar, not the admin's upload button.
+    cy.get('button[aria-label="Upload image for Alpha"]').should('not.exist')
+  })
+
+  it('keeps the management actions for an admin, alongside join and leave', () => {
+    cy.loginAs('admin')
+    openCommunitiesSettings()
+
+    cy.contains('button', 'New community').should('be.visible')
+    cy.get('button[aria-label="Alpha Community Options"]:visible').should('be.visible')
+    cy.get('button[aria-label="Leave Alpha"]:visible').should('be.visible')
+  })
+})

--- a/frontend/cypress/e2e/communities/join-leave.cy.ts
+++ b/frontend/cypress/e2e/communities/join-leave.cy.ts
@@ -53,6 +53,13 @@ describe('Joining and leaving a community', () => {
     cy.get('button[aria-label="Upload image for Alpha"]').should('not.exist')
   })
 
+  it('opens the customize sidebar dialog from the communities tab', () => {
+    openCommunitiesSettings()
+
+    cy.contains('button', 'Customize sidebar').click()
+    cy.contains('[role="dialog"]', 'Shown in sidebar').should('be.visible')
+  })
+
   it('keeps the management actions for an admin, alongside join and leave', () => {
     cy.loginAs('admin')
     openCommunitiesSettings()

--- a/frontend/cypress/e2e/shell/settings-menu.cy.ts
+++ b/frontend/cypress/e2e/shell/settings-menu.cy.ts
@@ -1,0 +1,26 @@
+// Settings must be reachable from the account (avatar) menu, not only from the
+// app logo menu — the avatar is where people look for it first.
+import { resetData } from '../../support/seed'
+
+describe('Settings entry points', () => {
+  beforeEach(() => {
+    resetData('onboarded')
+    cy.loginAs('member')
+    cy.visit('/g')
+    cy.url().should('include', '/discussions')
+  })
+
+  it('opens the settings dialog from the account menu', () => {
+    cy.selectDropdownOption('Account menu', 'Settings')
+
+    cy.location('pathname').should('equal', '/g/settings/profile')
+    cy.contains('[role="dialog"]', 'User settings').should('be.visible')
+  })
+
+  it('opens the settings dialog from the app menu', () => {
+    cy.selectDropdownOption('Gameplan menu', 'Settings')
+
+    cy.location('pathname').should('equal', '/g/settings/profile')
+    cy.contains('[role="dialog"]', 'User settings').should('be.visible')
+  })
+})

--- a/frontend/src/components/AppDropdown.vue
+++ b/frontend/src/components/AppDropdown.vue
@@ -22,17 +22,13 @@
 import { h, markRaw, ref } from 'vue'
 import { Dropdown } from 'frappe-ui'
 import { clear as clearIndexDb } from 'idb-keyval'
-import { showSettingsDialog } from '@/components/Settings'
+import { settingsShortcutLabel, showSettingsDialog } from '@/components/Settings'
 import AboutDialog from './AboutDialog.vue'
 import AppSelector from './AppSelector.vue'
 import GameplanLogo from './GameplanLogo.vue'
 import { openCustomizeSidebarDialog } from './AppRail/customizeSidebar'
 
 const showAboutDialog = ref(false)
-
-// Mirror the Cmd/Ctrl+Shift+, handler in SettingsDialog.vue.
-const isMac = /Mac/i.test(navigator.platform)
-const settingsShortcut = isMac ? '⌘⇧,' : 'Ctrl ⇧ ,'
 
 const dropdownItems = [
   {
@@ -49,7 +45,7 @@ const dropdownItems = [
     label: 'Settings',
     onClick: () => showSettingsDialog(),
     slots: {
-      suffix: () => h('span', { class: 'text-xs text-ink-gray-4' }, settingsShortcut),
+      suffix: () => h('span', { class: 'text-xs text-ink-gray-4' }, settingsShortcutLabel),
     },
   },
   {

--- a/frontend/src/components/AppRail/AppRail.vue
+++ b/frontend/src/components/AppRail/AppRail.vue
@@ -72,6 +72,7 @@
           type="button"
           class="flex size-7 items-center justify-center rounded-full transition focus-visible:ring-0 focus-visible:focus-ring"
           :class="open ? '' : 'hover:opacity-90'"
+          aria-label="Account menu"
         >
           <UserAvatar v-if="sessionUser.name" :user="sessionUser.name" size="md" class="size-7" />
         </button>

--- a/frontend/src/components/CommandPalette/CommandPalette.vue
+++ b/frontend/src/components/CommandPalette/CommandPalette.vue
@@ -127,7 +127,6 @@ import KeyboardShortcut from '../KeyboardShortcut.vue'
 import { showNewTaskDialog } from '../NewTaskDialog'
 import { GPPage } from '@/types/doctypes'
 import { showCommunitiesSettings, showSettingsDialog } from '@/components/Settings'
-import { useCanManageCommunities } from '@/composables/useCanManageCommunities'
 import {
   registeredCommands,
   type CommandPaletteGroup,
@@ -145,7 +144,6 @@ const commandPaletteListId = 'command-palette-listbox'
 
 const router = useRouter()
 const sessionUser = useSessionUser()
-const canManageCommunities = useCanManageCommunities()
 const activeCommunityIds = computed(
   () => new Set(activeCommunities.value.map((community) => community.name)),
 )
@@ -338,7 +336,8 @@ const shortcuts = computed((): CommandPaletteGroup[] => [
         search: 'Settings Communities manage communities manage spaces spaces settings',
         aliases: ['communities settings', 'manage spaces', 'spaces settings'],
         onClick: () => showCommunitiesSettings(),
-        condition: () => canManageCommunities.value,
+        // Matches the Communities settings tab: everyone browses it, to join or leave.
+        condition: () => !sessionUser.isGuest,
       },
       {
         title: 'Users',

--- a/frontend/src/components/Settings/CommunitiesSettings.vue
+++ b/frontend/src/components/Settings/CommunitiesSettings.vue
@@ -66,9 +66,15 @@
           <div class="flex shrink-0 items-center gap-2">
             <!-- Which communities sit in the sidebar, and in what order, is the
                  other half of joining one; the same dialog the app menu opens. -->
-            <Button icon-left="lucide-settings-2" @click="customizeSidebar">
-              Customize sidebar
-            </Button>
+            <!-- Beside "New community" the header has no room to spare, so a
+                 manager gets the icon alone and the label in a tooltip. -->
+            <Button
+              :icon="showNewCommunityButton ? 'lucide-settings-2' : undefined"
+              :icon-left="showNewCommunityButton ? undefined : 'lucide-settings-2'"
+              :tooltip="showNewCommunityButton ? 'Customize sidebar' : undefined"
+              label="Customize sidebar"
+              @click="customizeSidebar"
+            />
             <Button
               v-if="showNewCommunityButton"
               icon-left="lucide-plus"

--- a/frontend/src/components/Settings/CommunitiesSettings.vue
+++ b/frontend/src/components/Settings/CommunitiesSettings.vue
@@ -63,13 +63,20 @@
             v-model:search="search"
             v-model:visibility-filter="visibilityFilter"
           />
-          <Button
-            v-if="showNewCommunityButton"
-            icon-left="lucide-plus"
-            @click="newCommunityDialog = true"
-          >
-            New community
-          </Button>
+          <div class="flex shrink-0 items-center gap-2">
+            <!-- Which communities sit in the sidebar, and in what order, is the
+                 other half of joining one; the same dialog the app menu opens. -->
+            <Button icon-left="lucide-settings-2" @click="customizeSidebar">
+              Customize sidebar
+            </Button>
+            <Button
+              v-if="showNewCommunityButton"
+              icon-left="lucide-plus"
+              @click="newCommunityDialog = true"
+            >
+              New community
+            </Button>
+          </div>
         </div>
       </template>
     </div>
@@ -135,6 +142,7 @@ import { computed, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { Button, SettingsBody, SettingsHeader, Select } from 'frappe-ui'
 import NewSpaceDialog from '@/components/NewSpaceDialog.vue'
+import { openCustomizeSidebarDialog } from '@/components/AppRail/customizeSidebar'
 import { communities } from '@/data/communities'
 import { useSessionUser } from '@/data/users'
 import { canManageCommunity, isGlobalAdmin } from '@/utils/permissions'
@@ -180,6 +188,11 @@ const showAddMembers = ref(false)
 const newSpaceDialog = ref(false)
 const newCommunityDialog = ref(false)
 
+// The dialog itself is mounted once in AppRail; this only flips its shared flag.
+function customizeSidebar() {
+  openCustomizeSidebarDialog()
+}
+
 const viewButtons = [
   { label: 'Spaces', value: 'spaces' },
   { label: 'Members', value: 'members' },
@@ -198,8 +211,8 @@ const showNewCommunityButton = computed(
 const canCreateSpace = computed(() =>
   Boolean(
     selectedCommunity.value &&
-      canManageSelectedCommunity.value &&
-      !selectedCommunity.value.archived_at,
+    canManageSelectedCommunity.value &&
+    !selectedCommunity.value.archived_at,
   ),
 )
 function openCommunitySpaces(communityId: string) {

--- a/frontend/src/components/Settings/CommunitiesSettings.vue
+++ b/frontend/src/components/Settings/CommunitiesSettings.vue
@@ -27,7 +27,7 @@
           v-model:visibility-filter="spaceFilter"
         >
           <template #action>
-            <Button icon-left="lucide-plus" :disabled="!canCreateSpace" @click="openNewSpaceDialog">
+            <Button v-if="canCreateSpace" icon-left="lucide-plus" @click="openNewSpaceDialog">
               New space
             </Button>
           </template>

--- a/frontend/src/components/Settings/SettingsDialog.vue
+++ b/frontend/src/components/Settings/SettingsDialog.vue
@@ -55,7 +55,6 @@ import { show, activeTab, registerTabs, settingsBackgroundPath, type Tab } from 
 import { getHomeRoute } from '@/router'
 import UserAvatar from '@/components/UserAvatar.vue'
 import { isGameplanAdmin, useSessionUser } from '@/data/users'
-import { useCanManageCommunities } from '@/composables/useCanManageCommunities'
 import MembersSettings from './MembersSettings.vue'
 import CommunitiesSettings from './CommunitiesSettings.vue'
 import NotificationsSettings from './NotificationsSettings.vue'
@@ -79,7 +78,6 @@ interface TabGroup {
   tabs: SettingsTab[]
 }
 
-const canManageCommunities = useCanManageCommunities()
 const sessionUser = useSessionUser()
 
 const allTabs: SettingsTab[] = [
@@ -111,7 +109,9 @@ const allTabs: SettingsTab[] = [
     group: 'App settings',
     icon: 'lucide-building-2',
     component: markRaw(CommunitiesSettings),
-    condition: () => canManageCommunities.value,
+    // Every member browses communities here to join or leave one; the management
+    // actions inside the tab stay gated per community.
+    condition: () => !sessionUser.isGuest,
   },
   {
     label: 'Emojis',

--- a/frontend/src/components/Settings/index.ts
+++ b/frontend/src/components/Settings/index.ts
@@ -47,6 +47,12 @@ export function registerTabs(tabsArray: Tab[]) {
 }
 
 /**
+ * Label for the Cmd/Ctrl+Shift+, shortcut that toggles the dialog (handled in
+ * SettingsDialog.vue). Shared so every menu entry shows the same hint.
+ */
+export const settingsShortcutLabel = /Mac/i.test(navigator.platform) ? '⌘⇧,' : 'Ctrl ⇧ ,'
+
+/**
  * Open the settings dialog at a tab, addressed by its display label. Kept for
  * back-compat with existing callers (e.g. `showSettingsDialog('Notifications')`).
  * Navigates to the tab's URL; SettingsDialog.vue reacts to the route change.

--- a/frontend/src/components/SpaceOptions.vue
+++ b/frontend/src/components/SpaceOptions.vue
@@ -1,9 +1,12 @@
 <template>
+  <!-- No permitted action, no trigger: a member browsing a community's spaces in
+       settings would otherwise open an empty menu. -->
   <DropdownMoreOptions
+    v-if="permittedOptions.length"
     :label="`${space?.title} Space Options`"
     v-bind="$attrs"
     button-size="xs"
-    :options="options"
+    :options="permittedOptions"
   />
 
   <MergeSpaceDialog v-model="showSpaceMergeDialog" :spaceId="props.spaceId" />
@@ -82,6 +85,10 @@ const options = computed(() => [
     condition: () => canEditSpace.value,
   },
 ])
+
+const permittedOptions = computed(() =>
+  options.value.filter((option) => !option.condition || option.condition()),
+)
 
 useCommandPaletteCommands(
   computed(() =>

--- a/frontend/src/components/SpaceOptions.vue
+++ b/frontend/src/components/SpaceOptions.vue
@@ -32,7 +32,7 @@ const props = defineProps<{
   spaceId: string
 }>()
 
-const { space, canEditSpace, canManageAccess } = useSpacePermissions(() => props.spaceId)
+const { space, canEditSettings, canManageAccess } = useSpacePermissions(() => props.spaceId)
 const spaces = useDoctype<GPProject>('GP Project')
 
 const showSpaceMergeDialog = ref(false)
@@ -50,21 +50,19 @@ const options = computed(() => [
     label: 'Change Community',
     icon: 'lucide-log-out',
     onClick: () => (showSpaceCategoryDialog.value = true),
-    condition: () => canEditSpace.value,
+    condition: () => canEditSettings.value,
   },
   {
     label: 'Merge',
     icon: 'lucide-merge',
     onClick: () => (showSpaceMergeDialog.value = true),
-    condition: () => canEditSpace.value,
+    condition: () => canEditSettings.value,
   },
   {
     label: 'Archive',
     icon: 'lucide-archive',
     onClick: () => space.value && archiveSpace(space.value),
-    // Archiving is destructive — require manage access, matching the space header menu, so a
-    // regular member isn't offered an action they lack permission for.
-    condition: () => canEditSpace.value && canManageAccess.value,
+    condition: () => canEditSettings.value,
   },
   {
     label: 'Delete',
@@ -82,7 +80,7 @@ const options = computed(() => [
         onConfirm: () => spaces.delete.submit({ name: props.spaceId }),
       })
     },
-    condition: () => canEditSpace.value,
+    condition: () => canEditSettings.value,
   },
 ])
 

--- a/frontend/src/components/UserDropdown.vue
+++ b/frontend/src/components/UserDropdown.vue
@@ -8,6 +8,7 @@
 <script setup>
 import { h, computed } from 'vue'
 import { Dropdown } from 'frappe-ui'
+import { settingsShortcutLabel, showSettingsDialog } from '@/components/Settings'
 import { useUser } from '@/data/users'
 import { session } from '@/data/session'
 import { useTheme } from '@/utils/useTheme'
@@ -38,6 +39,14 @@ const dropdownItems = computed(() => [
     icon: 'lucide-files',
     label: 'Pages',
     route: { name: 'MyPages' },
+  },
+  {
+    icon: 'lucide-settings',
+    label: 'Settings',
+    onClick: () => showSettingsDialog(),
+    slots: {
+      suffix: () => h('span', { class: 'text-xs text-ink-gray-4' }, settingsShortcutLabel),
+    },
   },
   {
     icon: 'lucide-moon',

--- a/frontend/src/data/communities.ts
+++ b/frontend/src/data/communities.ts
@@ -1,5 +1,5 @@
 import { computed, MaybeRefOrGetter, toValue } from 'vue'
-import { useList } from 'frappe-ui'
+import { dialog, useDoctype, useList } from 'frappe-ui'
 import { GPTeam, GPMember } from '@/types/doctypes'
 import { communityOrder } from './communityOrder'
 import { useSessionUser } from './users'
@@ -70,6 +70,44 @@ export let getActiveCommunity = (communityId: string) => {
   return activeCommunities.value.find(
     (community) => community.name.toString() === communityId.toString(),
   )
+}
+
+const communityDoctype = useDoctype<GPTeam>('GP Team')
+
+/**
+ * Join a community. Membership is what lists a community and its public spaces in
+ * the sidebar, so this is how a member gets to a public community they can already
+ * read. Private communities are invite only and the backend rejects them.
+ */
+export function joinCommunity(community: Community) {
+  return communityDoctype.runMethod
+    .submit({ method: 'join_team', params: { team: community.name } })
+    .then(() => communities.reload())
+}
+
+export function leaveCommunity(community: Community) {
+  return communityDoctype.runMethod
+    .submit({ method: 'leave_team', params: { team: community.name } })
+    .then(() => communities.reload())
+}
+
+/**
+ * Ask before leaving. A public community is one click away again, but a private one's
+ * view permission *is* its membership (backend `can_view_community`), so leaving hides
+ * it and its Join action for good. Mirrors `confirmLeaveSpace`.
+ *
+ * The dialog holds its loading state until the call settles and renders a rejection
+ * inline, which is where the "last admin cannot leave" message lands.
+ */
+export function confirmLeaveCommunity(community: Community) {
+  dialog.confirm({
+    title: `Leave "${community.title}"?`,
+    message: community.is_private
+      ? "This community is private. You won't be able to rejoin unless a member adds you back."
+      : 'Its spaces leave your sidebar. You can rejoin at any time.',
+    confirmLabel: 'Leave',
+    onConfirm: () => leaveCommunity(community),
+  })
 }
 
 export function isCommunityJoined(community: Community) {

--- a/frontend/src/data/spaces.ts
+++ b/frontend/src/data/spaces.ts
@@ -63,11 +63,12 @@ export function useSpace(name: MaybeRefOrGetter<string | undefined>) {
 /**
  * Shared gates for the space-action menus (the options dropdown and the discussions-header
  * menu). Kept in one place so a permission-rule change can't leave the two menus disagreeing
- * about who may edit vs. manage a space. `canEditSpace` covers non-destructive edits on a live
- * space; `canManageAccess` mirrors the backend `can_manage_space` and additionally gates the
- * destructive/admin actions (manage access, archive, unarchive); `canChangeMembership` gates
- * joining and leaving, and `canMoveDiscussions` the bulk move. The last two are neither edits
- * nor admin actions, and both are closed to guests.
+ * about who may edit vs. manage a space. `canEditSpace` only says the space is writable at all
+ * (live, and not read-only mode); `canManageAccess` mirrors the backend `can_manage_space`;
+ * `canEditSettings` is both, and gates everything that writes GP Project itself (rename, change
+ * community, merge, archive, delete); `canChangeMembership` gates joining and leaving, and
+ * `canMoveDiscussions` the bulk move. The last two are neither edits nor admin actions, and both
+ * are closed to guests.
  *
  * They are kept off `canEditSpace` because a guest may edit content in a space they were
  * granted while being unable to do either of these. For membership, `get_joined_spaces` unions
@@ -82,12 +83,18 @@ export function useSpacePermissions(spaceId: MaybeRefOrGetter<string | undefined
   const isGuestUser = computed(() => isGuest(sessionUser))
   const canEditSpace = computed(() => !readOnlyMode && !isArchived.value)
   const canManageAccess = computed(() => !readOnlyMode && canManageSpace(space.value, sessionUser))
+  // Renaming a space, moving it, merging it, archiving or deleting it are all writes
+  // on GP Project, which the backend gates with can_manage_space. canEditSpace only
+  // says the space is writable at all (not archived, not read-only), so it is never
+  // enough on its own — every member can read a public space they do not manage.
+  const canEditSettings = computed(() => canEditSpace.value && canManageAccess.value)
   const canChangeMembership = computed(() => canEditSpace.value && !isGuestUser.value)
   const canMoveDiscussions = computed(() => canEditSpace.value && !isGuestUser.value)
   return {
     space,
     isArchived,
     canEditSpace,
+    canEditSettings,
     canManageAccess,
     canChangeMembership,
     canMoveDiscussions,

--- a/frontend/src/pages/Configure/CommunitiesList.vue
+++ b/frontend/src/pages/Configure/CommunitiesList.vue
@@ -6,10 +6,14 @@
   />
 
   <ConfigureEmptyState
-    v-if="!manageableCommunities.length"
+    v-if="!visibleCommunities.length"
     icon="lucide-blocks"
     title="No communities yet"
-    description="Create a community to group related spaces, members, and discussions."
+    :description="
+      showCreateCommunity
+        ? 'Create a community to group related spaces, members, and discussions.'
+        : 'A Gameplan Admin creates communities. Ask for one, or for an invite to a private community.'
+    "
   >
     <template #actions>
       <Button
@@ -68,7 +72,7 @@ import { List, ListHeader, ListHeaderCell } from 'frappe-ui/list'
 import { communities, type Community } from '@/data/communities'
 import { spaces } from '@/data/spaces'
 import { useSessionUser } from '@/data/users'
-import { getManageableCommunities, isGlobalAdmin } from '@/utils/permissions'
+import { isGlobalAdmin } from '@/utils/permissions'
 import ConfigureEmptyState from './ConfigureEmptyState.vue'
 import CommunityRow from './CommunityRow.vue'
 import CommunitiesListFilters from './CommunitiesListFilters.vue'
@@ -98,18 +102,19 @@ const emit = defineEmits<{
 
 const filteredCommunities = computed(() => {
   const term = search.value.trim().toLowerCase()
-  return manageableCommunities.value.filter(
+  return visibleCommunities.value.filter(
     (community) =>
       matchesScope(community, visibilityFilter.value) &&
       (!term || community.title.toLowerCase().includes(term)),
   )
 })
 
-const manageableCommunities = computed(() =>
-  getManageableCommunities(communities.data || [], sessionUser),
-)
+// Every community the user can read — public ones plus the private ones they belong
+// to; the backend list query scopes it. Members browse the full list to find one to
+// join, and each row only offers the actions that user can take.
+const visibleCommunities = computed(() => communities.data || [])
 const hasArchivedCommunities = computed(() =>
-  manageableCommunities.value.some((community) => community.archived_at),
+  visibleCommunities.value.some((community) => community.archived_at),
 )
 const showCreateCommunity = computed(() => isGlobalAdmin(sessionUser))
 

--- a/frontend/src/pages/Configure/CommunitiesList.vue
+++ b/frontend/src/pages/Configure/CommunitiesList.vue
@@ -29,7 +29,7 @@
 
   <List
     v-else-if="filteredCommunities.length"
-    :columns="['minmax(12rem,6fr)', 'minmax(6rem,1.2fr)', 'minmax(6rem,1.2fr)', '4rem', '1.5rem']"
+    :columns="['minmax(12rem,6fr)', 'minmax(6rem,1.2fr)', 'minmax(6rem,1.2fr)', '5.75rem']"
     class="list-gap-12 max-md:list-cols-[minmax(0,1fr)]"
   >
     <!-- Sticky at the settings scroll-viewport top — it rests exactly where it
@@ -39,9 +39,10 @@
       <ListHeaderCell>Community</ListHeaderCell>
       <ListHeaderCell class="px-1.5">Spaces</ListHeaderCell>
       <ListHeaderCell class="px-1.5">Members</ListHeaderCell>
-      <!-- Join/Leave gets its own column: it is 4rem wide and the options button
-           1.5rem, so sharing one cell pushed the button over the Members column. -->
-      <ListHeaderCell />
+      <!-- Join/Leave and the options button share the last column so both hug
+           the right edge. It is 5.75rem: the 4rem membership button, the gap,
+           and the 1.5rem options button. Anything narrower spills left over the
+           members column. -->
       <ListHeaderCell />
     </ListHeader>
     <CommunityRow

--- a/frontend/src/pages/Configure/CommunitiesList.vue
+++ b/frontend/src/pages/Configure/CommunitiesList.vue
@@ -29,7 +29,7 @@
 
   <List
     v-else-if="filteredCommunities.length"
-    :columns="['minmax(12rem,6fr)', 'minmax(6rem,1.2fr)', 'minmax(6rem,1.2fr)', '1.5rem']"
+    :columns="['minmax(12rem,6fr)', 'minmax(6rem,1.2fr)', 'minmax(6rem,1.2fr)', '4rem', '1.5rem']"
     class="list-gap-12 max-md:list-cols-[minmax(0,1fr)]"
   >
     <!-- Sticky at the settings scroll-viewport top — it rests exactly where it
@@ -39,6 +39,9 @@
       <ListHeaderCell>Community</ListHeaderCell>
       <ListHeaderCell class="px-1.5">Spaces</ListHeaderCell>
       <ListHeaderCell class="px-1.5">Members</ListHeaderCell>
+      <!-- Join/Leave gets its own column: it is 4rem wide and the options button
+           1.5rem, so sharing one cell pushed the button over the Members column. -->
+      <ListHeaderCell />
       <ListHeaderCell />
     </ListHeader>
     <CommunityRow

--- a/frontend/src/pages/Configure/CommunitiesListFilters.vue
+++ b/frontend/src/pages/Configure/CommunitiesListFilters.vue
@@ -13,24 +13,19 @@
 import { computed } from 'vue'
 import { Select, TextInput } from 'frappe-ui'
 import { communities } from '@/data/communities'
-import { useSessionUser } from '@/data/users'
-import { getManageableCommunities } from '@/utils/permissions'
 
 type VisibilityFilter = 'All' | 'Public' | 'Private' | 'Archived'
 
 const search = defineModel<string>('search', { default: '' })
 const visibilityFilter = defineModel<VisibilityFilter>('visibilityFilter', { default: 'All' })
 
-const sessionUser = useSessionUser()
-
-const manageableCommunities = computed(() =>
-  getManageableCommunities(communities.data || [], sessionUser),
-)
+// Counts must match CommunitiesList: every community the user can read.
+const visibleCommunities = computed(() => communities.data || [])
 const activeCommunities = computed(() =>
-  manageableCommunities.value.filter((community) => !community.archived_at),
+  visibleCommunities.value.filter((community) => !community.archived_at),
 )
 const archivedCount = computed(
-  () => manageableCommunities.value.length - activeCommunities.value.length,
+  () => visibleCommunities.value.length - activeCommunities.value.length,
 )
 
 const visibilityOptions = computed(() => {

--- a/frontend/src/pages/Configure/CommunityRow.vue
+++ b/frontend/src/pages/Configure/CommunityRow.vue
@@ -54,10 +54,8 @@
         @click="emit('view-members', community.name)"
       />
     </ListCell>
-    <ListCell class="justify-end max-md:hidden">
+    <ListCell class="justify-end gap-1 max-md:hidden">
       <MembershipButton v-if="showMembershipButton" :community="community" size="sm" />
-    </ListCell>
-    <ListCell class="justify-end max-md:hidden">
       <CommunityOptions
         v-if="canManage"
         :community="community"

--- a/frontend/src/pages/Configure/CommunityRow.vue
+++ b/frontend/src/pages/Configure/CommunityRow.vue
@@ -54,8 +54,10 @@
         @click="emit('view-members', community.name)"
       />
     </ListCell>
-    <ListCell class="justify-end gap-1 max-md:hidden">
+    <ListCell class="justify-end max-md:hidden">
       <MembershipButton v-if="showMembershipButton" :community="community" size="sm" />
+    </ListCell>
+    <ListCell class="justify-end max-md:hidden">
       <CommunityOptions
         v-if="canManage"
         :community="community"

--- a/frontend/src/pages/Configure/CommunityRow.vue
+++ b/frontend/src/pages/Configure/CommunityRow.vue
@@ -1,7 +1,12 @@
 <template>
   <ListRow class="h-10">
     <ListCell class="gap-2">
-      <CommunityImageUploader :community="community" class="shrink-0" />
+      <CommunityImageUploader v-if="canManage" :community="community" class="shrink-0" />
+      <CommunityImage
+        v-else
+        :community="community"
+        class="size-6 shrink-0 rounded-[5px] bg-surface-gray-1"
+      />
 
       <div class="min-w-0">
         <div class="truncate text-base-medium text-ink-gray-7">
@@ -26,6 +31,7 @@
             <span :class="[visibilityIcon(community.is_private), 'size-3.5']" />
             {{ visibilityLabel(community.is_private) }}
           </span>
+          <MembershipButton v-if="showMembershipButton" :community="community" size="xs" />
         </div>
       </div>
     </ListCell>
@@ -48,8 +54,10 @@
         @click="emit('view-members', community.name)"
       />
     </ListCell>
-    <ListCell class="justify-end max-md:hidden">
+    <ListCell class="justify-end gap-1 max-md:hidden">
+      <MembershipButton v-if="showMembershipButton" :community="community" size="sm" />
       <CommunityOptions
+        v-if="canManage"
         :community="community"
         @view-spaces="emit('view-spaces', community.name)"
         @view-members="emit('view-members', community.name)"
@@ -63,10 +71,14 @@
 import { computed } from 'vue'
 import { Button } from 'frappe-ui'
 import { ListCell, ListRow } from 'frappe-ui/list'
-import type { Community } from '@/data/communities'
+import CommunityImage from '@/components/CommunityImage.vue'
+import { isCommunityJoined, type Community } from '@/data/communities'
+import { useSessionUser } from '@/data/users'
+import { canManageCommunity } from '@/utils/permissions'
 import { visibilityIcon, visibilityLabel } from '@/utils/visibility'
 import CommunityImageUploader from './CommunityImageUploader.vue'
 import CommunityOptions from './CommunityOptions.vue'
+import MembershipButton from './MembershipButton.vue'
 
 const props = defineProps<{
   community: Community
@@ -78,6 +90,16 @@ const emit = defineEmits<{
   (event: 'view-members', communityId: string): void
   (event: 'merged', communityId: string): void
 }>()
+
+const sessionUser = useSessionUser()
+
+const canManage = computed(() => canManageCommunity(props.community, sessionUser))
+// An archived community is read-only, and a private one you are not in never reaches
+// this list, so the only Join offered is for a public community.
+const showMembershipButton = computed(() => {
+  if (sessionUser.isGuest || props.community.archived_at) return false
+  return isCommunityJoined(props.community) || !props.community.is_private
+})
 
 const spacesLabel = computed(() => formatCount(props.spacesCount, 'space'))
 const membersLabel = computed(() => formatCount(props.community.members?.length || 0, 'member'))

--- a/frontend/src/pages/Configure/MembershipButton.vue
+++ b/frontend/src/pages/Configure/MembershipButton.vue
@@ -3,7 +3,7 @@
        swaps between Join and Leave, so the row never shifts. -->
   <Button
     :size="size"
-    :variant="isJoined ? 'subtle' : 'solid'"
+    variant="subtle"
     :loading="isJoining"
     :label="isJoined ? `Leave ${community.title}` : `Join ${community.title}`"
     class="min-w-16 shrink-0"

--- a/frontend/src/pages/Configure/MembershipButton.vue
+++ b/frontend/src/pages/Configure/MembershipButton.vue
@@ -1,0 +1,59 @@
+<template>
+  <!-- One width for both states: min-w-16 holds the button steady as the label
+       swaps between Join and Leave, so the row never shifts. -->
+  <Button
+    :size="size"
+    :variant="isJoined ? 'subtle' : 'solid'"
+    :loading="isJoining"
+    :label="isJoined ? `Leave ${community.title}` : `Join ${community.title}`"
+    class="min-w-16 shrink-0"
+    @click="toggleMembership"
+  >
+    {{ isJoined ? 'Leave' : 'Join' }}
+  </Button>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { Button, toast } from 'frappe-ui'
+import { confirmLeaveCommunity, isCommunityJoined, joinCommunity } from '@/data/communities'
+import type { Community } from '@/data/communities'
+
+const props = withDefaults(
+  defineProps<{
+    community: Community
+    size?: 'xs' | 'sm' | 'md'
+  }>(),
+  { size: 'sm' },
+)
+
+// Leaving runs inside the confirm dialog, which owns its own loading state.
+const isJoining = ref(false)
+
+const isJoined = computed(() => isCommunityJoined(props.community))
+
+async function toggleMembership() {
+  if (isJoined.value) {
+    confirmLeaveCommunity(props.community)
+    return
+  }
+
+  isJoining.value = true
+  try {
+    await joinCommunity(props.community)
+    toast.success(`Joined ${props.community.title}`)
+  } catch (error) {
+    toast.error(errorMessage(error) || 'Could not join this community')
+  } finally {
+    isJoining.value = false
+  }
+}
+
+function errorMessage(error: unknown) {
+  if (error && typeof error === 'object' && 'messages' in error) {
+    const messages = (error as { messages?: string[] }).messages
+    if (messages?.length) return messages[0]
+  }
+  return error instanceof Error ? error.message : ''
+}
+</script>

--- a/frontend/src/pages/Configure/SpaceRow.vue
+++ b/frontend/src/pages/Configure/SpaceRow.vue
@@ -51,14 +51,14 @@
 
     <ListCell class="justify-end gap-1">
       <Button
-        v-if="space.archived_at"
+        v-if="space.archived_at && canManageSpaceSettings"
         variant="ghost"
         icon="lucide-archive-restore"
         tooltip="Unarchive space"
         :loading="isDocMethodLoading(space.name, 'unarchive')"
         @click="restoreSpace"
       />
-      <SpaceOptions v-else align="end" :spaceId="space.name" />
+      <SpaceOptions v-else-if="!space.archived_at" align="end" :spaceId="space.name" />
     </ListCell>
   </ListRow>
 </template>
@@ -72,7 +72,9 @@ import SpaceIcon from '@/components/SpaceIcon.vue'
 import SpaceOptions from '@/components/SpaceOptions.vue'
 import { isDocMethodLoading, spaces, type Space, unarchiveSpace } from '@/data/spaces'
 import { readOnlyMode } from '@/data/readOnlyMode'
+import { useSessionUser } from '@/data/users'
 import type { GPProject } from '@/types/doctypes'
+import { canManageSpace } from '@/utils/permissions'
 import { visibilityIcon, visibilityLabel } from '@/utils/visibility'
 
 const props = defineProps<{
@@ -85,7 +87,14 @@ const props = defineProps<{
 const project = useDoctype<GPProject>('GP Project')
 const title = ref(props.space.title)
 const savingTitle = ref(false)
-const canEditSpace = computed(() => !readOnlyMode && !props.space.archived_at)
+const sessionUser = useSessionUser()
+// The title field and the icon picker write GP Project, which the backend gates with
+// can_manage_space. Every member can read a public space here, so being on this screen
+// says nothing about being allowed to rename what is on it.
+const canManageSpaceSettings = computed(
+  () => !readOnlyMode && canManageSpace(props.space, sessionUser),
+)
+const canEditSpace = computed(() => canManageSpaceSettings.value && !props.space.archived_at)
 const contentLabel = computed(() => {
   const counts = [
     formatNonZeroCount(props.space.discussions_count ?? 0, 'post'),

--- a/frontend/src/pages/NoCommunities.vue
+++ b/frontend/src/pages/NoCommunities.vue
@@ -2,34 +2,52 @@
   <div class="body-container py-8">
     <EmptyStateBox class="mx-auto max-w-2xl px-6">
       <LucideFolderX class="mb-3 size-7 text-ink-gray-4" />
-      <div class="text-base text-ink-gray-7">No communities available</div>
+      <div class="text-base text-ink-gray-7">
+        {{ hasCommunityToJoin ? 'You have not joined a community' : 'No communities available' }}
+      </div>
       <p class="mt-2 max-w-md text-center text-p-sm text-ink-gray-5">
-        {{
-          canManageCommunities
-            ? 'Create or unarchive a community so your team can start collaborating.'
-            : 'Ask a Gameplan Admin to create or unarchive a community so you can start collaborating.'
-        }}
+        {{ description }}
       </p>
       <Button
-        v-if="canManageCommunities"
+        v-if="hasCommunityToJoin || canManageCommunities"
         class="mt-4"
         variant="solid"
         icon-left="lucide-building-2"
         @click="showCommunitiesSettings()"
       >
-        Manage communities
+        {{ canManageCommunities ? 'Manage communities' : 'Browse communities' }}
       </Button>
     </EmptyStateBox>
   </div>
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue'
 import { Button, usePageMeta } from 'frappe-ui'
 import EmptyStateBox from '@/components/EmptyStateBox.vue'
 import { useCanManageCommunities } from '@/composables/useCanManageCommunities'
 import { showCommunitiesSettings } from '@/components/Settings'
+import { availableCommunities } from '@/data/communities'
+import { useSessionUser } from '@/data/users'
 
+const sessionUser = useSessionUser()
 const canManageCommunities = useCanManageCommunities()
+
+// This page is only reached with no community joined, so any public community the
+// user can see is one they can join from the Communities settings tab.
+const hasCommunityToJoin = computed(
+  () =>
+    !sessionUser.isGuest && availableCommunities.value.some((community) => !community.is_private),
+)
+
+const description = computed(() => {
+  if (hasCommunityToJoin.value) {
+    return 'Join a community to see its spaces and discussions in your sidebar.'
+  }
+  return canManageCommunities.value
+    ? 'Create or unarchive a community so your team can start collaborating.'
+    : 'Ask a Gameplan Admin to create or unarchive a community so you can start collaborating.'
+})
 
 usePageMeta(() => {
   return {

--- a/frontend/src/pages/SpaceDiscussions.vue
+++ b/frontend/src/pages/SpaceDiscussions.vue
@@ -132,13 +132,13 @@ const router = useRouter()
 const {
   space: currentSpace,
   isArchived,
-  canEditSpace,
+  canEditSettings,
   canManageAccess,
   canChangeMembership,
   canMoveDiscussions,
 } = useSpacePermissions(() => props.spaceId)
-// Not `canEditSpace`: that one is about editing the space, and it says yes to a guest,
-// who cannot start a discussion anywhere.
+// Not `canEditSettings`: that one is about administering the space, and posting is open
+// to every member of a live space — but not to a guest, who cannot start a discussion.
 const canStartDiscussion = computed(() => canPostInSpace(currentSpace.value))
 const isJoined = computed(() => hasJoined(props.spaceId))
 const showSpaceAccessDialog = ref(false)
@@ -191,9 +191,7 @@ const spaceActions = computed(() => [
     label: 'Archive',
     icon: 'lucide-archive',
     onClick: () => currentSpace.value && archiveSpace(currentSpace.value),
-    // Archiving is destructive — gate it behind manage access, mirroring Unarchive, so a
-    // regular member isn't offered (and can't submit) an action they lack permission for.
-    condition: () => canEditSpace.value && canManageAccess.value,
+    condition: () => canEditSettings.value,
   },
   {
     label: 'Unarchive',

--- a/gameplan/gameplan/doctype/gp_team/gp_team.py
+++ b/gameplan/gameplan/doctype/gp_team/gp_team.py
@@ -212,6 +212,62 @@ class GPTeam(Archivable, Document):
 
 @frappe.whitelist(methods=["POST"])
 @validate_type
+def join_team(team: str):
+	"""Add the session user to one community.
+
+	Membership is what puts a community and its public spaces in the sidebar. This is
+	the single-community counterpart of `update_joined_teams`, which rewrites the whole
+	joined list. Only active, public communities can be joined; a private one is invite
+	only.
+
+	Lives at module level rather than on the doc because a plain member has no write
+	permission on GP Team, and the document method route demands one for POST.
+	"""
+	doc = get_team_for_membership_change(team)
+	if doc.is_private:
+		frappe.throw(_("This community is invite only"), frappe.PermissionError)
+
+	if doc.get_member(frappe.session.user):
+		return
+
+	doc.add_member(frappe.session.user)
+	doc.save(ignore_permissions=True)
+
+
+@frappe.whitelist(methods=["POST"])
+@validate_type
+def leave_team(team: str):
+	"""Remove the session user from one community.
+
+	Drops the membership row only, exactly like `update_joined_teams`, so rejoining a
+	public community restores what the member had. Private space memberships stay, in
+	contrast to `GPTeam.remove_member`, which an admin uses to revoke someone's access.
+	"""
+	doc = get_team_for_membership_change(team)
+	member = doc.get_member(frappe.session.user)
+	if not member:
+		return
+
+	if member.is_admin and doc.count_admins(excluding_user=frappe.session.user) == 0:
+		frappe.throw(_("Make someone else an admin before you leave this community"))
+
+	doc.remove(member)
+	doc.save(ignore_permissions=True)
+
+
+def get_team_for_membership_change(team: str):
+	if gameplan.is_guest():
+		frappe.throw(_("Guests cannot join or leave communities"), frappe.PermissionError)
+
+	doc = frappe.get_doc("GP Team", team)
+	doc.check_permission("read")
+	if doc.archived_at:
+		frappe.throw(_("This community is archived"))
+	return doc
+
+
+@frappe.whitelist(methods=["POST"])
+@validate_type
 def update_joined_teams(teams: list = None, sidebar_badge_style: str | None = None):
 	if gameplan.is_guest():
 		frappe.throw("Guests cannot manage communities")

--- a/gameplan/tests/features/test_communities.py
+++ b/gameplan/tests/features/test_communities.py
@@ -12,10 +12,11 @@ from frappe.tests.utils import FrappeTestCase
 from gameplan.gameplan.doctype.gp_member.patches.backfill_team_admins import (
 	execute as backfill_team_admins,
 )
-from gameplan.gameplan.doctype.gp_team.gp_team import update_joined_teams
+from gameplan.gameplan.doctype.gp_team.gp_team import join_team, leave_team, update_joined_teams
 from gameplan.gameplan.doctype.gp_user_profile.gp_user_profile import get_session_user_profile
 from gameplan.tests.base import GameplanTestCase
 from gameplan.tests.fixtures import (
+	_name,
 	create_community,
 	create_discussion,
 	create_member,
@@ -318,3 +319,109 @@ class TestCommunityAdminBackfill(GameplanTestCase):
 
 		community.reload()
 		self.assertTrue(any(row.user == self.member.name and row.is_admin for row in community.members))
+
+
+class TestCommunityJoinLeave(GameplanTestCase):
+	"""Joining and leaving a community as yourself, from the Communities settings list.
+
+	Membership is what puts a community and its public spaces in the sidebar, so these
+	two endpoints are the single-community counterpart of `update_joined_teams`.
+	"""
+
+	def _is_member(self, community, user):
+		community.reload()
+		return any(row.user == _name(user) for row in community.members)
+
+	def _sole_admin(self, community, user):
+		"""Strip every other admin row, leaving `user` as the community's only admin."""
+		community.reload()
+		for row in list(community.members):
+			if row.user != _name(user):
+				community.remove(row)
+		community.get_member(_name(user)).is_admin = 1
+		community.save(ignore_permissions=True)
+		return community
+
+	def test_member_joins_a_public_community(self):
+		community = create_community("Joinable Community")
+
+		with self.as_user(self.member):
+			join_team(community.name)
+
+		self.assertTrue(self._is_member(community, self.member))
+
+	def test_joining_twice_adds_one_membership_row(self):
+		community = create_community("Rejoinable Community", members=[self.member])
+
+		with self.as_user(self.member):
+			join_team(community.name)
+
+		community.reload()
+		self.assertEqual(len([row for row in community.members if row.user == self.member.name]), 1)
+
+	def test_member_cannot_join_a_private_community(self):
+		community = create_community("Invite Only Community", is_private=1)
+
+		with self.as_user(self.member), self.assertRaises(frappe.PermissionError):
+			join_team(community.name)
+
+		self.assertFalse(self._is_member(community, self.member))
+
+	def test_nobody_joins_an_archived_community(self):
+		community = create_community("Archived Joinable Community")
+		community.archive()
+
+		with self.as_user(self.member), self.assertRaises(frappe.ValidationError):
+			join_team(community.name)
+
+	def test_guest_cannot_join(self):
+		community = create_community("Guest Blocked Community")
+
+		with self.as_user(self.guest), self.assertRaises(frappe.PermissionError):
+			join_team(community.name)
+
+	def test_member_leaves_a_community(self):
+		community = create_community("Leavable Community", members=[self.member])
+
+		with self.as_user(self.member):
+			leave_team(community.name)
+
+		self.assertFalse(self._is_member(community, self.member))
+
+	def test_leaving_keeps_private_space_membership(self):
+		# Unlike an admin's remove_member, leaving is the sidebar's own toggle: it drops
+		# the community row only, so rejoining restores what the member had.
+		community = create_community("Self Leave Community", members=[self.member])
+		private_space = create_space("Self Leave Space", community, is_private=1, members=[self.member])
+
+		with self.as_user(self.member):
+			leave_team(community.name)
+
+		private_space.reload()
+		self.assertTrue(any(row.user == self.member.name for row in private_space.members))
+
+	def test_leaving_when_not_a_member_does_nothing(self):
+		community = create_community("Unjoined Community")
+
+		with self.as_user(self.outsider):
+			leave_team(community.name)
+
+		self.assertFalse(self._is_member(community, self.outsider))
+
+	def test_only_admin_cannot_leave(self):
+		community = self._sole_admin(
+			create_community("Sole Admin Community", admins=[self.member]), self.member
+		)
+
+		with self.as_user(self.member), self.assertRaises(frappe.ValidationError):
+			leave_team(community.name)
+
+		self.assertTrue(self._is_member(community, self.member))
+
+	def test_admin_leaves_when_another_admin_remains(self):
+		community = create_community("Shared Admin Community", admins=[self.member, self.second_member])
+
+		with self.as_user(self.member):
+			leave_team(community.name)
+
+		self.assertFalse(self._is_member(community, self.member))


### PR DESCRIPTION
Two related changes to the Settings dialog. Both start from reports in the Raven Raven-gameplan channel: people could not find Settings, and once there, a member had no way to join a community.

## 1. Settings in the account menu

The settings dialog had no entry point in the account (avatar) menu at the bottom of the app rail. It opened only from the logo menu at the top of the rail, the command palette, the profile page, or Cmd/Ctrl+Shift+,.

Root cause: `UserDropdown.vue` never listed a Settings item. The only item calling `showSettingsDialog()` lived in `AppDropdown.vue`.

- `UserDropdown.vue`: Settings item above Toggle theme, with the shortcut hint.
- `Settings/index.ts`: export `settingsShortcutLabel` so both menus share one label.
- `AppRail.vue`: the avatar trigger had no accessible name; now `aria-label="Account menu"`.

## 2. Join or leave a community

Membership in a community is what puts it and its public spaces in the sidebar. Until now only the Customize Sidebar dialog could change it, and the Communities settings tab was hidden from anyone who could not manage communities. A member who wanted to join an open community had no obvious control.

The tab is now open to every member and shows only the actions that user can take.

Backend, `gp_team.py`:

- `join_team(team)` and `leave_team(team)`, both POST-only. They are module-level whitelisted functions, not doc methods: a plain member has no write permission on `GP Team`, and the `/document/<doctype>/<name>/method/<m>` route demands one for POST.
- Join refuses a private community, an archived one, and a guest. It is idempotent.
- Leave removes the membership row only; it never touches the community or its spaces. The last remaining admin cannot leave.

Frontend:

- `MembershipButton.vue`: one Join/Leave button per row, subtle in both states so the row stays quiet and the width never changes. Leave goes through a confirm dialog, mirroring "Leave space".
- `CommunityRow.vue`: management actions (image upload, options menu) render only for a manager. The membership button hides for guests, for archived communities, and for private communities the user is not in. Join/Leave shares the last column with the options menu, widened to 5.75rem so both hug the right edge and neither spills over the members cell.
- `CommunitiesList.vue`: lists every visible community instead of only manageable ones.
- Communities tab and its command-palette entry: shown to any non-guest.
- `SpaceOptions.vue`: the options menu no longer renders when a user can take none of its actions.
- `NoCommunities.vue`: points a member at the Communities tab when something is there to join.
- `CommunitiesSettings.vue`: a "Customize sidebar" button in the tab header opens the same dialog the app menu opens. Joining decides which communities exist in the sidebar; that dialog decides which of them show, and in what order. Beside "New community" the header has no room to spare, so a manager gets the icon alone with the label in a tooltip.

## Demo

One pass through the tab as a plain member: join Alpha, open Customize sidebar, look at Alpha's spaces (no admin actions there), then leave again.

![join, customize, leave](https://md.netchamp.dev/gameplan-join-leave-community/demo-v4.gif)

MP4 of the same pass: https://md.netchamp.dev/gameplan-join-leave-community/demo-v4.mp4


## Screenshots

Before — the Communities tab is not in the dialog at all for a plain member:

![before](https://md.netchamp.dev/gameplan-join-leave-community/before-1.png)

After — the tab is there, each row has Join, and no management actions appear:

![after](https://md.netchamp.dev/gameplan-join-leave-community/after-1-v3.png)

After joining Alpha — the button becomes Leave, the member count rises, and Alpha enters the app rail:

![after joining](https://md.netchamp.dev/gameplan-join-leave-community/after-2-v3.png)

The customize dialog opens over the settings dialog and takes the focus:

![customize sidebar over the settings dialog](https://md.netchamp.dev/gameplan-join-leave-community/customize-v3.png)

A manager sees the same rows plus New community, the row options menu, and the image uploader. Leave and the options button sit together at the right edge, and Customize sidebar drops to an icon:

![communities tab for an admin](https://md.netchamp.dev/gameplan-join-leave-community/admin-v2.png)

A community admin sees this on their own community only: options and the uploader on that row, none on the others, and no New community button.

## 3. Space actions a member cannot use

Opening the Communities tab to everyone put a plain member in front of each community's Spaces screen, which offered actions the backend refuses:

- The per-space menu listed **Change Community, Merge, Delete** for any signed-in user, because `canEditSpace` only asked whether the space was live and not in read-only mode. The title field and icon picker used the same flag.
- **New space** rendered disabled instead of hidden.

The API was never at risk — as a non-member, rename, change-community and delete all return `HTTP 403 PermissionError` — so this was dead UI that ends in an error toast. It predates this PR (the same menu shows on any public space page), but the new tab is where a member meets it first.

`useSpacePermissions` now exposes `canEditSettings` (`canEditSpace` **and** the frontend mirror of backend `can_manage_space`), and every action that writes GP Project is gated on it. The space header menu uses it for Archive too, so both menus read from one flag.

Before — a member who belongs to no community, on Alpha's spaces:

![space options offered to a plain member](https://md.netchamp.dev/gameplan-join-leave-community/spaces-before.png)

After:

![no space management actions](https://md.netchamp.dev/gameplan-join-leave-community/spaces-after.png)

## Verification

Backend, worktree code against the demo site:

```
bench --site gameplan-demo.test run-tests --app gameplan --module gameplan.tests.features.test_communities
...
Ran 24 tests in 1.760s

OK
```

Ten of those are new: join public, idempotent join, private refused, archived refused, guest refused, leave, leave keeps private-space membership, leave when not a member, sole admin blocked, admin leaves when another admin remains.

Cypress — the new spec plus every space and community spec, to check the permission change did not take anything away from an admin:

```
       Spec                                              Tests  Passing  Failing
  ┌───────────────────────────────────────────────────────────────────────────────┐
  │ ✔  spaces/archived-content.cy.ts            00:14        2        2        -  │
  │ ✔  spaces/membership.cy.ts                  00:14        4        4        -  │
  │ ✔  spaces/move-and-archive.cy.ts            00:11        2        2        -  │
  │ ✔  spaces/space-creation-guardrails.cy.ts   00:05        2        2        -  │
  │ ✔  communities/join-leave.cy.ts             00:14        7        7        -  │
  │ ✔  communities/merge-url-healing.cy.ts      00:10        1        1        -  │
  │ ✔  shell/command-palette.cy.ts              00:13        5        5        -  │
  └───────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                        01:24       23       23        -
```

`join-leave.cy.ts` carries seven tests: join, leave with confirm, no community management for a member, no space management for a member, both kept for an admin, and the customize dialog opening from the tab.

Shell and profile specs for change 1:

```
       Spec                                              Tests  Passing  Failing
  ┌───────────────────────────────────────────────────────────────────────────────┐
  │ ✔  shell/command-palette.cy.ts              00:15        5        5        -  │
  │ ✔  shell/community-routing.cy.ts            00:08        3        3        -  │
  │ ✔  shell/community-shell.cy.ts              00:06        3        3        -  │
  │ ✔  shell/community-switching.cy.ts          00:11        3        3        -  │
  │ ✔  shell/scoped-links.cy.ts                 00:11        3        3        -  │
  │ ✔  shell/settings-menu.cy.ts                00:07        2        2        -  │
  │ ✔  profile/profile-card-editing.cy.ts       00:19        7        7        -  │
  └───────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                        01:19       26       26        -
```

Also walked the join → leave loop in a browser: button state, toast, confirm copy, rail entry.

Not done: the mobile More menu still has no settings entry, so join and leave are desktop-only. The settings dialog is desktop-only there by design (`mobile/more-pages.cy.ts` asserts it), so that is a separate decision. Screenshots are hosted outside GitHub because this branch was pushed from a CLI session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


