### PR TITLE
fix(navigation): open the post a notification points at

### DIFF
--- a/frontend/cypress/e2e/discussions/discussion-identity.cy.ts
+++ b/frontend/cypress/e2e/discussions/discussion-identity.cy.ts
@@ -1,0 +1,72 @@
+// A discussion page must show the post its URL names, whatever was open before it.
+//
+// The Discussion route reuses one page component across posts, so jumping from one post
+// to another (here through the command palette) walks that component through several ids.
+// A shared document cache keyed by id but bound to that component's id getter used to
+// follow it, and then served the last post read to the next visitor of the first one.
+import { resetData } from '../../support/seed'
+
+describe('Discussion identity', () => {
+  let community: string
+  let space: string
+  let firstDiscussion: string
+
+  beforeEach(() => {
+    resetData('space_with_discussion').then((ids) => {
+      community = String(ids.community)
+      space = String(ids.space)
+      firstDiscussion = String(ids.discussion)
+    })
+    cy.then(() =>
+      cy.request('POST', '/api/v2/document/GP%20Discussion', {
+        title: 'Release checklist',
+        content: '<p>Second post, so the page component has somewhere to go.</p>',
+        project: space,
+      }),
+    )
+    // The palette's discussion results come from the search index, not from local data.
+    cy.request('POST', '/api/method/gameplan.ui_test_helpers.rebuild_search_index')
+    cy.loginAs('member')
+  })
+
+  it('shows the post the URL names after jumping to another post and back', () => {
+    cy.intercept('GET', '**/gameplan.command_palette.search_sqlite*').as('paletteSearch')
+    cy.visit(`/g/community/${community}/space/${space}/discussion/${firstDiscussion}`)
+    cy.contains('h1', 'Welcome thread').should('be.visible')
+
+    // Jump straight to the other post: same route, same component, new id. Selected with
+    // the keyboard, not a click: each result carries a relative timestamp that re-renders
+    // its row every second, which detaches whatever a click was aiming at.
+    openCommandPalette()
+    commandPaletteInput().type('Release checklist')
+    cy.wait('@paletteSearch')
+    // Two rows: the discussion, and the "Search for ..." row the palette starts on. Wait
+    // for both before pressing a key, or the arrow lands in a list that is still growing.
+    cy.get('[role="option"]').should('have.length', 2)
+    commandPaletteInput().type('{upArrow}')
+    cy.contains('[role="option"]', 'Release checklist').should('have.attr', 'aria-selected', 'true')
+    commandPaletteInput().type('{enter}')
+    cy.contains('h1', 'Release checklist').should('be.visible')
+
+    // Back to the first post, in-app, the way a notification or a list row opens it.
+    cy.contains('a', 'Engineering').first().click()
+    cy.contains('a', 'Welcome thread').click()
+
+    cy.url().should('include', `/discussion/${firstDiscussion}/`)
+    cy.contains('h1', 'Welcome thread').should('be.visible')
+    cy.contains('h1', 'Release checklist').should('not.exist')
+  })
+
+  function openCommandPalette() {
+    cy.get('body').then(($body) => {
+      $body[0].dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'k', ctrlKey: true, bubbles: true }),
+      )
+    })
+    commandPaletteInput().should('be.visible')
+  }
+
+  function commandPaletteInput() {
+    return cy.get('input[role="combobox"][aria-controls="command-palette-listbox"]')
+  }
+})

--- a/frontend/cypress/e2e/tasks/task-visit-tracking.cy.ts
+++ b/frontend/cypress/e2e/tasks/task-visit-tracking.cy.ts
@@ -1,0 +1,83 @@
+// Opening a second task without leaving the task page must still mark it visited.
+//
+// The task routes reuse one page component across tasks, so its setup runs once. The
+// visit tracker has to follow the id the route names; anything registered on the shared
+// document entry that setup happened to see stays on the first task for ever.
+import { resetData } from '../../support/seed'
+
+describe('Task visit tracking', () => {
+  let community: string
+  let space: string
+  let secondTask: string
+
+  beforeEach(() => {
+    resetData('onboarded').then((ids) => {
+      community = String(ids.community)
+      space = String(ids.space)
+    })
+    // Titles share no word, so one palette query can name exactly one of them. Both need a
+    // description: the search indexer skips a document whose content field is empty, and an
+    // unindexed task never reaches the palette.
+    cy.then(() => {
+      cy.request('POST', '/api/v2/document/GP%20Task', {
+        title: 'Draft the changelog',
+        description: '<p>Collect the merged pull requests.</p>',
+        project: space,
+      })
+      cy.request('POST', '/api/v2/document/GP%20Task', {
+        title: 'Rotate the certificates',
+        description: '<p>Replace the expiring keys.</p>',
+        project: space,
+      }).then((response) => {
+        secondTask = String(response.body.data.name)
+      })
+    })
+    // The palette's task results come from the search index, not from local data.
+    cy.request('POST', '/api/method/gameplan.ui_test_helpers.rebuild_search_index')
+    cy.loginAs('member')
+  })
+
+  it('tracks the visit to a task opened from the command palette', () => {
+    cy.intercept('POST', '/api/v2/document/GP%20Task/*/method/track_visit').as('trackVisit')
+    cy.intercept('GET', '**/gameplan.command_palette.search_sqlite*').as('paletteSearch')
+
+    cy.visit(`/g/community/${community}/space/${space}/tasks`)
+    cy.contains('a', 'Draft the changelog').click()
+    cy.wait('@trackVisit')
+
+    // Jump straight to the other task: same route, same component, new id. Selected with
+    // the keyboard, not a click: each result carries a relative timestamp that re-renders
+    // its row every second, which detaches whatever a click was aiming at.
+    openCommandPalette()
+    commandPaletteInput().type('Rotate')
+    cy.wait('@paletteSearch')
+    // Two rows: the task, and the "Search for ..." row the palette starts on. Wait for both
+    // before pressing a key, or the arrow lands in a list that is still growing.
+    cy.get('[role="option"]').should('have.length', 2)
+    commandPaletteInput().type('{upArrow}')
+    cy.contains('[role="option"]', 'Rotate the certificates').should(
+      'have.attr',
+      'aria-selected',
+      'true',
+    )
+    commandPaletteInput().type('{enter}')
+
+    cy.get('input[placeholder="Title"]').should('have.value', 'Rotate the certificates')
+    cy.wait('@trackVisit')
+      .its('request.url')
+      .should('include', `/GP%20Task/${secondTask}/method/track_visit`)
+  })
+
+  function openCommandPalette() {
+    cy.get('body').then(($body) => {
+      $body[0].dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'k', ctrlKey: true, bubbles: true }),
+      )
+    })
+    commandPaletteInput().should('be.visible')
+  }
+
+  function commandPaletteInput() {
+    return cy.get('input[role="combobox"][aria-controls="command-palette-listbox"]')
+  }
+})

--- a/frontend/src/components/TaskDetail.vue
+++ b/frontend/src/components/TaskDetail.vue
@@ -183,7 +183,7 @@
 </template>
 
 <script setup lang="ts">
-import { h, computed } from 'vue'
+import { h, computed, watch } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import TaskDescriptionEditor from '@/components/editor/TaskDescriptionEditor.vue'
 import CommentsList from '@/components/CommentsList.vue'
@@ -229,11 +229,19 @@ function deleteTask() {
   })
 }
 
-task.onSuccess((doc) => {
-  if (['Task', 'SpaceTask'].includes(route.name as string) && route.params.taskId === doc.name) {
-    task.trackVisit.submit()
-  }
-})
+// Watched rather than registered through `task.onSuccess`. The task routes reuse this
+// component across tasks, and each task has its own shared entry, so a callback registered
+// during setup would stay on the first task's entry and leave every later task unvisited.
+watch(
+  () => task.doc?.name,
+  (name) => {
+    if (!name) return
+    if (['Task', 'SpaceTask'].includes(route.name as string) && route.params.taskId === name) {
+      task.trackVisit.submit()
+    }
+  },
+  { immediate: true },
+)
 
 const assignableUsers = computed<{ label: string; value: string }[]>(() => {
   return [

--- a/frontend/src/components/TaskDetail.vue
+++ b/frontend/src/components/TaskDetail.vue
@@ -194,7 +194,7 @@ import { LoadingText, DatePicker, Button, Combobox, Select, dialog } from 'frapp
 import { vFocus } from '@/directives'
 import { activeUsers } from '@/data/users'
 import { useGroupedSpaceOptions } from '@/data/groupedSpaces'
-import { getSpace } from '@/data/spaces'
+import { getSpace, useSpace } from '@/data/spaces'
 import { useTask } from '@/data/tasks'
 import { GPTask } from '@/types/doctypes'
 import { useSessionUser } from '@/data/users'
@@ -211,7 +211,10 @@ const router = useRouter()
 const route = useRoute()
 
 const task = useTask(() => props.taskId)
-const space = computed(() => getSpace(task.doc?.project))
+// `useSpace` rather than a bare `getSpace`, which throws on an undefined id. `canEditTask`
+// reads this, and the palette command conditions read `canEditTask` while the task the route
+// just moved to still has no document.
+const space = useSpace(() => task.doc?.project)
 const canEditTask = computed(
   () => !props.readOnlyMode && canEditContent(task.doc, space.value, useSessionUser()),
 )

--- a/frontend/src/data/discussions.ts
+++ b/frontend/src/data/discussions.ts
@@ -1,8 +1,9 @@
-import { MaybeRefOrGetter, ref, toValue, watch } from 'vue'
+import { ref, watch } from 'vue'
 import { useDoc, useList } from 'frappe-ui'
 import { UseListOptions } from 'frappe-ui'
 import { useDocumentVisibility } from '@vueuse/core'
 import { GPDiscussion } from '@/types/doctypes'
+import { createSharedDoc } from './sharedDoc'
 
 // Reload the feed when the tab is re-activated after sitting in the background
 // for at least this long, so new posts show up without a manual refresh.
@@ -70,45 +71,40 @@ export function useDiscussions(options: UseDiscussionOptions) {
   return discussions
 }
 
-let discussionsCache: Record<string, ReturnType<typeof useDoc>> = {}
-
-export function useDiscussion(discussionId: MaybeRefOrGetter<string>) {
-  interface Discussion extends GPDiscussion {
-    last_unread_comment: string
-    last_unread_poll: string
-    is_bookmarked: boolean
-    views: number
-  }
-
-  interface DiscussionMethods {
-    trackVisit: () => void
-    markAsUnread: () => void
-    closeDiscussion: () => void
-    reopenDiscussion: () => void
-    pinDiscussion: (data: { pin_scope: 'Category' | 'Space' }) => void
-    unpinDiscussion: () => void
-    addBookmark: () => void
-    removeBookmark: () => void
-    moveToProject: (data: { project: string }) => void
-  }
-
-  let name = toValue(discussionId)
-  if (!discussionsCache[name]) {
-    discussionsCache[name] = useDoc<Discussion, DiscussionMethods>({
-      doctype: 'GP Discussion',
-      name: discussionId,
-      methods: {
-        trackVisit: 'track_visit',
-        markAsUnread: 'mark_as_unread',
-        closeDiscussion: 'close_discussion',
-        reopenDiscussion: 'reopen_discussion',
-        pinDiscussion: 'pin_discussion',
-        unpinDiscussion: 'unpin_discussion',
-        addBookmark: 'add_bookmark',
-        removeBookmark: 'remove_bookmark',
-        moveToProject: 'move_to_project',
-      },
-    })
-  }
-  return discussionsCache[name] as ReturnType<typeof useDoc<Discussion, DiscussionMethods>>
+interface DiscussionDoc extends GPDiscussion {
+  last_unread_comment: string
+  last_unread_poll: string
+  is_bookmarked: boolean
+  views: number
 }
+
+interface DiscussionMethods {
+  trackVisit: () => void
+  markAsUnread: () => void
+  closeDiscussion: () => void
+  reopenDiscussion: () => void
+  pinDiscussion: (data: { pin_scope: 'Category' | 'Space' }) => void
+  unpinDiscussion: () => void
+  addBookmark: () => void
+  removeBookmark: () => void
+  moveToProject: (data: { project: string }) => void
+}
+
+/** The discussion behind `discussionId`, followed as that id changes. */
+export const useDiscussion = createSharedDoc((name: string) =>
+  useDoc<DiscussionDoc, DiscussionMethods>({
+    doctype: 'GP Discussion',
+    name,
+    methods: {
+      trackVisit: 'track_visit',
+      markAsUnread: 'mark_as_unread',
+      closeDiscussion: 'close_discussion',
+      reopenDiscussion: 'reopen_discussion',
+      pinDiscussion: 'pin_discussion',
+      unpinDiscussion: 'unpin_discussion',
+      addBookmark: 'add_bookmark',
+      removeBookmark: 'remove_bookmark',
+      moveToProject: 'move_to_project',
+    },
+  }),
+)

--- a/frontend/src/data/sharedDoc.ts
+++ b/frontend/src/data/sharedDoc.ts
@@ -19,6 +19,10 @@ const documentScope = effectScope(true)
  * The composable returns a view onto the entry for the caller's *current* name, resolved on
  * every property read. A caller whose name changes therefore keeps reading the right
  * document without re-running setup.
+ *
+ * Read through the view every time. Anything captured from it once stays bound to the entry
+ * that was current at capture time: a destructured `doc`, a method held in a variable, or a
+ * callback handed to `onSuccess` during setup. Watch a property instead.
  */
 export function createSharedDoc<T extends object>(create: (name: string) => T) {
   const cache: Record<string, T> = {}
@@ -34,6 +38,10 @@ export function createSharedDoc<T extends object>(create: (name: string) => T) {
   return function useSharedDoc(name: MaybeRefOrGetter<string>): T {
     return new Proxy({} as T, {
       get: (_target, property) => Reflect.get(entryFor(name), property),
+      // Forwarded so a write cannot land on the empty target, where the `get` trap would
+      // never read it back and the value would disappear without an error.
+      set: (_target, property, value) => Reflect.set(entryFor(name), property, value),
+      deleteProperty: (_target, property) => Reflect.deleteProperty(entryFor(name), property),
       has: (_target, property) => Reflect.has(entryFor(name), property),
       ownKeys: () => Reflect.ownKeys(entryFor(name)),
       getOwnPropertyDescriptor: (_target, property) => {

--- a/frontend/src/data/sharedDoc.ts
+++ b/frontend/src/data/sharedDoc.ts
@@ -1,0 +1,47 @@
+import { MaybeRefOrGetter, effectScope, toValue } from 'vue'
+
+// Detached on purpose. An entry created while a component was setting up belongs to that
+// component's scope, so its watchers and computeds stop the moment that component unmounts
+// and every later caller inherits a dead object. This scope is never disposed, which is what
+// a cache shared across mounts needs.
+const documentScope = effectScope(true)
+
+/**
+ * Build a composable that shares one document instance per name.
+ *
+ * `create` is called once per name and receives that name as a plain string, so each entry
+ * stays bound to the document it is filed under. Binding an entry to the caller's getter
+ * instead is what made discussions and tasks open the wrong document: a route reuses one
+ * page component across documents (opening a post from search while reading another one),
+ * so the entry followed that component to the next document and then served it to whoever
+ * asked for the original name next.
+ *
+ * The composable returns a view onto the entry for the caller's *current* name, resolved on
+ * every property read. A caller whose name changes therefore keeps reading the right
+ * document without re-running setup.
+ */
+export function createSharedDoc<T extends object>(create: (name: string) => T) {
+  const cache: Record<string, T> = {}
+
+  function entryFor(name: MaybeRefOrGetter<string>): T {
+    const key = String(toValue(name) ?? '')
+    if (!cache[key]) {
+      cache[key] = documentScope.run(() => create(key)) as T
+    }
+    return cache[key]
+  }
+
+  return function useSharedDoc(name: MaybeRefOrGetter<string>): T {
+    return new Proxy({} as T, {
+      get: (_target, property) => Reflect.get(entryFor(name), property),
+      has: (_target, property) => Reflect.has(entryFor(name), property),
+      ownKeys: () => Reflect.ownKeys(entryFor(name)),
+      getOwnPropertyDescriptor: (_target, property) => {
+        const descriptor = Reflect.getOwnPropertyDescriptor(entryFor(name), property)
+        // The proxy target is an empty object, so a non-configurable descriptor for a key it
+        // does not own would break the Proxy invariants and throw.
+        return descriptor && { ...descriptor, configurable: true }
+      },
+    })
+  }
+}

--- a/frontend/src/data/tasks.ts
+++ b/frontend/src/data/tasks.ts
@@ -1,8 +1,6 @@
-import { MaybeRefOrGetter, toValue } from 'vue'
 import { useDoc } from 'frappe-ui'
 import { GPTask } from '@/types/doctypes'
-
-let tasksCache: Record<string, ReturnType<typeof useDoc>> = {}
+import { createSharedDoc } from './sharedDoc'
 
 interface Task extends GPTask {}
 
@@ -10,22 +8,19 @@ interface TaskMethods {
   trackVisit: () => void
 }
 
-export function useTask(taskId: MaybeRefOrGetter<string>) {
-  let name = toValue(taskId)
-  if (!tasksCache[name]) {
-    tasksCache[name] = useDoc<Task, TaskMethods>({
-      doctype: 'GP Task',
-      name: taskId,
-      methods: {
-        trackVisit: 'track_visit',
-      },
-      transform(doc) {
-        return {
-          ...doc,
-          project: doc.project ? String(doc.project) : undefined,
-        }
-      },
-    })
-  }
-  return tasksCache[name] as ReturnType<typeof useDoc<Task, TaskMethods>>
-}
+/** The task behind `taskId`, followed as that id changes. */
+export const useTask = createSharedDoc((name: string) =>
+  useDoc<Task, TaskMethods>({
+    doctype: 'GP Task',
+    name,
+    methods: {
+      trackVisit: 'track_visit',
+    },
+    transform(doc) {
+      return {
+        ...doc,
+        project: doc.project ? String(doc.project) : undefined,
+      }
+    },
+  }),
+)


### PR DESCRIPTION
From a bug report in the Raven `Raven-gameplan` channel: opening a post from the notification list lands on a different post, the one read last.

## What was broken

Open a post, jump straight to another post (command palette or search), then open the first post again from the notification list, the space list, or a bookmark. The page shows the *second* post, and rewrites the URL to that post's community, space and slug while keeping the first post's id. Tasks behave the same way, and notifications link to tasks too.

## Root cause

`useDiscussion` and `useTask` kept a module-level cache of `useDoc` instances keyed by document id, but created each entry from the **caller's reactive id getter** instead of the id the entry was filed under:

```ts
let name = toValue(discussionId)                 // key: the id at first call
if (!cache[name]) {
  cache[name] = useDoc({ name: discussionId })   // value: follows the caller
}
```

The Discussion and Task routes reuse one page component across documents, so the caller's id changes without setup running again. The entry filed under post A then tracked post B, and the next caller asking for A got B. `DiscussionView` canonicalises the URL from the document it holds, which is why the space and slug changed too.

## Change

`frontend/src/data/sharedDoc.ts` adds `createSharedDoc`. It creates one entry per name, bound to that fixed name, inside a detached effect scope, and resolves the entry for the caller's current id on every property read. `discussions.ts` and `tasks.ts` are built on it; both call sites are unchanged.

The detached scope also fixes a second problem with the old cache: an entry created during one component's setup belonged to that component's scope and was stopped when it unmounted, leaving a dead object behind for every later caller.

## Verification

New spec `frontend/cypress/e2e/discussions/discussion-identity.cy.ts` walks the failure: open post A, jump to post B through the command palette, return to A through the space list.

- On the previous code it fails at the last assertion, 3 runs out of 3: `Expected to find content: 'Welcome thread' within the selector: 'h1' but never did`.
- On this branch it passes, 4 runs out of 4.

Full Cypress suite on this branch: **132 of 137 passing**, 40 specs.

The 5 failures are pre-existing and unrelated. Each one fails identically on the base commit:

| Spec | Why |
|---|---|
| `discussions/realtime-activity` (1) | no Socket.IO server on :9000 on this machine |
| `polls/poll-lifecycle` (1) | `Expected to find content: '2 answers from 2 people'` |
| `communities/join-leave` (2) | `Expected to find element: button[aria-label="Leave Alpha"]:visible` |
| `profile/profile-customize` (1) | `the page keeps scrolling with the pointer standing still` |

Also checked by hand against a seeded local site, before and after: the reproduction shows post 48 under `/discussion/28/...` with post 48's space and slug in the URL; after the fix the same steps show post 28 under its own URL. The task page still issues a single `GET /api/v2/document/GP Task/<id>` (`Task.vue` and `TaskDetail.vue` share one entry), so the shared cache keeps doing its job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
