### PR TITLE
fix: merge dialog navigation and global admin access to private communities

### DIFF
--- a/frontend/src/components/MergeSpaceDialog.vue
+++ b/frontend/src/components/MergeSpaceDialog.vue
@@ -39,20 +39,26 @@
 </template>
 <script setup lang="ts">
 import { computed, ref } from 'vue'
-import { useRouter } from 'vue-router'
 import { Combobox } from 'frappe-ui'
 import { useGroupedSpaceOptions } from '@/data/groupedSpaces'
 import { useDoctype } from 'frappe-ui'
 import { GPProject } from '@/types/doctypes'
-import { getSpace, useSpace } from '@/data/spaces'
+import { spaces as spaceList, useSpace } from '@/data/spaces'
 import { useSessionUser } from '@/data/users'
 import { canManageSpace, isGuest } from '@/utils/permissions'
 
 const props = defineProps<{
   spaceId: string
 }>()
+/**
+ * Where to go after a merge is the caller's decision, not this dialog's. Merging from the
+ * space you are reading has to move you off it; merging from a list of spaces should leave
+ * you on that list. Same split as MergeCommunityDialog.
+ */
+const emit = defineEmits<{
+  (event: 'merged', spaceId: string): void
+}>()
 
-const router = useRouter()
 const spaces = useDoctype<GPProject>('GP Project')
 const space = useSpace(() => props.spaceId)
 const sessionUser = useSessionUser()
@@ -105,16 +111,17 @@ function submit() {
         }
       },
     })
-    .then(() => {
-      if (selectedSpace.value) {
-        show.value = false
-        return router.replace({
-          name: 'Space',
-          params: {
-            communityId: getSpace(selectedSpace.value)?.team,
-            spaceId: selectedSpace.value,
-          },
-        })
+    .then(async () => {
+      const targetSpace = selectedSpace.value
+      // Close before reloading: this space no longer exists, so a reload while the dialog
+      // is still open re-renders it with an empty target list.
+      show.value = false
+      // The merged space is gone on the server. Until the list is refetched it stays in
+      // every space picker, and merging it a second time comes back as a raw
+      // "GP Project <id> not found".
+      await spaceList.reload()
+      if (targetSpace) {
+        emit('merged', targetSpace)
       }
     })
 }

--- a/frontend/src/components/SpaceOptions.vue
+++ b/frontend/src/components/SpaceOptions.vue
@@ -9,7 +9,11 @@
     :options="permittedOptions"
   />
 
-  <MergeSpaceDialog v-model="showSpaceMergeDialog" :spaceId="props.spaceId" />
+  <MergeSpaceDialog
+    v-model="showSpaceMergeDialog"
+    :spaceId="props.spaceId"
+    @merged="emit('merged', $event)"
+  />
   <ChangeSpaceCategoryDialog v-model="showSpaceCategoryDialog" :spaceId="props.spaceId" />
   <SpaceAccessDialog v-model="showSpaceAccessDialog" :spaceId="props.spaceId" />
 </template>
@@ -30,6 +34,9 @@ defineOptions({
 
 const props = defineProps<{
   spaceId: string
+}>()
+const emit = defineEmits<{
+  (event: 'merged', spaceId: string): void
 }>()
 
 const { space, canEditSettings, canManageAccess } = useSpacePermissions(() => props.spaceId)

--- a/gameplan/gameplan/doctype/gp_team/gp_team.py
+++ b/gameplan/gameplan/doctype/gp_team/gp_team.py
@@ -10,7 +10,11 @@ from pypika.terms import ExistsCriterion
 
 import gameplan
 from gameplan.mixins.archivable import Archivable
-from gameplan.permissions import apply_team_query_filter, require_can_manage_community
+from gameplan.permissions import (
+	apply_team_query_filter,
+	is_global_admin,
+	require_can_manage_community,
+)
 from gameplan.utils import validate_type
 
 
@@ -19,8 +23,17 @@ class GPTeam(Archivable, Document):
 	on_delete_set_null = ["GP Notification"]
 
 	def as_dict(self, *args, **kwargs) -> dict:
-		members = [m.user for m in self.members]
-		if self.is_private and frappe.session.user not in members:
+		"""Hide a private community from everyone but its members and global admins.
+
+		The admin bypass is not cosmetic. `frappe.api.v2.execute_doc_method` serialises the
+		document with `as_dict` AFTER running the requested method, so a throw here loses the
+		write that already ran: the request ends in a rollback and the admin sees only
+		"Not permitted". That silently broke every whitelisted method on a private community
+		an admin does not belong to — archive, merge_into_team, add_members, remove_member,
+		set_member_admin — even though `can_manage_community` grants all of them.
+		"""
+		user = frappe.session.user
+		if self.is_private and not is_global_admin(user) and user not in [m.user for m in self.members]:
 			frappe.throw("Not permitted", frappe.PermissionError)
 
 		d = super().as_dict(*args, **kwargs)

--- a/gameplan/tests/features/test_communities.py
+++ b/gameplan/tests/features/test_communities.py
@@ -425,3 +425,42 @@ class TestCommunityJoinLeave(GameplanTestCase):
 			leave_team(community.name)
 
 		self.assertFalse(self._is_member(community, self.member))
+
+
+class TestPrivateCommunitySerialisation(GameplanTestCase):
+	"""`GPTeam.as_dict` hides a private community from outsiders, but not from admins.
+
+	`frappe.api.v2.execute_doc_method` serialises the document AFTER running the requested
+	method, so a throw here does not just hide a field: it discards the write that already
+	ran and answers "Not permitted". Every whitelisted method on a private community an
+	admin does not belong to used to fail that way.
+	"""
+
+	def test_global_admin_can_serialise_a_private_community_they_do_not_belong_to(self):
+		community = create_community("Admin Serialised Community", is_private=1, admins=[self.member])
+
+		with self.as_user(self.admin):
+			self.assertEqual(community.as_dict().title, "Admin Serialised Community")
+
+	def test_member_of_a_private_community_can_serialise_it(self):
+		community = create_community("Member Serialised Community", is_private=1, members=[self.member])
+
+		with self.as_user(self.member):
+			self.assertEqual(community.as_dict().title, "Member Serialised Community")
+
+	def test_outsider_cannot_serialise_a_private_community(self):
+		community = create_community("Hidden Community", is_private=1, admins=[self.member])
+
+		with self.as_user(self.outsider), self.assertRaises(frappe.PermissionError):
+			community.as_dict()
+
+	def test_global_admin_archives_a_private_community_and_the_response_serialises(self):
+		community = create_community("Admin Archived Community", is_private=1, admins=[self.member])
+
+		# The two steps execute_doc_method runs, in order. The archive used to be rolled
+		# back because the serialisation that follows it threw.
+		with self.as_user(self.admin):
+			community.archive()
+			community.as_dict()
+
+		self.assertTrue(frappe.db.get_value("GP Team", community.name, "archived_at"))


### PR DESCRIPTION
Two fixes from bugs Neha reported on Raven for partners.frappe.io. One commit each.

## Merge dialog navigated away from Settings

Merging a space from Settings → Communities closed the settings dialog and dropped the user on the merge target.

Where to go after a merge belongs to the entry point, not to the dialog. Merging the space you are reading has to move you off it. Merging from a list should leave you on that list.

`MergeSpaceDialog` now closes, reloads the space list, and emits `merged` with the target id. `SpaceOptions` forwards the event. That is the same split `MergeCommunityDialog` already uses. The one caller today is the settings space list, which stays where it is.

The list reload is part of this fix, not a spare change. The merged space is gone on the server, and until the list is refetched it stays in every space picker. Merging it a second time comes back as a raw `DoesNotExistError: GP Project <id> not found`, which is the error in Neha's recording.

## Global admin could not act on a private community

`GPTeam.as_dict` hid a private community from anyone outside its member list, global admins included.

`frappe.api.v2.execute_doc_method` serialises the document **after** running the requested method. The throw did not just hide a field: it discarded the write that had already run and answered `PermissionError: Not permitted`.

Every whitelisted method on a private community an admin did not belong to failed that way: `archive`, `merge_into_team`, `add_members`, `remove_member`, `set_member_admin`. `can_manage_community` grants all of them. On partners.frappe.io an admin could not archive a community a member had created.

Outsiders are still refused.

## Verification

- 4 new backend tests in `test_communities.py`. They fail on `develop` (2 errors) and pass here.
- Full backend suite run module by module. Two modules fail, `test_profiles` (17 errors) and `test_reactions` (7 failures), with identical counts on clean `develop`. Pre-existing, unrelated.
- Merge flow driven in a real browser against a local site: one POST, settings dialog stays open on the community's space list, the merged space disappears from the list, URL unchanged at `/g/settings/communities/<id>/spaces`.
- `pre-commit` clean. `yarn build` passes.

## Not in this PR

- `discussions_count` and `tasks_count` are not recomputed on the merge target, so a merged-into space keeps showing "No content" in Settings. There is no `after_rename` on `GPProject`. Reproduced but left alone.
- `merge_with_project` is still not idempotent and still surfaces the raw `DoesNotExistError` if a stale client retries.
- Members can still create communities and spaces (`create: 1` for `Gameplan Member` on `GP Team` and `GP Project`). That needs a product decision, not a bug fix.