### PR TITLE
docs: cut AGENTS.md to what the code cannot teach

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,87 +1,76 @@
 # Gameplan
 
-Async-first discussions tool for remote teams. Frappe (Python) backend + Vue 3 / TypeScript SPA frontend.
+Async-first discussions tool for remote teams. Frappe (Python) backend + Vue 3 /
+TypeScript SPA served at `/g`.
 
-## Architecture
+Backend in `gameplan/`, frontend in `frontend/src/` (`components/`, `pages/`,
+`data/` for fetching composables, `utils/`).
 
-- **Dual app**: Frappe app serving a Vue SPA at the `/g` route via `gameplan/www/g.py` (boot data) and `gameplan/api.py` (whitelisted endpoints). Real-time via Socket.IO.
-- **Backend**: DocTypes in `gameplan/gameplan/doctype/`. MariaDB. Full-text search via SQLite FTS5 (`gameplan.search_sqlite.GameplanSearch`, wired in `hooks.py`).
-- **Frontend**: `frontend/src/` — `components/` (shared), `pages/`, `data/` (fetching composables), `utils/`. Vue Router under `/g/`. No state libraries (use `ref`/`computed`).
-- **frappe-ui**: local copy in `./frappe-ui/` (git submodule). TS types auto-generated from the doctype list in `frontend/vite.config.ts`.
+**The code is the source of truth for conventions.** It is consistent — find the
+nearest precedent and copy it. This file covers only what the code cannot tell you.
+Where a trap or policy below contradicts the precedent you found, this file wins.
 
-## Product language vs. schema
+## Naming: product vs schema
 
-UI/product language is **Community** and **Space**; the schema still uses old names. Use Community/Space in app/UI code; the doctype names stay as-is until a migration is planned.
+New code, UI copy and commit messages say **Space** and **Community**. The schema
+still carries the old names. Do not rename the doctypes.
 
-- `GP Project` = **Space** (holds discussions, tasks, pages)
-- `GP Team` = **Community** (groups spaces; "Category" in older UI)
-- Other core doctypes: `GP Discussion`, `GP Comment`, `GP Page`, `GP Task`, `GP User Profile`
+- `GP Project` = Space
+- `GP Team` = Community
 
-## Commands
+## Where the non-obvious things live
 
-Local site names vary by development environment. This repository's local test commands use the
-disposable `gameplan-demo.test` site; CI uses `gameplan.test`.
+- Boot data: `gameplan/www/g.py`. Whitelisted endpoints: `gameplan/api.py`, plus
+  document methods on the doctype classes.
+- Permissions: `gameplan/permissions.py` and the `has_permission` hooks in `hooks.py`.
+- Full-text search: `gameplan/search_sqlite.py` (SQLite FTS5 in its own per-site
+  file), registered once in `hooks.py`. Async index queue drained by cron.
+- Patches sit next to their doctype in `gameplan/gameplan/doctype/<dt>/patches/`,
+  registered in `gameplan/patches.txt`. App-level `gameplan/patches/` is for
+  cross-doctype work only.
 
-- `yarn dev` — Vite frontend on :8080 (unlinks local frappe-ui, uses published package)
-- `yarn dev:frappe-ui` — same, but symlinks `node_modules/frappe-ui` → `./frappe-ui/` for library work
-- `yarn build` / `bench start` (from `frappe-bench/`) — build frontend / run backend
-- Backend tests: `bench --site gameplan-demo.test run-tests --app gameplan` (or `--module <path>`, `--test <method>`).
-- E2E: `cd frontend && yarn test` (Cypress, specs in `frontend/cypress/e2e/`). **Always run Cypress against the demo site `gameplan-demo.test`, never another local site** — specs call `gameplan.ui_test_helpers.reset`, which deletes ALL Gameplan data on whichever site the request resolves to. `resetData` now probes the responding site's own name first and fails the spec if it is not the site `baseUrl` names, but the seed API also has to be _switched on_, which takes three things (see TESTING.md §3 "Enabling the seed API"): `enable_ui_tests: 1` and `allow_tests: 1` in that site's `site_config.json`, and a server started as a dev server — `bench start`, or `DEV_SERVER=1 bench --site gameplan-demo.test serve --port 8002`. A plain `bench serve` does not set `DEV_SERVER`, so the seed endpoints refuse and every spec fails in `beforeEach`.
-- frappe-ui units: `cd frappe-ui && yarn test` (Vitest)
-- Lint: `pre-commit run --all-files` (ruff for Python — tabs, double quotes, line 110; Prettier for frontend)
-- Login over HTTP with a seeded user and password `admin`:
-  `curl -sS -c jar -X POST http://gameplan-demo.test:8002/api/method/login
-  --data-urlencode 'usr=<user>' --data-urlencode 'pwd=admin'`. Extract the HttpOnly
-  sid with `awk -F'\t' '$6=="sid"{print $7}' jar` (`bench browse --user X --sid` is
-  not available in Frappe v16.28).
-- Switching users while clicking around: a dev build shows a floating switcher at the
-  bottom left (`frontend/src/components/DevUserSwitcher.vue`). It needs
-  `enable_dev_user_switcher: 1` in that site's `site_config.json` **and** a server
-  started as a dev server (`bench start`, or `DEV_SERVER=1 bench serve`) — the same
-  DEV_SERVER gate the seed API uses. It is never in a production build: `App.vue`
-  mounts it behind `import.meta.env.DEV`, which folds away at build time.
+## Traps
 
-## Frontend conventions
+- **The vendored `./frappe-ui/` is not the version that runs.** The submodule is on
+  beta.28; `frontend/package.json` pins beta.51. `yarn dev:frappe-ui` symlinks the
+  stale checkout. Read `frontend/node_modules/frappe-ui/` for current library
+  source; use `./frappe-ui/` only when doing library work.
+- **Cypress wipes the entire site**, not the records a spec created — `resetData`
+  calls `gameplan.ui_test_helpers.reset`. Point it at a disposable site, nothing else.
+- **Colour shades**: in Gameplan code use gray tokens. Amber survives in
+  `ReactionsDesktop.vue`, `ReactionsMobile.vue` and the `DiscussionRow.vue` unread
+  badge — the exception, not a licence to add more. frappe-ui's own components do
+  ship colour (the Rail unread badge is `theme="red"`); that is the library's call
+  and not a precedent for new Gameplan markup. Unread is drawn amber, red and gray
+  in three different places, so match the rule here, not the nearest neighbour.
+- **On a SQLite site, backend tests fail intermittently while a dev server is
+  running** — both hold the same DB file. Symptom is dozens of
+  `QueryDeadlockError: database is locked`, never an assertion failure. Stop the
+  server or re-run; do not debug it as a real failure.
 
-- `<script setup lang="ts">` + Composition API. Small component → single file; large → folder with `index.ts`.
-- Prefer `useTemplateRef` over `ref`/`querySelector` for DOM access.
-- **Data fetching**: only frappe-ui's `useList` / `useDoc` / `useCall` — never `useFetch`. Examples in `frontend/src/data/`.
-- Always prefer `/api/v2` endpoints over v1
-- `useCall` defaults to `method: 'GET'` — always pass `method: 'POST'` explicitly for calls that mutate data (see Backend conventions below for why a GET mutation silently no-ops)
-- **Styling / design / Tailwind**
-  - Follow `./frappe-ui/skills/frappe-ui/SKILL.md` (components + semantic design tokens)
-  - Gameplan rule: **gray shades only — never color shades, even for primary states.**
-- @vueuse/core is available — prefer it over custom implementations.
+## Policy
 
-## Backend conventions
+- Fix a `frappe` or `frappe-ui` bug upstream, not with a Gameplan workaround. A local
+  workaround needs a comment naming the upstream PR that removes it.
+- Verify UI work in a browser before calling it done. Screenshots belong in the PR as
+  GitHub attachments, never in the repo.
 
-- Prefer `frappe.qb.get_query()` over `frappe.db.get_all()` (pass `ignore_permissions=False` when checks are needed).
-- Prefer `frappe.qb` for writing database patches as well.
-- Permissions: `has_permission` hooks in `hooks.py` (e.g. `GP Page`); community/space membership gates access.
-- Debugging: add `def execute():` to a file like `gameplan/debug.py`, run via `bench --site gameplan-demo.test execute gameplan.debug.execute`.
-- Mutating `@frappe.whitelist()` endpoints must set `methods=["POST"]` (or another unsafe method) explicitly. Frappe rolls back the DB transaction at the end of any GET request (`frappe/app.py::sync_database`) regardless of what the function did — a mutation left reachable via GET runs, calls `save()` with no error, then gets silently discarded.
-- Prefer a doctype-scoped instance method (e.g. `GPUserProfile.set_image`, called via `useDoc({ methods })` → `POST /api/v2/document/<doctype>/<name>/method/<method>`) over a generic function in `api.py` when the action targets one specific document. Keep any admin/business-logic gate (e.g. `require_admin()`) inside the method itself — the doctype's own `has_permission` alone may be more permissive (e.g. letting a user write their own doc) than the action should allow.
+## Environment
 
-## Feature Verification
+Site names and ports vary per bench. Resolve them, do not assume.
 
-When building a feature with UI, always verify it in browser. Use the in-app browser if available, otherwise use Chrome Devtools MCP. Create a test user (or users) for yourself on the local site you are testing.
-
-When a PR needs visual evidence, upload before/after screenshots as GitHub attachments in the PR description. Never add screenshot files to the repository.
-
-## Code comments
-
-Explain _why_, not _what_. JSDoc/TSDoc for complex functions/composables. No comments for self-explanatory code.
-
-## Codebase health
-
-- When editing code, always find opportunities to refactor code and leave it better than it was before
-- Prefer generic components and utilities if code is repeated in multiple areas
-- Prefer simpler code over complex
-- When working on a specific component in Gameplan, if some generic part could be extracted out which can benefit other Frappe apps via frappe-ui, suggest it.
-
-## Fixing bugs in dependencies
-
-If a bug is actually in `frappe` or `frappe-ui`, fix it upstream (PR against `frappe/frappe` or `frappe/frappe-ui`) instead of working around it in Gameplan.
-
-- No local hacks (dropping a field, reimplementing framework logic, monkey-patching) to dodge a dependency bug — that just hides it from every other app using the same dependency.
-- A temporary local workaround is fine only if Gameplan is blocked and the upstream fix won't land in time — reference the upstream PR in a comment and remove the workaround once it ships.
+- Sites: `ls sites/`. Use the one with `"allow_tests": true` in its `site_config.json`.
+- Vite dev port is `8080 + (webserver_port - 8000)`, read from
+  `sites/common_site_config.json`.
+- Backend tests: `bench --site <site> run-tests --app gameplan` (also `--module`,
+  `--test`).
+- E2E: `cd frontend && yarn test`. Needs a dev server (`bench start`, or
+  `DEV_SERVER=1 bench serve`) plus `allow_tests`, `enable_ui_tests: 1` and
+  `developer_mode: 1` in `site_config.json`. `enable_ui_tests` is read through
+  `cint`, so `"true"` counts as off.
+- Lint: `pre-commit run --all-files` (ruff: tabs, double quotes, line 110).
+- Debug: add `def execute():` to `gameplan/debug.py`, run
+  `bench --site <site> execute gameplan.debug.execute`.
+- Sign in as another user: `bench browse --site <site> --user <u> --sid` (needs
+  `developer_mode`). In the app, `DevUserSwitcher.vue` shows in dev builds with
+  `enable_dev_user_switcher: 1`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,10 @@ still carries the old names. Do not rename the doctypes.
 
 Site names and ports vary per bench. Resolve them, do not assume.
 
-- Sites: `ls sites/`. Use the one with `"allow_tests": true` in its `site_config.json`.
+- Sites: `ls sites/`. Use a site whose data is expendable, and confirm that with the
+  human if you do not already know. `"allow_tests": true` permits tests; it does not
+  promise the data is disposable, and several sites can carry it. See the Cypress
+  trap above for the blast radius.
 - Vite dev port is `8080 + (webserver_port - 8000)`, read from
   `sites/common_site_config.json`.
 - Backend tests: `bench --site <site> run-tests --app gameplan` (also `--module`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,1 @@
 See @AGENTS.md for project guidance.
-
-## Response style
-
-- Concise, task focused, and direct
-- Use simple formatted easy to read responses
-- Use plain english in most cases
-- Use technical jargon only when it is needed

--- a/TESTING.md
+++ b/TESTING.md
@@ -149,10 +149,17 @@ changed (cite the decision in the commit message, as the guest policy above did)
 
 ### How to run
 
-Always run against a disposable test site, never a dev site with real data.
+`<site>` in every command below is a site whose data you are willing to lose. You
+have to know that independently. `"allow_tests": true` only means a site permits
+tests; it is not a claim that its data is expendable, and more than one site in a
+bench can carry it. Use it to rule sites out, never to pick one.
 
-`<site>` in every command below is your bench's test site. Resolve it once: run
-`ls sites/` and pick the site whose `site_config.json` has `"allow_tests": true`.
+The blast radius is the whole site. The Cypress suite calls
+`gameplan.ui_test_helpers.reset`, which deletes every Gameplan record and managed
+user on whichever site answers, not just the records a spec created. The backend
+suite writes fixtures of its own. Neither takes a backup.
+
+If your bench has no expendable site, create one before you run anything here.
 CI uses `gameplan.test`.
 
 ```bash

--- a/TESTING.md
+++ b/TESTING.md
@@ -15,7 +15,7 @@ Each layer owns a different kind of check. Put a test in the layer that owns it.
 
 Frontend coverage is collected from the Cypress layer, not from Vitest — see
 § 2 "Coverage". There is still no unit-test runner; `src/utils` and `src/composables`
-together are ~630 of 27k frontend lines, which is why one has not earned its keep.
+together are ~970 of 32k frontend lines, which is why one has not earned its keep.
 
 The rule:
 
@@ -149,14 +149,18 @@ changed (cite the decision in the commit message, as the guest policy above did)
 
 ### How to run
 
-Always run against the local demo site, never a dev site with real data.
+Always run against a disposable test site, never a dev site with real data.
+
+`<site>` in every command below is your bench's test site. Resolve it once: run
+`ls sites/` and pick the site whose `site_config.json` has `"allow_tests": true`.
+CI uses `gameplan.test`.
 
 ```bash
 # Full backend suite
-bench --site gameplan-demo.test run-tests --app gameplan
+bench --site <site> run-tests --app gameplan
 
 # Just the permission matrix
-bench --site gameplan-demo.test run-tests --module gameplan.tests.permissions.test_permission_matrix
+bench --site <site> run-tests --module gameplan.tests.permissions.test_permission_matrix
 ```
 
 ### Coverage
@@ -168,8 +172,8 @@ and no check fails on coverage. Both emit Cobertura XML, so one script renders b
 ```bash
 # Backend — writes sites/coverage.xml
 # (needs coverage in the bench env: env/bin/pip install coverage)
-bench --site gameplan-demo.test run-tests --app gameplan --coverage
-python .github/scripts/coverage_report.py ~/benches/frappe-bench/sites/coverage.xml \
+bench --site <site> run-tests --app gameplan --coverage
+python .github/scripts/coverage_report.py ../../sites/coverage.xml \
   --profile backend
 
 # Frontend — needs an instrumented build, then the usual Cypress run
@@ -198,7 +202,7 @@ the headline (87.6% unfiltered against 83.7% real, when this was written). Each
 profile's `excluded` tuple is the filter, and the report footer always names what it
 dropped.
 
-The frontend has the mirror-image trap. 33 routes are lazy `() => import(...)`, so a
+The frontend has the mirror-image trap. 32 routes are lazy `() => import(...)`, so a
 page no spec visits never registers in `window.__coverage__` and would drop out of
 the report entirely — flattering the percentage by shrinking the denominator rather
 than counting the file as 0%. `frontend/vite.config.ts` therefore writes a zeroed
@@ -321,7 +325,7 @@ The dev-server part is the one that bites. `frappe._dev_server` is read from the
 
 ```bash
 bench start                                                     # sets DEV_SERVER itself
-DEV_SERVER=1 bench --site gameplan-demo.test serve --port 8002  # standalone server
+DEV_SERVER=1 bench --site <site> serve --port 8002              # standalone server
 ```
 
 CI needs no special handling: GitHub Actions exports `CI`, the workflow runs
@@ -403,14 +407,15 @@ cy.task("requestAsUser", {
 This is the source of truth for Cypress site/port routing:
 
 - **Local:** `frontend/cypress.config.ts` defaults to
-  `http://gameplan-demo.test:8002`. Start it with
-  `DEV_SERVER=1 bench --site gameplan-demo.test serve --port 8002` — without
+  `http://gameplan-demo.test:8002`, which is one developer's site name. On any other
+  bench, override it with `CYPRESS_BASE_URL=http://<site>:8002`. Start the server with
+  `DEV_SERVER=1 bench --site <site> serve --port 8002` — without
   `DEV_SERVER` the seed API's test-mode gate refuses (see "Enabling the seed API"
-  above). All local Cypress runs and seed/reset calls use this disposable demo site.
+  above). All local Cypress runs and seed/reset calls use this disposable test site.
 - **Local realtime authentication:** `:8000` is a second
-  `gameplan-demo.test`-pinned Frappe server used by Socket.IO to authenticate the
+  `<site>`-pinned Frappe server used by Socket.IO to authenticate the
   browser session. Start it with
-  `DEV_SERVER=1 bench --site gameplan-demo.test serve --port 8000`. Socket.IO itself
+  `DEV_SERVER=1 bench --site <site> serve --port 8000`. Socket.IO itself
   listens on `:9000` (`bench socketio`). Do not point Cypress or seed/reset calls at
   `:8000`; it is an authentication target, not the configured local test runner.
 - **CI:** `.github/workflows/ui-test.yml` overrides `CYPRESS_BASE_URL` with
@@ -446,13 +451,15 @@ Three traps matter when checking this manually:
 1. `frappe.realtime.get_user_info` returns `{}` unless the request includes
    `X-Frappe-Socket-Secret`; `{}` means “missing secret,” not “Guest” or “wrong
    site.” Get the secret with
-   `bench --site gameplan-demo.test execute frappe.realtime.get_socketio_secret`.
+   `bench --site <site> execute frappe.realtime.get_socketio_secret`.
 2. Test-suite pressure can expire sessions within minutes. Mint the sid and resolve
    it in the same step; otherwise `session_expired` / `Guest` can be misdiagnosed as
    a site-routing failure.
-3. `bench browse --user X --sid` is unavailable in Frappe v16.28. Log in with
-   `POST /api/method/login` and password `admin`. Curl stores the HttpOnly sid on a
-   `#HttpOnly_` line; extract it from the cookie jar with
+3. `bench browse --site <site> --user X --sid` prints a session id for that user and
+   exits. It needs `developer_mode: 1` in `site_config.json` for any user but
+   Administrator, and `--sid` without `--user` exits with an error. Where that command
+   is not available, log in with `POST /api/method/login` and password `admin`. Curl
+   stores the HttpOnly sid on a `#HttpOnly_` line; extract it from the cookie jar with
    `awk -F'\t' '$6=="sid"{print $7}' jar`.
 
 Known Frappe limitation, deliberately without a PR yet: in `developer_mode`,
@@ -484,7 +491,7 @@ browser watching while a separate server-side session makes the change.
 cd frontend && yarn test
 ```
 
-- Run only against `gameplan-demo.test`, never another local site.
+- Run only against the disposable test site, never a site with real data.
 - The target site needs `enable_ui_tests: 1` and `allow_tests: 1` in its
   `site_config.json`, and its server must have been started with `DEV_SERVER` set —
   see "Enabling the seed API" above.
@@ -505,8 +512,9 @@ cd frontend && yarn test
 
 ## 4. CI
 
-- **Server tests** run the full backend suite twice: on MariaDB (`server-tests.yml`)
-  and on SQLite (`server-tests-sqlite.yml`), both via
+- **Server tests** run the full backend suite three times: on MariaDB
+  (`server-tests.yml`), on SQLite (`server-tests-sqlite.yml`), and on MariaDB against
+  Frappe `version-16` (`server-tests-v16.yml`), all via
   `bench --site gameplan.test run-tests --app gameplan`.
 - **Backend coverage** is collected only in the canonical MariaDB lane
   (`server-tests.yml`), which runs with `--coverage`. SQLite and v16 stay cheaper
@@ -527,10 +535,11 @@ cd frontend && yarn test
 
 The migration is done. Everything described above is the current state, not a plan:
 
-- Backend tests all live under `gameplan/tests/{features,permissions,platform}/`. No
-  `test_*.py` remains beside a doctype, and the old `tests/utils.py` is gone — builders
-  live in `fixtures.py`.
-- All 33 specs sit in the grouped folders under `cypress/e2e/`, seed through
+- Most backend tests live under `gameplan/tests/{features,permissions,platform}/`, and
+  no `test_*.py` remains beside a doctype. New builders live in `fixtures.py`. The old
+  `tests/utils.py` is still there, used only by `tests/test_v16_api_compat.py` and
+  `tests/test_get_request_transactions.py`, which also still sit at the top level.
+- All 39 specs sit in the grouped folders under `cypress/e2e/`, seed through
   `resetData(scenario)`, and log in with `cy.loginAs(persona)`.
 - `gameplan/test_api.py` is deleted. `gameplan/ui_test_helpers.py` is the only seed
   surface, and every entry point is behind the three gates described in


### PR DESCRIPTION
Rewrites `AGENTS.md` and corrects stale facts in `TESTING.md`. Agents ran the evals and verified every claim.

## Why

`AGENTS.md` had grown to ~1950 tokens and loaded on every session. Rather than trim it by opinion, agents tested it.

Method: run realistic tasks with the file hidden. Anything an agent gets right from codebase precedent alone is a line that buys nothing. 12 probe tasks covering features, bug diagnosis, code review, permissions, styling, e2e tests, patches, dependency bugs, search, and refactors. Then an old-vs-new A/B on three more.

## What the evals found

Across all 12 probes, no instruction turned a wrong answer into a right one. Agents derived the conventions from precedent every time.

The clearest case is the `methods=["POST"]` rule, the most valuable-looking line in the file. `gameplan/tests/test_get_request_transactions.py` already walks every whitelisted endpoint and fails the build, with an assertion message that explains the rule better than the doc did. Same for `useCall` defaulting to GET: it is at `useCall.ts:18`, and `Notifications.vue:222` already carries an explanatory comment.

Parts of the file were wrong, not merely idle. It named `gameplan-demo.test`, which does not exist in every bench. That cost a failed first command in two of three A/B runs.

| Task | Arm | Attempts to a working command | Tool calls | Files touched |
|---|---|---|---|---|
| Run the discussions tests | old | 3 | 21 | |
| | new | 0 | 16 | |
| Add mute-discussion | old | 2 | 64 | 14 |
| | new | 1 | 78 | 12 |
| Add an unread pill | old | | 141 | 6 |
| | new | | 84 | 2 |

No arm produced a worse design. Both mute arms converged on the same architecture. Both pill arms chose a gray badge over the amber precedent.

## Cut

The conventions agents already follow from precedent: the POST decorator, `useCall` GET, doctype methods over `api.py`, `frappe.qb`, `/api/v2`, `<script setup lang="ts">`, single file vs folder, `useTemplateRef`, `@vueuse/core`.

The Codebase health block, which was worse than idle. On the unread-pill task an agent rewrote four unrelated call sites and named the block as its reason, against a standing "no drive-by refactors" rule. Without the block the same task touched two files.

## Fixed

The site name is gone in favour of resolving it. Frappe is 17.0.0-dev here, so `bench browse --sid` does work. Vite binds `8080 + (webserver_port - 8000)`. The data-fetching rule listed three composables and omitted `useDoctype` and `useNewDoc`, which the code uses, so an agent obeying it literally would avoid two working APIs.

## Added

Three traps agents hit that the file did not cover. The vendored `./frappe-ui/` is on beta.28 while `frontend/package.json` pins beta.51, so `yarn dev:frappe-ui` symlinks a stale checkout. SQLite tests throw phantom `database is locked` errors while a dev server holds the file. Colour precedent disagrees with itself across three components, so the rule has to win over the nearest neighbour.

## TESTING.md

Same treatment. The hardcoded site name, the false `bench browse` claim, and drifted counts: 32 lazy routes not 33, 39 Cypress specs not 33, three CI backend runs not two. `gameplan/tests/utils.py` still exists and is still imported, so two claims about it were wrong. The coverage-report path pointed outside the repo.

## Not done

`TESTING.md` still omits the mutation-testing layer, though `gameplan/tests/mutation/` and two workflows run on PRs. Its coverage percentages are unverified. The global instruction file that loads alongside `AGENTS.md` still duplicates the styling-token and component-reuse rules removed here.

Evidence, probe definitions and run output are at `.scratch/agents-md-eval/`, outside the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
