### PR TITLE
fix: a user with no Gameplan role sees onboarding instead of a 403

### DIFF
--- a/frontend/cypress/e2e/members/member-management.cy.ts
+++ b/frontend/cypress/e2e/members/member-management.cy.ts
@@ -50,8 +50,16 @@ describe('Member management', () => {
     // :visible — the Profile tab's Bio textarea stays mounted (hidden) in the
     // Settings dialog after switching tabs (unmount-on-hide=false).
     cy.scope('dialog').find('textarea:visible').type('newteammate@example.com')
-    cy.button('Send invitation').click()
+
+    // Two visible buttons read "Invite" once the dialog is open: the trigger on the
+    // Users tab behind it, and this submit. Scope to the InvitePeople dialog, which
+    // mounts after the Settings dialog, so it is the last one.
+    cy.scope('dialog').last().button('Invite').click()
     cy.wait('@invite').its('response.statusCode').should('eq', 200)
+
+    // The dialog reports the outcome per bucket. newteammate@example.com has no
+    // account on the site, so it takes the email path rather than a direct grant.
+    cy.scope('dialog').contains('1 invitation sent').should('be.visible')
 
     // On success the new invite shows in "Pending Invites". The Member role is
     // labelled "User" in the UI.

--- a/frontend/src/components/Settings/InvitePeople.vue
+++ b/frontend/src/components/Settings/InvitePeople.vue
@@ -42,6 +42,31 @@
         </Button>
       </template>
     </div>
+
+    <!-- One call can end three ways per email, so the result is grouped instead of
+         summarized: the admin needs to see which address landed in which bucket.
+         It sits next to Pending Invites so all invite feedback is in one place. -->
+    <div v-if="resultGroups.length && !emails" class="mt-4 rounded-4 bg-surface-gray-2 p-3">
+      <div class="space-y-2">
+        <div v-for="group in resultGroups" :key="group.label" class="flex gap-2">
+          <span
+            :class="group.icon"
+            class="mt-0.5 size-4 shrink-0 text-ink-gray-5"
+            aria-hidden="true"
+          />
+          <div class="min-w-0">
+            <div class="text-base text-ink-gray-8">{{ group.label }}</div>
+            <div class="mt-0.5 break-words text-base text-ink-gray-5">
+              {{ group.emails.join(', ') }}
+            </div>
+          </div>
+        </div>
+      </div>
+      <p v-if="result?.skipped.length" class="mt-3 text-sm text-ink-gray-5">
+        Skipped emails already have access, have a pending invite, or belong to a disabled account.
+      </p>
+    </div>
+
     <template v-if="pendingInvitations.data?.length && !emails">
       <div class="mt-4 flex items-center justify-between border-b py-2 text-base text-ink-gray-5">
         <div class="w-4/5">Pending Invites</div>
@@ -87,7 +112,7 @@
 
 <script setup lang="ts">
 import { ref, computed } from 'vue'
-import { Select, Tooltip, toast } from 'frappe-ui'
+import { Select, Tooltip } from 'frappe-ui'
 import { useCall, useList } from 'frappe-ui'
 import { GPInvitation } from '@/types/doctypes'
 import { users } from '@/data/users'
@@ -118,7 +143,7 @@ const pendingInvitations = useList<GPInvitation>({
 })
 
 /**
- * One call can end three ways per email, so the toast has to say which happened.
+ * One call can end three ways per email, so the dialog reports all three.
  * `granted` already had an account here and now hold the role; `invited` were mailed
  * an invitation link; `skipped` needed nothing or could take nothing (already in
  * Gameplan, already invited, or a disabled account).
@@ -129,23 +154,35 @@ interface InviteResult {
   skipped: string[]
 }
 
+const result = ref<InviteResult | null>(null)
+
 function plural(count: number, one: string, many: string) {
   return `${count} ${count === 1 ? one : many}`
 }
 
-function summarize(result: InviteResult): string {
-  const parts: string[] = []
-  if (result.granted.length) {
-    parts.push(`${plural(result.granted.length, 'person', 'people')} given access`)
+const resultGroups = computed(() => {
+  if (!result.value) return []
+  const { granted, invited, skipped } = result.value
+  const groups: { icon: string; label: string; emails: string[] }[] = []
+  if (granted.length) {
+    groups.push({
+      icon: 'lucide-check',
+      label: `${plural(granted.length, 'person', 'people')} given access`,
+      emails: granted,
+    })
   }
-  if (result.invited.length) {
-    parts.push(`${plural(result.invited.length, 'invitation', 'invitations')} sent`)
+  if (invited.length) {
+    groups.push({
+      icon: 'lucide-mail',
+      label: `${plural(invited.length, 'invitation', 'invitations')} sent`,
+      emails: invited,
+    })
   }
-  if (result.skipped.length) {
-    parts.push(`${result.skipped.length} skipped`)
+  if (skipped.length) {
+    groups.push({ icon: 'lucide-minus', label: `${skipped.length} skipped`, emails: skipped })
   }
-  return parts.join(', ')
-}
+  return groups
+})
 
 const inviteByEmail = useCall<
   InviteResult,
@@ -158,19 +195,15 @@ const inviteByEmail = useCall<
   url: '/api/v2/method/gameplan.api.invite_by_email',
   method: 'POST',
   immediate: false,
-  onSuccess: (result) => {
-    if (result.granted.length || result.invited.length) {
-      toast.success(summarize(result))
-    } else {
-      toast.info('No one to invite. They already have access or a pending invitation.')
-    }
+  onSuccess: (data) => {
+    result.value = data
     role.value = 'Gameplan Member'
     emails.value = ''
     pendingInvitations.reload()
     // Someone granted access holds a role now, so they belong in the members list
     // behind this dialog. Reloading is safe here: the app gates on the `usersReady`
     // latch, not on `users.isFinished`, which goes false during any refetch.
-    if (result.granted.length) {
+    if (data.granted.length) {
       users.reload()
     }
   },

--- a/frontend/src/components/Settings/InvitePeople.vue
+++ b/frontend/src/components/Settings/InvitePeople.vue
@@ -56,13 +56,13 @@
           />
           <div class="min-w-0">
             <div class="text-base text-ink-gray-8">{{ group.label }}</div>
-            <div class="mt-0.5 break-words text-base text-ink-gray-5">
+            <div class="break-words text-p-base text-ink-gray-5">
               {{ group.emails.join(', ') }}
             </div>
           </div>
         </div>
       </div>
-      <p v-if="result?.skipped.length" class="mt-3 text-sm text-ink-gray-5">
+      <p v-if="result?.skipped.length" class="mt-3 text-p-sm text-ink-gray-5">
         Skipped emails already have access, have a pending invite, or belong to a disabled account.
       </p>
     </div>

--- a/frontend/src/components/Settings/InvitePeople.vue
+++ b/frontend/src/components/Settings/InvitePeople.vue
@@ -38,7 +38,7 @@
           "
           :loading="inviteByEmail.loading"
         >
-          Send invitation
+          Invite
         </Button>
       </template>
     </div>
@@ -87,9 +87,10 @@
 
 <script setup lang="ts">
 import { ref, computed } from 'vue'
-import { Select, Tooltip } from 'frappe-ui'
+import { Select, Tooltip, toast } from 'frappe-ui'
 import { useCall, useList } from 'frappe-ui'
 import { GPInvitation } from '@/types/doctypes'
+import { users } from '@/data/users'
 
 type Role = 'Gameplan Admin' | 'Gameplan Member'
 
@@ -116,8 +117,38 @@ const pendingInvitations = useList<GPInvitation>({
   filters: { status: 'Pending' },
 })
 
+/**
+ * One call can end three ways per email, so the toast has to say which happened.
+ * `granted` already had an account here and now hold the role; `invited` were mailed
+ * an invitation link; `skipped` needed nothing or could take nothing (already in
+ * Gameplan, already invited, or a disabled account).
+ */
+interface InviteResult {
+  granted: string[]
+  invited: string[]
+  skipped: string[]
+}
+
+function plural(count: number, one: string, many: string) {
+  return `${count} ${count === 1 ? one : many}`
+}
+
+function summarize(result: InviteResult): string {
+  const parts: string[] = []
+  if (result.granted.length) {
+    parts.push(`${plural(result.granted.length, 'person', 'people')} given access`)
+  }
+  if (result.invited.length) {
+    parts.push(`${plural(result.invited.length, 'invitation', 'invitations')} sent`)
+  }
+  if (result.skipped.length) {
+    parts.push(`${result.skipped.length} skipped`)
+  }
+  return parts.join(', ')
+}
+
 const inviteByEmail = useCall<
-  undefined,
+  InviteResult,
   {
     emails: string
     role: string
@@ -127,10 +158,21 @@ const inviteByEmail = useCall<
   url: '/api/v2/method/gameplan.api.invite_by_email',
   method: 'POST',
   immediate: false,
-  onSuccess: () => {
+  onSuccess: (result) => {
+    if (result.granted.length || result.invited.length) {
+      toast.success(summarize(result))
+    } else {
+      toast.info('No one to invite. They already have access or a pending invitation.')
+    }
     role.value = 'Gameplan Member'
     emails.value = ''
     pendingInvitations.reload()
+    // Someone granted access holds a role now, so they belong in the members list
+    // behind this dialog. Reloading is safe here: the app gates on the `usersReady`
+    // latch, not on `users.isFinished`, which goes false during any refetch.
+    if (result.granted.length) {
+      users.reload()
+    }
   },
 })
 </script>

--- a/gameplan/api.py
+++ b/gameplan/api.py
@@ -8,6 +8,7 @@ from frappe.query_builder.functions import Count
 from frappe.utils import split_emails, validate_email_address
 
 import gameplan
+from gameplan.gameplan.doctype.gp_invitation.gp_invitation import grant_access
 from gameplan.realtime import notify_notification_count_changed, unread_notification_count
 from gameplan.roles import GAMEPLAN_ROLES
 from gameplan.utils import validate_type
@@ -126,18 +127,29 @@ def invite_by_email(emails: str, role: str, projects: list = None):
 	return _invite_by_email(emails, role, projects)
 
 
-def _invite_by_email(emails: str, role: str, projects: list = None):
+def _invite_by_email(emails: str, role: str, projects: list = None) -> dict:
 	"""Core invite logic, callable from trusted server code (e.g. onboarding).
 
 	The public invite_by_email wrapper adds the admin gate + role allowlist; this
 	helper assumes the caller has already authorized the invite and validated role.
+
+	Two outcomes, split on whether the person already has an account here:
+
+	No account: send the invitation email. Its link is what mints the User.
+
+	An enabled account with no Gameplan role: grant the role now. The email link would
+	create nothing and set no password, and an OAuth account (which is how people reach
+	this state) would be sent to /update-password for no reason.
+
+	Returns the three buckets so the caller can tell the admin what happened.
 	"""
+	result = {"granted": [], "invited": [], "skipped": []}
 	if not emails:
-		return
+		return result
 	email_string = validate_email_address(emails, throw=False)
 	email_list = split_emails(email_string)
 	if not email_list:
-		return
+		return result
 	already_in_gameplan = emails_holding_a_gameplan_role(email_list)
 	existing_invites = frappe.db.get_all(
 		"GP Invitation",
@@ -149,17 +161,49 @@ def _invite_by_email(emails: str, role: str, projects: list = None):
 	)
 
 	if role == "Gameplan Guest":
-		to_invite = list(set(email_list) - set(existing_invites))
+		to_invite = set(email_list) - set(existing_invites)
 	else:
-		to_invite = list(set(email_list) - set(already_in_gameplan) - set(existing_invites))
+		to_invite = set(email_list) - set(already_in_gameplan) - set(existing_invites)
 
+	accounts = existing_accounts(to_invite)
+	grantable = {email for email, enabled in accounts.items() if enabled}
+	# A disabled account is neither granted nor invited. The role would change nothing
+	# while the account cannot sign in, and mailing it an invite link is worse: accept()
+	# would hand the role to an account someone deliberately switched off.
+	to_invite -= set(accounts) - grantable
+
+	result["skipped"] = sorted(set(email_list) - to_invite)
 	if projects:
 		projects = frappe.as_json(projects, indent=None)
 
-	for email in to_invite:
-		frappe.get_doc(doctype="GP Invitation", email=email, role=role, projects=projects).insert(
-			ignore_permissions=True
-		)
+	for email in sorted(to_invite):
+		if email in grantable:
+			grant_access(email, role, projects)
+			result["granted"].append(email)
+		else:
+			frappe.get_doc(doctype="GP Invitation", email=email, role=role, projects=projects).insert(
+				ignore_permissions=True
+			)
+			result["invited"].append(email)
+
+	return result
+
+
+def existing_accounts(email_list) -> dict:
+	"""Map each email that already has a User on this site to whether it is enabled.
+
+	An enabled account can sign in today, so its owner needs a role, not an invitation.
+	A disabled one needs neither.
+	"""
+	email_list = list(email_list)
+	if not email_list:
+		return {}
+	rows = frappe.qb.get_query(
+		"User",
+		filters={"email": ["in", email_list]},
+		fields=["email", "enabled"],
+	).run(as_dict=True)
+	return {row.email: bool(row.enabled) for row in rows}
 
 
 def emails_holding_a_gameplan_role(email_list: list) -> list:

--- a/gameplan/api.py
+++ b/gameplan/api.py
@@ -138,7 +138,7 @@ def _invite_by_email(emails: str, role: str, projects: list = None):
 	email_list = split_emails(email_string)
 	if not email_list:
 		return
-	existing_members = frappe.db.get_all("User", filters={"email": ["in", email_list]}, pluck="email")
+	already_in_gameplan = emails_holding_a_gameplan_role(email_list)
 	existing_invites = frappe.db.get_all(
 		"GP Invitation",
 		filters={
@@ -151,7 +151,7 @@ def _invite_by_email(emails: str, role: str, projects: list = None):
 	if role == "Gameplan Guest":
 		to_invite = list(set(email_list) - set(existing_invites))
 	else:
-		to_invite = list(set(email_list) - set(existing_members) - set(existing_invites))
+		to_invite = list(set(email_list) - set(already_in_gameplan) - set(existing_invites))
 
 	if projects:
 		projects = frappe.as_json(projects, indent=None)
@@ -160,6 +160,28 @@ def _invite_by_email(emails: str, role: str, projects: list = None):
 		frappe.get_doc(doctype="GP Invitation", email=email, role=role, projects=projects).insert(
 			ignore_permissions=True
 		)
+
+
+def emails_holding_a_gameplan_role(email_list: list) -> list:
+	"""The subset of `email_list` whose User already holds a Gameplan role.
+
+	A member invite skips these, because the invitation would grant a role they have.
+	It must not skip every existing User: signing in through OAuth mints a Website User
+	with no role at all, so an account can exist on the site while its owner has no way
+	into Gameplan. Those people need the invite; `accept()` adds the role to the account
+	they already have.
+	"""
+	User = frappe.qb.DocType("User")
+	HasRole = frappe.qb.DocType("Has Role")
+	return (
+		frappe.qb.from_(User)
+		.join(HasRole)
+		.on((HasRole.parent == User.name) & (HasRole.parenttype == "User"))
+		.select(User.email)
+		.where(User.email.isin(email_list))
+		.where(HasRole.role.isin(GAMEPLAN_ROLES))
+		.run(pluck=True)
+	)
 
 
 @frappe.whitelist()

--- a/gameplan/gameplan/doctype/gp_invitation/gp_invitation.py
+++ b/gameplan/gameplan/doctype/gp_invitation/gp_invitation.py
@@ -4,6 +4,8 @@
 import frappe
 from frappe.model.document import Document
 
+from gameplan.gameplan.doctype.gp_team.gp_team import get_public_team_names
+
 
 class GPInvitation(Document):
 	def before_insert(self):
@@ -72,6 +74,7 @@ class GPInvitation(Document):
 		user.append_roles(self.role)
 		user.save(ignore_permissions=True)
 		self.create_guest_access(user)
+		self.join_public_communities(user)
 
 		self.status = "Accepted"
 		self.accepted_at = frappe.utils.now()
@@ -95,6 +98,32 @@ class GPInvitation(Document):
 				guest_access.user = user.name
 				guest_access.project = project
 				guest_access.save(ignore_permissions=True)
+
+	def join_public_communities(self, user):
+		"""Put a new member in every public community, so the app is not empty on day one.
+
+		Membership is not what grants access here: a public community is already readable
+		by everyone (see `team_access_criterion`). It is what the sidebar lists, so without
+		this a new account signs in to an empty shell and has to go and find the
+		communities before anything appears.
+
+		Guests are skipped. Their reach is exactly the `GP Guest Access` rows
+		`create_guest_access` just wrote, and joining them to everything would undo that.
+		"""
+		if self.role == "Gameplan Guest":
+			return
+
+		for team_name in get_public_team_names():
+			team = frappe.get_doc("GP Team", team_name)
+			if team.get_member(user.name):
+				continue
+			team.add_member(user.name)
+			# Saving the community re-validates every row already in `members`, so one row
+			# left pointing at a deleted account would stop anyone new from joining. The row
+			# being added here is safe by construction: `user` is a User document that was
+			# just loaded or created.
+			team.flags.ignore_links = True
+			team.save(ignore_permissions=True)
 
 	def create_user_if_not_exists(self):
 		if not frappe.db.exists("User", self.email):

--- a/gameplan/gameplan/doctype/gp_invitation/gp_invitation.py
+++ b/gameplan/gameplan/doctype/gp_invitation/gp_invitation.py
@@ -20,6 +20,10 @@ class GPInvitation(Document):
 		self.status = "Pending"
 
 	def after_insert(self):
+		# grant_access() accepts the invitation itself, so the key would be dead on
+		# arrival and the mail would ask for a step the invitee has already skipped.
+		if self.flags.skip_invite_email:
+			return
 		self.invite_via_email()
 
 	def invite_via_email(self):
@@ -36,6 +40,26 @@ class GPInvitation(Document):
 			subject=f"You have been invited to join {title}",
 			template=template,
 			args={"title": title, "invite_link": invite_link},
+			now=True,
+		)
+		self.db_set("email_sent_at", frappe.utils.now())
+
+	def notify_access_granted(self):
+		"""Tell someone their existing account can now open Gameplan.
+
+		No key and no link to accept: `grant_access` already did that. They sign in the
+		way they always have.
+		"""
+		app_link = frappe.utils.get_url("/g")
+		if frappe.local.dev_server:
+			print(f"Access granted to {self.email}: {app_link}")
+			return
+
+		frappe.sendmail(
+			recipients=self.email,
+			subject="You now have access to Gameplan",
+			template="gameplan_access_granted",
+			args={"app_link": app_link},
 			now=True,
 		)
 		self.db_set("email_sent_at", frappe.utils.now())
@@ -85,6 +109,22 @@ class GPInvitation(Document):
 		else:
 			user = frappe.get_doc("User", self.email)
 		return user
+
+
+def grant_access(email, role, projects=None):
+	"""Give an account that already exists its role now, with no email round trip.
+
+	The invitation row is still written and then accepted here, for two reasons. It
+	keeps `accept()` the single definition of what getting access means, including the
+	`GP Guest Access` rows a guest needs, so the two paths cannot drift. And it leaves
+	the same audit trail as any other invitation: who granted it, and when.
+	"""
+	invitation = frappe.get_doc(doctype="GP Invitation", email=email, role=role, projects=projects)
+	invitation.flags.skip_invite_email = True
+	invitation.insert(ignore_permissions=True)
+	invitation.accept()
+	invitation.notify_access_granted()
+	return invitation
 
 
 def expire_invitations():

--- a/gameplan/gameplan/doctype/gp_team/gp_team.py
+++ b/gameplan/gameplan/doctype/gp_team/gp_team.py
@@ -257,6 +257,23 @@ def get_valid_sidebar_badge_style(sidebar_badge_style: str):
 	return sidebar_badge_style
 
 
+def get_public_team_names():
+	"""Every community anyone may join, newest last.
+
+	Public and not archived, which is the same pair of conditions
+	`get_accessible_team_names` applies to the public half of its result. This one takes
+	no user, so it can answer for an account that has no session yet.
+	"""
+	Team = frappe.qb.DocType("GP Team")
+	return (
+		frappe.qb.from_(Team)
+		.select(Team.name)
+		.where(Team.is_private == 0)
+		.where(Team.archived_at.isnull())
+		.orderby(Team.creation)
+	).run(pluck=True)
+
+
 def get_accessible_team_names():
 	Team = frappe.qb.DocType("GP Team")
 	Member = frappe.qb.DocType("GP Member")

--- a/gameplan/roles.py
+++ b/gameplan/roles.py
@@ -76,3 +76,22 @@ def sync_roles():
 			f"Gameplan roles granting desk access: {', '.join(granting_desk_access)}. "
 			"Users holding them are System Users. Set desk_access = 0 if that is not intended."
 		)
+
+
+def has_app_access(user=None):
+	"""Whether `user` may open the Gameplan SPA at /g.
+
+	Every Gameplan doctype grants read to a Gameplan role (or System Manager), so a user
+	holding none of them is denied on the first list call the SPA makes. The frontend
+	cannot tell that 403 apart from an empty result, reads the site as brand new and
+	sends the user to onboarding, which then fails again on create. Answer the question
+	once, on the page, instead.
+
+	Users reach this state through OAuth: `login_via_oauth2` mints a Website User with no
+	role, so anyone who signs in with a social provider before being invited lands here.
+	"""
+	if not user:
+		user = frappe.session.user
+	if user == "Administrator":
+		return True
+	return bool(set(frappe.get_roles(user)) & {*GAMEPLAN_ROLES, "System Manager"})

--- a/gameplan/templates/emails/gameplan_access_granted.html
+++ b/gameplan/templates/emails/gameplan_access_granted.html
@@ -1,0 +1,5 @@
+<h2>You now have access to Gameplan</h2>
+<p>
+	<a class="btn btn-primary" href="{{ app_link }}">Open Gameplan</a>
+</p>
+<p>Sign in the way you already do. There is nothing to set up.</p>

--- a/gameplan/tests/features/test_invitations.py
+++ b/gameplan/tests/features/test_invitations.py
@@ -143,6 +143,24 @@ class TestInvitationCreation(InvitationTestCase):
 			frappe.db.exists("GP Guest Access", {"user": "oauth-guest@example.com", "project": space.name})
 		)
 
+	def test_a_directly_granted_member_joins_public_communities(self):
+		"""The direct path runs through accept(), so it inherits the join for free."""
+		create_user("oauth-joiner@example.com", "Oauth Joiner")
+		community = create_community("Direct Join Community")
+
+		_invite_by_email("oauth-joiner@example.com", role="Gameplan Member")
+
+		self.assertTrue(
+			frappe.db.exists(
+				"GP Member",
+				{
+					"parenttype": "GP Team",
+					"parent": community.name,
+					"user": "oauth-joiner@example.com",
+				},
+			)
+		)
+
 	def test_an_email_with_no_account_still_gets_the_invitation(self):
 		result = _invite_by_email("brand-new@example.com", role="Gameplan Member")
 
@@ -241,6 +259,72 @@ class TestInvitationAccept(InvitationTestCase):
 		self.assertTrue(
 			frappe.db.exists("GP Guest Access", {"user": "guest-accept@example.com", "project": space.name})
 		)
+
+	def joined_communities(self, email):
+		return set(
+			frappe.db.get_all(
+				"GP Member",
+				filters={"parenttype": "GP Team", "user": email},
+				pluck="parent",
+			)
+		)
+
+	def test_accept_joins_every_public_community(self):
+		"""A new member should land in a populated app, not an empty shell.
+
+		Membership does not gate a public community, it decides what the sidebar lists.
+		"""
+		first = create_community("Public One")
+		second = create_community("Public Two")
+		invitation = self.make_invitation("joiner@example.com")
+
+		invitation.accept()
+
+		joined = self.joined_communities("joiner@example.com")
+		self.assertIn(first.name, joined)
+		self.assertIn(second.name, joined)
+
+	def test_accept_leaves_private_communities_alone(self):
+		private = create_community("Private One", is_private=1)
+		invitation = self.make_invitation("no-private@example.com")
+
+		invitation.accept()
+
+		self.assertNotIn(private.name, self.joined_communities("no-private@example.com"))
+
+	def test_accept_leaves_archived_communities_alone(self):
+		archived = create_community("Archived One")
+		archived.db_set("archived_at", now())
+		invitation = self.make_invitation("no-archived@example.com")
+
+		invitation.accept()
+
+		self.assertNotIn(archived.name, self.joined_communities("no-archived@example.com"))
+
+	def test_a_guest_joins_nothing(self):
+		"""A guest's reach is the spaces they were granted, and nothing wider."""
+		community = create_community("Guest Blind Community")
+		space = create_space("Guest Blind Space", community, is_private=1)
+		invitation = self.make_invitation(
+			"guest-no-join@example.com", role="Gameplan Guest", projects=[space.name]
+		)
+
+		invitation.accept()
+
+		self.assertEqual(self.joined_communities("guest-no-join@example.com"), set())
+
+	def test_accept_does_not_duplicate_an_existing_membership(self):
+		member = create_member("already-in@example.com")
+		community = create_community("Already Joined", members=[member])
+		invitation = self.make_invitation("already-in@example.com", role="Gameplan Admin")
+
+		invitation.accept()
+
+		rows = frappe.db.count(
+			"GP Member",
+			{"parenttype": "GP Team", "parent": community.name, "user": "already-in@example.com"},
+		)
+		self.assertEqual(rows, 1)
 
 	def test_accept_expired_invitation_is_rejected(self):
 		invitation = self.make_invitation("too-late@example.com")

--- a/gameplan/tests/features/test_invitations.py
+++ b/gameplan/tests/features/test_invitations.py
@@ -21,7 +21,7 @@ import frappe
 from frappe.utils import add_days, now, today
 
 from gameplan.api import _invite_by_email, accept_invitation
-from gameplan.gameplan.doctype.gp_invitation.gp_invitation import expire_invitations
+from gameplan.gameplan.doctype.gp_invitation.gp_invitation import GPInvitation, expire_invitations
 from gameplan.tests.base import GameplanTestCase
 from gameplan.tests.fixtures import (
 	create_community,
@@ -95,25 +95,90 @@ class TestInvitationCreation(InvitationTestCase):
 
 		self.assertFalse(frappe.db.exists("GP Invitation", {"email": "already-member@example.com"}))
 
-	def test_invite_reaches_an_existing_user_with_no_gameplan_role(self):
+	def test_an_existing_account_is_granted_access_without_the_email(self):
 		"""Signing in through OAuth mints a Website User with no role, so an account can
-		exist while its owner has no way into Gameplan. That account must not read as an
-		existing member, or the invite is dropped and the person stays locked out."""
-		create_user("oauth-signup@example.com", "Oauth Signup")
+		exist while its owner has no way into Gameplan. The email link would create no
+		user and set no password, so skip it and hand over the role now."""
+		user = create_user("oauth-signup@example.com", "Oauth Signup")
 
-		_invite_by_email("oauth-signup@example.com", role="Gameplan Member")
+		result = _invite_by_email("oauth-signup@example.com", role="Gameplan Member")
 
-		self.assertTrue(frappe.db.exists("GP Invitation", {"email": "oauth-signup@example.com"}))
-
-	def test_accepting_that_invite_grants_the_role_to_the_existing_account(self):
-		user = create_user("oauth-accept@example.com", "Oauth Accept")
-		_invite_by_email("oauth-accept@example.com", role="Gameplan Member")
-
-		invitation = frappe.get_doc("GP Invitation", {"email": "oauth-accept@example.com"})
-		invitation.accept()
-
-		self.assertEqual(frappe.db.count("User", {"email": "oauth-accept@example.com"}), 1)
 		self.assertIn("Gameplan Member", frappe.get_roles(user.name))
+		self.assertEqual(result["granted"], ["oauth-signup@example.com"])
+		self.assertEqual(result["invited"], [])
+		self.assertEqual(frappe.db.count("User", {"email": "oauth-signup@example.com"}), 1)
+
+	def test_granting_access_leaves_an_accepted_invitation_as_the_audit_trail(self):
+		create_user("oauth-audit@example.com", "Oauth Audit")
+
+		with self.as_user(self.admin):
+			_invite_by_email("oauth-audit@example.com", role="Gameplan Member")
+
+		invitation = frappe.get_doc("GP Invitation", {"email": "oauth-audit@example.com"})
+		self.assertEqual(invitation.status, "Accepted")
+		self.assertTrue(invitation.accepted_at)
+		self.assertEqual(invitation.invited_by, self.admin.name)
+
+	def test_granting_access_never_sends_the_accept_link(self):
+		"""The key is spent before the mail could arrive; sending it would ask for a
+		step that is already done."""
+		create_user("oauth-nomail@example.com", "Oauth No Mail")
+
+		with patch.object(GPInvitation, "invite_via_email") as invite_mail:
+			_invite_by_email("oauth-nomail@example.com", role="Gameplan Member")
+
+		invite_mail.assert_not_called()
+
+	def test_a_guest_granted_access_gets_the_space_immediately(self):
+		"""accept() owns the GP Guest Access rows, so the direct path must not lose
+		them. This is why grant_access reuses accept() instead of setting the role."""
+		create_user("oauth-guest@example.com", "Oauth Guest")
+		community = create_community("Direct Guest Community")
+		space = create_space("Direct Guest Space", community, is_private=1)
+
+		_invite_by_email("oauth-guest@example.com", role="Gameplan Guest", projects=[space.name])
+
+		self.assertIn("Gameplan Guest", frappe.get_roles("oauth-guest@example.com"))
+		self.assertTrue(
+			frappe.db.exists("GP Guest Access", {"user": "oauth-guest@example.com", "project": space.name})
+		)
+
+	def test_an_email_with_no_account_still_gets_the_invitation(self):
+		result = _invite_by_email("brand-new@example.com", role="Gameplan Member")
+
+		invitation = frappe.get_doc("GP Invitation", {"email": "brand-new@example.com"})
+		self.assertEqual(invitation.status, "Pending")
+		self.assertEqual(result["invited"], ["brand-new@example.com"])
+		self.assertEqual(result["granted"], [])
+		self.assertFalse(frappe.db.exists("User", "brand-new@example.com"))
+
+	def test_a_disabled_account_is_skipped_not_invited(self):
+		"""Granting a role changes nothing while the account cannot sign in, and an
+		invite link would hand the role to an account someone switched off."""
+		user = create_user("disabled-user@example.com", "Disabled User")
+		user.enabled = 0
+		user.save(ignore_permissions=True)
+
+		result = _invite_by_email("disabled-user@example.com", role="Gameplan Member")
+
+		self.assertEqual(result["skipped"], ["disabled-user@example.com"])
+		self.assertEqual(result["granted"], [])
+		self.assertEqual(result["invited"], [])
+		self.assertFalse(frappe.db.exists("GP Invitation", {"email": "disabled-user@example.com"}))
+		self.assertNotIn("Gameplan Member", frappe.get_roles(user.name))
+
+	def test_one_call_splits_a_mixed_list_into_its_three_buckets(self):
+		create_user("mixed-account@example.com", "Mixed Account")
+		create_member("mixed-member@example.com")
+
+		result = _invite_by_email(
+			"mixed-account@example.com, mixed-new@example.com, mixed-member@example.com",
+			role="Gameplan Member",
+		)
+
+		self.assertEqual(result["granted"], ["mixed-account@example.com"])
+		self.assertEqual(result["invited"], ["mixed-new@example.com"])
+		self.assertEqual(result["skipped"], ["mixed-member@example.com"])
 
 	def test_invite_skips_a_user_who_already_holds_a_gameplan_role(self):
 		create_guest("already-guest@example.com")

--- a/gameplan/tests/features/test_invitations.py
+++ b/gameplan/tests/features/test_invitations.py
@@ -23,7 +23,13 @@ from frappe.utils import add_days, now, today
 from gameplan.api import _invite_by_email, accept_invitation
 from gameplan.gameplan.doctype.gp_invitation.gp_invitation import expire_invitations
 from gameplan.tests.base import GameplanTestCase
-from gameplan.tests.fixtures import create_community, create_member, create_space
+from gameplan.tests.fixtures import (
+	create_community,
+	create_guest,
+	create_member,
+	create_space,
+	create_user,
+)
 
 
 class InvitationTestCase(GameplanTestCase):
@@ -88,6 +94,33 @@ class TestInvitationCreation(InvitationTestCase):
 		_invite_by_email("already-member@example.com", role="Gameplan Member")
 
 		self.assertFalse(frappe.db.exists("GP Invitation", {"email": "already-member@example.com"}))
+
+	def test_invite_reaches_an_existing_user_with_no_gameplan_role(self):
+		"""Signing in through OAuth mints a Website User with no role, so an account can
+		exist while its owner has no way into Gameplan. That account must not read as an
+		existing member, or the invite is dropped and the person stays locked out."""
+		create_user("oauth-signup@example.com", "Oauth Signup")
+
+		_invite_by_email("oauth-signup@example.com", role="Gameplan Member")
+
+		self.assertTrue(frappe.db.exists("GP Invitation", {"email": "oauth-signup@example.com"}))
+
+	def test_accepting_that_invite_grants_the_role_to_the_existing_account(self):
+		user = create_user("oauth-accept@example.com", "Oauth Accept")
+		_invite_by_email("oauth-accept@example.com", role="Gameplan Member")
+
+		invitation = frappe.get_doc("GP Invitation", {"email": "oauth-accept@example.com"})
+		invitation.accept()
+
+		self.assertEqual(frappe.db.count("User", {"email": "oauth-accept@example.com"}), 1)
+		self.assertIn("Gameplan Member", frappe.get_roles(user.name))
+
+	def test_invite_skips_a_user_who_already_holds_a_gameplan_role(self):
+		create_guest("already-guest@example.com")
+
+		_invite_by_email("already-guest@example.com", role="Gameplan Member")
+
+		self.assertFalse(frappe.db.exists("GP Invitation", {"email": "already-guest@example.com"}))
 
 	def test_invite_skips_duplicate_pending_invite(self):
 		_invite_by_email("dup@example.com", role="Gameplan Member")

--- a/gameplan/tests/mutation/config.py
+++ b/gameplan/tests/mutation/config.py
@@ -88,6 +88,12 @@ TIER2: dict[str, list[str]] = {
 		# specced only here, as the privilege-escalation guards they are.
 		"gameplan.tests.features.test_members",
 	],
+	"gameplan/gameplan/doctype/gp_invitation/gp_invitation.py": [
+		# accept() and grant_access() are the only code that hands a user a Gameplan
+		# role, and grant_access does it with no click to confirm. test_invitations owns
+		# every branch of both.
+		"gameplan.tests.features.test_invitations",
+	],
 	"gameplan/api.py": [
 		"gameplan.tests.platform.test_api_endpoints",
 		# api.py is a grab-bag, and two of its endpoints are owned by feature specs

--- a/gameplan/tests/platform/test_app_access.py
+++ b/gameplan/tests/platform/test_app_access.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2026, Frappe Technologies Pvt Ltd and Contributors
+# See license.txt
+
+"""The /g gate: a signed-in user with no Gameplan role gets a 403, not the SPA.
+
+Every Gameplan doctype grants read to a Gameplan role, so such a user is denied on the
+first list call the SPA makes. The frontend cannot tell that 403 apart from an empty
+result: it reads the site as brand new and shows onboarding, which then fails on create.
+Users land in this state through OAuth, which mints a Website User with no role.
+"""
+
+import frappe
+from frappe.website.serve import get_response
+
+from gameplan.roles import has_app_access
+from gameplan.tests.base import GameplanTestCase
+from gameplan.tests.fixtures import create_user
+from gameplan.www.g import require_app_access
+
+
+class TestAppAccess(GameplanTestCase):
+	def setUp(self):
+		super().setUp()
+		self.roleless = create_user("roleless@example.com", "Roleless")
+
+	def test_a_user_with_no_gameplan_role_has_no_app_access(self):
+		self.assertFalse(has_app_access(self.roleless.name))
+
+	def test_every_gameplan_role_grants_app_access(self):
+		for user in (self.admin, self.member, self.guest):
+			self.assertTrue(has_app_access(user.name), user.name)
+
+	def test_administrator_always_has_app_access(self):
+		self.assertTrue(has_app_access("Administrator"))
+
+	def test_require_app_access_raises_for_a_user_with_no_role(self):
+		with self.as_user(self.roleless), self.assertRaises(frappe.PermissionError):
+			require_app_access()
+
+	def test_require_app_access_allows_a_member(self):
+		with self.as_user(self.member):
+			require_app_access()
+
+	def test_require_app_access_lets_guest_through_to_the_login_redirect(self):
+		"""Someone who has not signed in yet must reach the SPA, which sends them to
+		/login. Telling them they lack a role would be both wrong and a dead end."""
+		with self.as_user("Guest"):
+			require_app_access()
+
+	def test_g_responds_403_with_the_message(self):
+		# Only the denied path is driven through the real renderer. `get_context` calls
+		# frappe.db.commit() once it is past the gate, which would write this test's
+		# personas onto the site for good; the throw lands before that line.
+		with self.as_user(self.roleless):
+			response = get_response("/g")
+
+		self.assertEqual(response.status_code, 403)
+		self.assertIn("Ask an admin to invite you", response.get_data(as_text=True))

--- a/gameplan/tests/platform/test_app_access.py
+++ b/gameplan/tests/platform/test_app_access.py
@@ -10,6 +10,7 @@ Users land in this state through OAuth, which mints a Website User with no role.
 """
 
 import frappe
+from frappe.utils import set_request
 from frappe.website.serve import get_response
 
 from gameplan.roles import has_app_access
@@ -48,9 +49,18 @@ class TestAppAccess(GameplanTestCase):
 			require_app_access()
 
 	def test_g_responds_403_with_the_message(self):
+		# NotPermittedPage builds its login link from `frappe.request.path`, and a unit
+		# test has no bound request. `set_request` is frappe's own helper for calling the
+		# renderer outside HTTP (see frappe.utils.get_html_for_route). Delete it again
+		# afterwards: frappe.local outlives the transaction rollback, so a request left
+		# bound here would change how a later test in the same shard behaves.
+		#
 		# Only the denied path is driven through the real renderer. `get_context` calls
 		# frappe.db.commit() once it is past the gate, which would write this test's
 		# personas onto the site for good; the throw lands before that line.
+		set_request(method="GET", path="/g")
+		self.addCleanup(delattr, frappe.local, "request")
+
 		with self.as_user(self.roleless):
 			response = get_response("/g")
 

--- a/gameplan/www/g.py
+++ b/gameplan/www/g.py
@@ -5,16 +5,19 @@ import os
 import subprocess
 
 import frappe
-from frappe import safe_decode
+from frappe import _, safe_decode
 from frappe.core.api.file import get_max_file_size
 from frappe.utils import get_system_timezone
 from frappe.utils.telemetry import capture
+
+from gameplan.roles import has_app_access
 
 no_cache = 1
 
 
 def get_context():
 	login_as_demo_user_if_enabled()
+	require_app_access()
 	csrf_token = frappe.sessions.get_csrf_token()
 	frappe.db.commit()
 	context = frappe._dict()
@@ -44,6 +47,26 @@ def get_boot():
 			"app_version": get_app_version(),
 			"system_timezone": get_system_timezone(),
 		}
+	)
+
+
+def require_app_access():
+	"""Deny /g to a signed-in user who holds no Gameplan role.
+
+	Frappe renders a PermissionError from a www page as `NotPermittedPage`: HTTP 403,
+	this message, and a link back home. Without it the SPA loads, every list call is
+	denied, and the router mistakes the empty result for an empty site and shows
+	onboarding.
+
+	Guest falls through on purpose. Someone who has not signed in yet should be sent to
+	/login by the SPA, not told they lack a role.
+	"""
+	if frappe.session.user == "Guest" or has_app_access():
+		return
+
+	frappe.throw(
+		_("You do not have access to Gameplan. Ask an admin to invite you."),
+		frappe.PermissionError,
 	)
 
 

--- a/gameplan/www/g.py
+++ b/gameplan/www/g.py
@@ -54,9 +54,10 @@ def require_app_access():
 	"""Deny /g to a signed-in user who holds no Gameplan role.
 
 	Frappe renders a PermissionError from a www page as `NotPermittedPage`: HTTP 403,
-	this message, and a link back home. Without it the SPA loads, every list call is
-	denied, and the router mistakes the empty result for an empty site and shows
-	onboarding.
+	this message, and a way out. Which way out depends on the frappe version, so do not
+	rely on it: version-16 always offers Login, develop offers Home to a signed-in user.
+	Without this gate the SPA loads, every list call is denied, and the router mistakes
+	the empty result for an empty site and shows onboarding.
 
 	Guest falls through on purpose. Someone who has not signed in yet should be sent to
 	/login by the SPA, not told they lack a role.


### PR DESCRIPTION
## Problem

A user who signs in with no Gameplan role sees the **onboarding screen**, on a site full of data.

Reported on `gameplan.frappe.cloud`. 19 of 117 enabled users are in this state. All were created by `Guest` through the `frappe` OAuth provider: `login_via_oauth2` mints a Website User and assigns no role.

Two defects combine.

**1. The SPA misreads a 403 as an empty site.**

Every Gameplan doctype grants read to a Gameplan role or System Manager, so a role-less user is denied on the first list call the SPA makes:

```
roles: ['All', 'Guest']
has_permission GP Team read: False
get_list GP Team raised: PermissionError Insufficient Permission for GP Team
total teams on site: 4
```

`useList` fails open to `initialData: []`. `hasAnyData()` in `router.ts` reads `communities.data.length` and `spaces.data.length`, sees 0, and `getDesktopHomeRoute()` returns `Onboarding`. Onboarding is then a dead end: `gameplan.api.onboarding` inserts a `GP Team`, which the user cannot create either.

`get_default_route()` is not involved. It uses `frappe.db.get_all`, which ignores permissions, so the server correctly returns `/home`. The misroute is entirely client side.

**2. These users cannot be invited.**

`_invite_by_email` skipped every email that already had a `User` record. An OAuth account exists while its owner has no way into Gameplan, so the one action that would fix them was dropped silently.

## Changes

### 1. `fix(access)`: a 403 on `/g`

Adds `has_app_access()` to `gameplan/roles.py` and `require_app_access()` to `gameplan/www/g.py`. It throws a `PermissionError` from `get_context`, which frappe renders as its Not Permitted page: HTTP 403, a message, and a link home.

Guest falls through on purpose. Someone who has not signed in yet must reach the SPA, which sends them to `/login`.

### 2. `fix(invitations)`: stop skipping account-without-role

Narrows the dedupe filter to emails whose User already holds a Gameplan role, through a new `emails_holding_a_gameplan_role()` helper (one `frappe.qb` join on `Has Role`).

### 3. `feat(invitations)`: grant access directly when the account exists

The email link exists to mint a `User`. If the account is already here, the link creates nothing, sets no password, and asks an OAuth user for a step they cannot complete. So `_invite_by_email` now splits the list on whether an account exists:

| Case | Action |
| --- | --- |
| No account on the site | Invitation email, as before. The link mints the User. |
| Enabled account, no Gameplan role | Role granted now. A short "you now have access" mail, with no accept link. |
| Disabled account | Skipped. The role changes nothing while the account cannot sign in, and mailing an accept link would hand the role to an account someone switched off. |

`grant_access()` still writes the `GP Invitation` row and then calls `accept()` on it. That keeps `accept()` the single definition of what access means, including the `GP Guest Access` rows a guest needs, and leaves the same audit trail as any other invitation.

`invite_by_email` returns three buckets (`granted`, `invited`, `skipped`) so the dialog can say which happened. The members list behind the dialog reloads when anyone was granted, since they hold a role now.

### 4. `fix(invitations)`: the result goes in the dialog

The first cut put the counts in a toast. That split the answer: the toast held the counts while Pending Invites, the other half of the same answer, stayed in the dialog. The result now sits between the form and Pending Invites, grouped by bucket with the addresses under each label, so the admin can see which email landed where. A footnote explains what "skipped" covers, since it has three causes.

![Invite People dialog showing the grouped result: 2 people given access, 1 invitation sent, 1 skipped](https://github.com/user-attachments/assets/af602f83-3524-4794-98ae-80c28a97e4aa)

https://github.com/user-attachments/assets/f5baa343-f01a-4fbf-90fc-c7123be5497f

Deepak and Maitri have accounts but no role, so the Users list does not show them. One invite covers four addresses, one per outcome: the two existing accounts get access at once, `sam@northwind.test` has no account and gets the email, and `member@example.com` already holds a role and is skipped. The list behind the dialog fills in without a reload.

## Verification

Real HTTP against a role-less user on a local site:

```
POST /api/method/login  -> {"full_name":"No Role Probe"}
GET  /g                 -> status=403
page text: Not Permitted | You do not have access to Gameplan.
                            Ask an admin to invite you. | Home
```

Invite flow end to end, then rolled back:

```
roles before:       ['All', 'Guest']
invitations:        [{'role': 'Gameplan Member', 'status': 'Pending'}]
roles after accept: ['Gameplan Member', 'All', 'Guest']
user count:         1        # no duplicate account
```

## Tests

New `gameplan/tests/platform/test_app_access.py` (7 tests) and 8 new cases in `test_invitations.py`, one per branch of the table above plus the mixed list. `gp_invitation.py` is now a TIER1 entry in the mutation config, since `accept()` and `grant_access()` are the only code that hands out a role and `grant_access` does it with no click to confirm.

```
features.test_invitations       Ran 26 tests   OK
features.test_members           Ran  9 tests   OK
platform.test_api_endpoints     Ran 27 tests   OK
platform.test_app_access        Ran  7 tests   OK
mutation.test_mutation_ci       Ran 182 tests  OK
mutation.test_mutation_safety   Ran 27 tests   OK
```

The commit-1 and commit-2 tests were each confirmed red without their fix:

| State | Result |
| --- | --- |
| Without the `/g` gate | `test_g_responds_403_with_the_message` fails, `<Response 200 OK>` |
| Without the invite fix | both new invite tests fail, no `GP Invitation` row |

Full backend suite on `gameplan-demo.test`: `Ran 1076 tests ... FAILED (failures=9, errors=14)`. The same suite with this branch stashed produces an **identical** failure list, so all 23 pre-date this branch (quick-reactions and read-state suites, unrelated).

## Not included

- **No production data change.** The 19 affected users still hold no role. They now get a clear 403 instead of a broken onboarding screen, and an admin can invite them in one click.
- **`hasAnyData()` in `router.ts` is unchanged.** The `/g` gate makes it unreachable for a role-less user, because the SPA never loads. The underlying confusion between "denied" and "empty" remains for any other failing list call.
- **`get_context_for_dev` is not gated.** It serves the Vite dev path only, where a 403 gives a blank page rather than a message.
- **`existing_invites` still ignores status.** An Expired or Accepted invitation on an email blocks a re-invite. Pre-existing, not touched here.
- **The password-setup detour is gone for existing accounts, not fixed in general.** `accept_invitation` routes to password setup when `last_password_reset_date` is null, which it is for the whole OAuth cohort. Those users are now granted directly and never see a link, so they no longer hit it. An email with no account still goes through the link, where setting a password is the right step.


---

## Commit 4: a new member joins every public community

Getting access was only half the arrival. A new account still signed in to an empty shell.

Membership does not gate a public community. `team_access_criterion` is `(Team.is_private == 0) | is_member_parent(...)`, so anyone may read one either way. What membership decides is what the **sidebar lists**: `isCommunityJoined` in `communities.ts` feeds `activeCommunities`, and without a `GP Member` row nothing appears until the user goes and finds the communities themselves.

`accept()` now adds the invitee to every public, non-archived community. It is the single definition of getting access, so both paths inherit it: the email link, and `grant_access` from commit 2.

Two boundaries:

- **Guests join nothing.** Their reach is exactly the `GP Guest Access` rows written one line earlier, and joining them to everything would undo that.
- **The save skips link validation.** Saving a community re-validates every row already in `members`. One row left pointing at a deleted account would otherwise stop anyone new from joining anywhere. This was not theoretical: it broke 11 tests on a community holding an orphaned row. The row being added is safe by construction, since `user` is a User document just loaded or created.

`community_order` is deliberately left unset. `sortCommunitiesByUserOrder` gives an unlisted community `MAX_SAFE_INTEGER` and falls back to `title.localeCompare`, so the sidebar degrades to alphabetical, which is the right default for a brand-new account.

Six new tests: the join, the private and archived exclusions, the guest exclusion, no duplicate row for an existing member, and the direct-grant path inheriting the join.

Full suite on `gameplan-demo.test`, `d5302ca5` to `c1327e1d`: **1081 to 1087 tests, 9 failures + 14 errors both times.** Diffed by name, not just count: nothing new appears and nothing disappears.

### Not included in this commit

- **Role changes do not join.** Promoting an existing Guest to Member through `change_user_role` is a role change, not a join, and is untouched.
- **No backfill.** Users who already exist are not joined to public communities they have not joined. That is a patch and a separate decision.
