### PR TITLE
feat(communities): bulk-add members with a searchable picker

### DIFF
--- a/frontend/cypress/e2e/communities/add-members.cy.ts
+++ b/frontend/cypress/e2e/communities/add-members.cy.ts
@@ -1,0 +1,81 @@
+// Adding members is the community manager's bulk action: search the people who
+// are not in the community yet, tick as many as you want, add them in one call.
+import { resetData } from '../../support/seed'
+
+describe('Adding members to a community', () => {
+  beforeEach(() => {
+    resetData('two_communities')
+    // Administrator manages every community, so the Add members trigger is there.
+    cy.loginAs('admin')
+    cy.visit('/g/settings/communities/alpha/members')
+    cy.contains('button:visible', 'Add members').should('be.visible')
+  })
+
+  // The settings screen is itself a dialog, so scope by something only the
+  // picker has.
+  const picker = () => cy.get('[role="dialog"]').filter(':has(input[aria-label="Search people"])')
+  const pickerRows = () => cy.get('[aria-label="People you can add"] [data-slot="list-row"]')
+  const selectAll = () => picker().contains('label', /^Select /)
+
+  const openPicker = () => {
+    cy.contains('button:visible', 'Add members').click()
+    cy.get('input[aria-label="Search people"]').should('be.visible')
+  }
+
+  it('lists only the people who are not members yet', () => {
+    openPicker()
+
+    pickerRows().should('have.length.at.least', 1)
+    pickerRows().contains('Outsider').should('be.visible')
+    // Alpha's seeded members are already in, so they are not offered again.
+    pickerRows().contains('Second Member').should('not.exist')
+
+    picker().contains('0 selected').should('be.visible')
+    picker().contains('button', 'Add members').should('be.disabled')
+  })
+
+  it('filters the list as you search', () => {
+    openPicker()
+
+    cy.get('input[aria-label="Search people"]').type('outsider')
+    pickerRows().should('have.length', 1)
+    pickerRows().contains('Outsider').should('be.visible')
+    selectAll().should('contain.text', 'Select 1 matching')
+
+    cy.get('input[aria-label="Search people"]').clear().type('nobodyhasthisname')
+    cy.contains('No people match your search.').should('be.visible')
+  })
+
+  it('selects every addable person at once and counts them on the button', () => {
+    openPicker()
+
+    pickerRows().then(($rows) => {
+      const count = $rows.length
+      selectAll().click()
+
+      picker().contains(`${count} selected`).should('be.visible')
+      const label = count === 1 ? 'Add 1 member' : `Add ${count} members`
+      picker().contains('button', label).should('be.enabled')
+    })
+  })
+
+  it('adds everyone selected in one submit', () => {
+    openPicker()
+
+    pickerRows().then(($rows) => {
+      const count = $rows.length
+      selectAll().click()
+      const label = count === 1 ? 'Add 1 member' : `Add ${count} members`
+      picker().contains('button', label).click()
+    })
+
+    // The picker closes and the members list behind it picks up the new rows.
+    cy.get('input[aria-label="Search people"]').should('not.exist')
+    cy.contains(/added to Alpha/).should('be.visible')
+    cy.contains('[data-slot="list-row"]', 'Outsider').should('be.visible')
+
+    // Reopening offers nobody: everyone belongs to the community now.
+    cy.contains('button:visible', 'Add members').click()
+    cy.contains('Everyone already belongs to this community.').should('be.visible')
+  })
+})

--- a/frontend/src/pages/Configure/AddCommunityMembersDialog.vue
+++ b/frontend/src/pages/Configure/AddCommunityMembersDialog.vue
@@ -1,0 +1,268 @@
+<template>
+  <Dialog v-model:open="show" size="md" bare @after-leave="reset">
+    <!-- Fixed height: the body never resizes when the filter narrows, when rows
+         are selected, or while the user list loads. dvh (not vh) because the
+         mobile keyboard opens over this dialog the moment the search focuses. -->
+    <div class="flex flex-col" style="height: min(560px, calc(100dvh - 8rem))">
+      <div
+        class="flex shrink-0 items-center justify-between border-b border-outline-gray-1 px-4 py-3"
+      >
+        <Dialog.Title as-child>
+          <h2 class="text-lg font-medium text-ink-gray-9">Add members</h2>
+        </Dialog.Title>
+        <Dialog.Close as-child>
+          <Button variant="ghost" label="Close" icon="lucide-x" />
+        </Dialog.Close>
+      </div>
+
+      <!-- Named for the dialog itself: without a description reka logs a missing
+           aria-describedby warning, and a screen reader gets only the title. -->
+      <Dialog.Description as-child>
+        <p class="sr-only">Search people and select who to add to {{ community.title }}.</p>
+      </Dialog.Description>
+
+      <div class="shrink-0 space-y-3 border-b border-outline-gray-1 px-4 py-3">
+        <TextInput
+          v-model="search"
+          class="w-full"
+          placeholder="Search by name or email"
+          aria-label="Search people"
+          autofocus
+        >
+          <template #prefix>
+            <span class="lucide-search size-4 text-ink-gray-4" aria-hidden="true" />
+          </template>
+        </TextInput>
+
+        <!-- Fixed height so the bar never changes the body's size. -->
+        <div class="flex h-7 items-center justify-between gap-3">
+          <Checkbox
+            size="sm"
+            :label="selectAllLabel"
+            :model-value="allMatchesSelected"
+            :indeterminate="someMatchesSelected"
+            :disabled="!matches.length"
+            @update:model-value="setMatchesSelected"
+          />
+          <div class="flex items-center gap-2">
+            <span class="text-base text-ink-gray-5" aria-live="polite">
+              {{ selected.length }} selected
+            </span>
+            <Button variant="ghost" size="sm" :disabled="!selected.length" @click="selected = []">
+              Clear
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <ScrollArea class="min-h-0 flex-1" viewport-class="px-2 py-2">
+        <div v-if="!usersReady" class="space-y-1" role="status" aria-label="Loading people">
+          <div v-for="n in 8" :key="n" class="flex h-13 items-center gap-3 px-3">
+            <Skeleton class="size-7 shrink-0 rounded-full" />
+            <div class="min-w-0 flex-1 space-y-2">
+              <Skeleton class="h-3.5 w-40 rounded-4" />
+              <Skeleton class="h-3 w-56 rounded-4" />
+            </div>
+          </div>
+        </div>
+
+        <EmptyStateBox v-else-if="!addableUsers.length" class="mt-6">
+          <span class="lucide-users size-5 text-ink-gray-4" aria-hidden="true" />
+          <div class="mt-2 text-p-sm text-ink-gray-5">
+            Everyone already belongs to this community.
+          </div>
+        </EmptyStateBox>
+
+        <EmptyStateBox v-else-if="!matches.length" class="mt-6">
+          <span class="lucide-search-x size-5 text-ink-gray-4" aria-hidden="true" />
+          <div class="mt-2 text-p-sm text-ink-gray-5">No people match your search.</div>
+          <Button class="mt-3" @click="search = ''">Clear search</Button>
+        </EmptyStateBox>
+
+        <!-- list-row-px-2 matches the viewport's px-2 gutter, the same rule as
+             Search.vue: row content lines up with the search field above (and
+             so does the checkbox column), and only the highlight surface bleeds
+             one gutter past it on each side.
+             Dividers keep consecutive selected rows apart. They step up to
+             outline-gray-2 on a selected row, because outline-gray-1 is one
+             shade off the selected surface and disappears into it. -->
+        <List
+          v-else
+          selectable
+          v-model:selection="selected"
+          :columns="['auto', 'minmax(0,1fr)']"
+          :row-height="52"
+          divider="inset"
+          aria-label="People you can add"
+          class="list-row-px-2 [&_[data-slot=list-row][data-state=selected]]:bg-surface-gray-2 sm:[&_[data-slot=list-row][data-state=selected]:hover]:bg-surface-gray-3 [&_[data-slot=list-row][data-state=selected]_[data-slot=list-divider]]:border-outline-gray-2"
+        >
+          <!-- Virtualized: a full user list would otherwise mount one avatar per
+               person at once. ListRows windows against the ScrollArea viewport. -->
+          <ListRows :items="matches" virtual row-key="name" v-slot="{ item: user }">
+            <ListRow :value="user.name" :aria-label="`${user.full_name}, ${user.email}`">
+              <ListCell>
+                <UserAvatar :user="user.name" size="lg" class="shrink-0" />
+              </ListCell>
+              <ListCell>
+                <div class="min-w-0">
+                  <div class="truncate text-base text-ink-gray-8">{{ user.full_name }}</div>
+                  <div class="mt-0.5 truncate text-sm text-ink-gray-5">{{ user.email }}</div>
+                </div>
+              </ListCell>
+            </ListRow>
+          </ListRows>
+        </List>
+      </ScrollArea>
+
+      <!-- Stacked below sm: a right-aligned button leaves a dead strip beside it
+           on a phone, so the button takes the full width and the error sits
+           above it. -->
+      <div
+        class="flex shrink-0 flex-col gap-2 border-t border-outline-gray-1 px-4 py-3 sm:flex-row sm:items-center sm:justify-between sm:gap-3"
+      >
+        <!-- min-h-5 holds one line of error text, so a failed submit does not
+             resize the footer. -->
+        <div class="min-h-5 min-w-0 sm:flex-1">
+          <ErrorMessage :message="submitError" />
+        </div>
+        <!-- min-w-32: the label grows leftwards as the count changes, so nothing
+             else in the footer moves. -->
+        <Button
+          variant="solid"
+          class="w-full shrink-0 sm:w-auto sm:min-w-32"
+          :disabled="!selected.length"
+          :loading="isAdding"
+          @click="submit"
+        >
+          {{ submitLabel }}
+        </Button>
+      </div>
+    </div>
+  </Dialog>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import {
+  Button,
+  Checkbox,
+  Dialog,
+  ErrorMessage,
+  ScrollArea,
+  Skeleton,
+  TextInput,
+  toast,
+  useDoctype,
+} from 'frappe-ui'
+import { List, ListCell, ListRow, ListRows } from 'frappe-ui/list'
+import UserAvatar from '@/components/UserAvatar.vue'
+import EmptyStateBox from '@/components/EmptyStateBox.vue'
+import { communities, type Community } from '@/data/communities'
+import { activeUsers, usersReady, useUser } from '@/data/users'
+import type { GPTeam } from '@/types/doctypes'
+
+const props = defineProps<{
+  community: Community
+}>()
+
+const show = defineModel<boolean>()
+
+const teams = useDoctype<GPTeam>('GP Team')
+const search = ref('')
+const selected = ref<string[]>([])
+const submitError = ref<Error | string>()
+
+const searchTerm = computed(() => search.value.trim().toLowerCase())
+
+const addableUsers = computed(() => {
+  const existingMembers = new Set(props.community.members.map((member) => member.user))
+  return activeUsers.value
+    .filter((user) => user.isNotGuest && !existingMembers.has(user.name))
+    .sort((a, b) => a.full_name.localeCompare(b.full_name))
+})
+
+const matches = computed(() => {
+  const term = searchTerm.value
+  if (!term) return addableUsers.value
+  return addableUsers.value.filter(
+    (user) =>
+      user.full_name.toLowerCase().includes(term) ||
+      (user.email || '').toLowerCase().includes(term),
+  )
+})
+
+const matchNames = computed(() => new Set(matches.value.map((user) => user.name)))
+const selectedSet = computed(() => new Set(selected.value))
+
+const allMatchesSelected = computed(
+  () => matches.value.length > 0 && matches.value.every((user) => selectedSet.value.has(user.name)),
+)
+
+const someMatchesSelected = computed(
+  () => !allMatchesSelected.value && matches.value.some((user) => selectedSet.value.has(user.name)),
+)
+
+const selectAllLabel = computed(() => {
+  if (!matches.value.length) return 'Select all'
+  if (!searchTerm.value) return `Select all ${matches.value.length} people`
+  return `Select ${matches.value.length} matching`
+})
+
+const submitLabel = computed(() => {
+  const count = selected.value.length
+  if (!count) return 'Add members'
+  return count === 1 ? 'Add 1 member' : `Add ${count} members`
+})
+
+const isAdding = computed(() => teams.runDocMethod.isLoading(props.community.name, 'add_members'))
+
+/**
+ * Add or remove exactly the users the current search matches, leaving every other
+ * pick alone — the same rule as frappe-ui's own `List.toggleSelectAll`.
+ *
+ * Driven by the checkbox's own value rather than by toggling the current state, so
+ * it stays correct even though `Checkbox` emits `update:modelValue` twice per click.
+ */
+function setMatchesSelected(checked: boolean | 1 | 0 | undefined) {
+  if (checked) {
+    selected.value = [...new Set([...selected.value, ...matchNames.value])]
+  } else {
+    selected.value = selected.value.filter((name) => !matchNames.value.has(name))
+  }
+}
+
+function successMessage(users: string[]) {
+  if (users.length === 1) {
+    return `${useUser(users[0]).full_name} added to ${props.community.title}`
+  }
+  return `${users.length} members added to ${props.community.title}`
+}
+
+async function submit() {
+  const users = [...selected.value]
+  if (!users.length) return
+
+  submitError.value = undefined
+  try {
+    await teams.runDocMethod.submit({
+      name: props.community.name,
+      method: 'add_members',
+      params: { users },
+    })
+  } catch (error) {
+    // Kept in a local ref rather than read off `teams.runDocMethod.error`, which
+    // outlives the dialog and would reappear on the next open.
+    submitError.value = error as Error
+    return
+  }
+  await communities.reload()
+  toast.success(successMessage(users))
+  show.value = false
+}
+
+function reset() {
+  search.value = ''
+  selected.value = []
+  submitError.value = undefined
+}
+</script>

--- a/frontend/src/pages/Configure/AddCommunityMembersDialog.vue
+++ b/frontend/src/pages/Configure/AddCommunityMembersDialog.vue
@@ -80,12 +80,10 @@
         </EmptyStateBox>
 
         <!-- list-row-px-2 matches the viewport's px-2 gutter, the same rule as
-             Search.vue: row content lines up with the search field above (and
-             so does the checkbox column), and only the highlight surface bleeds
-             one gutter past it on each side.
-             Dividers keep consecutive selected rows apart. They step up to
-             outline-gray-2 on a selected row, because outline-gray-1 is one
-             shade off the selected surface and disappears into it. -->
+             Search.vue: row content and the checkbox column line up with the
+             search field above.
+             The row carries no hover or selected surface: the checkbox is the
+             only selection state, so a 700-row list never washes grey. -->
         <List
           v-else
           selectable
@@ -94,7 +92,7 @@
           :row-height="52"
           divider="inset"
           aria-label="People you can add"
-          class="list-row-px-2 [&_[data-slot=list-row][data-state=selected]]:bg-surface-gray-2 sm:[&_[data-slot=list-row][data-state=selected]:hover]:bg-surface-gray-3 [&_[data-slot=list-row][data-state=selected]_[data-slot=list-divider]]:border-outline-gray-2"
+          class="list-row-px-2 sm:[&_[data-slot=list-row]:hover]:bg-transparent"
         >
           <!-- Virtualized: a full user list would otherwise mount one avatar per
                person at once. ListRows windows against the ScrollArea viewport. -->

--- a/frontend/src/pages/Configure/CommunityMembersList.vue
+++ b/frontend/src/pages/Configure/CommunityMembersList.vue
@@ -73,60 +73,16 @@
 
   <CommunityGuestsList class="mt-10" :community="community" :can-manage="canManage" />
 
-  <Dialog v-if="canManage" title="Add members" v-model:open="showAddDialog">
-    <div class="space-y-4">
-      <ul v-if="membersToAdd.length" class="flex flex-wrap gap-2">
-        <li
-          class="flex items-center gap-2 rounded-4 bg-surface-gray-2 px-2 py-1.5"
-          v-for="user in membersToAdd"
-          :key="user.value"
-        >
-          <UserAvatar :user="user.value" size="sm" />
-          <span class="text-base text-ink-gray-8">{{ user.label }}</span>
-          <Button
-            variant="ghost"
-            size="xs"
-            icon="lucide-x"
-            @click="membersToAdd = membersToAdd.filter((member) => member.value !== user.value)"
-          />
-        </li>
-      </ul>
-
-      <Combobox
-        :options="addableMembers"
-        v-model="selectedUser"
-        placeholder="Jane Doe"
-        open-on-click
-      >
-        <template #item-prefix="{ item }">
-          <UserAvatar :user="item.value" size="xs" />
-        </template>
-      </Combobox>
-      <ErrorMessage :message="teams.runDocMethod.error" />
-    </div>
-    <template #actions>
-      <Button
-        class="w-full"
-        variant="solid"
-        :disabled="!membersToAdd.length"
-        :loading="teams.runDocMethod.isLoading(community.name, 'add_members')"
-        @click="addMembers"
-      >
-        Add
-      </Button>
-    </template>
-  </Dialog>
+  <AddCommunityMembersDialog v-if="canManage" v-model="showAddDialog" :community="community" />
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
-import { Button, Combobox, Dialog, ErrorMessage, toast, useDoctype } from 'frappe-ui'
+import { computed } from 'vue'
+import { Button } from 'frappe-ui'
 import { List, ListHeader, ListHeaderCell } from 'frappe-ui/list'
 import type { Community } from '@/data/communities'
-import { communities } from '@/data/communities'
-import { activeUsers, useUser } from '@/data/users'
-import UserAvatar from '@/components/UserAvatar.vue'
-import type { GPTeam } from '@/types/doctypes'
+import { useUser } from '@/data/users'
+import AddCommunityMembersDialog from './AddCommunityMembersDialog.vue'
 import ConfigureEmptyState from './ConfigureEmptyState.vue'
 import CommunityGuestsList from './CommunityGuestsList.vue'
 import CommunityMembersListControls from './CommunityMembersListControls.vue'
@@ -148,10 +104,6 @@ const props = withDefaults(
 // header while this component still renders the list and owns the add dialog.
 const search = defineModel<string>('search', { default: '' })
 const showAddDialog = defineModel<boolean>('showAddDialog', { default: false })
-
-const teams = useDoctype<GPTeam>('GP Team')
-const selectedUser = ref<string | null>(null)
-const membersToAdd = ref<{ value: string; label: string }[]>([])
 
 const communityMembers = computed(() => {
   const seen = new Set<string>()
@@ -177,47 +129,4 @@ const filteredMembers = computed(() => {
     )
   })
 })
-
-const addableMembers = computed(() => {
-  const existingMembers = new Set(props.community.members.map((member) => member.user))
-  const queuedMembers = new Set(membersToAdd.value.map((member) => member.value))
-
-  return activeUsers.value
-    .filter((user) => user.isNotGuest)
-    .filter((user) => !existingMembers.has(user.name) && !queuedMembers.has(user.name))
-    .sort((a, b) => a.full_name.localeCompare(b.full_name))
-    .map((user) => ({ value: user.name, label: user.full_name }))
-})
-
-watch(selectedUser, (value) => {
-  if (!value) return
-
-  const user = addableMembers.value.find((member) => member.value === value)
-  if (user) {
-    membersToAdd.value.push(user)
-  }
-  selectedUser.value = null
-})
-
-watch(showAddDialog, (value) => {
-  if (!value) {
-    selectedUser.value = null
-    membersToAdd.value = []
-  }
-})
-
-async function addMembers() {
-  if (!props.canManage || !membersToAdd.value.length) return
-
-  await teams.runDocMethod.submit({
-    name: props.community.name,
-    method: 'add_members',
-    params: {
-      users: membersToAdd.value.map((member) => member.value),
-    },
-  })
-  await communities.reload()
-  toast.success('Members added')
-  showAddDialog.value = false
-}
 </script>


### PR DESCRIPTION
Adding people to a community was one person per interaction. On partners.frappe.io that community has 700+ users and 119 members, and an admin has no way to close the gap. Community membership is what puts a community and its public spaces in a person's sidebar, so the people outside it are not just missing a row in a list.

This replaces the picker with a searchable multi-select list and makes "add everyone" one click.

## Demo

Open the picker, search, clear, tick two people, select all 19, submit.

![add members demo](https://md.netchamp.dev/gameplan-add-members-ux/demo.gif)

WebM of the same pass: https://md.netchamp.dev/gameplan-add-members-ux/demo.webm

## What was wrong

Measured in a browser, not read off the code:

- The Combobox kept the last picked name as its value, so the same person appeared twice: once as a chip, once in the input.
- The dialog resized on every pick — 512x196 empty, 512x232 with two chips — and re-centred as chips wrapped.
- The dropdown closed after each selection, so adding N people cost N reopens.
- The trigger was 262px wide inside a 512px dialog.
- Escape wiped the queued chips with no confirm.
- No count, no select-all, no loading state, no "everyone is already a member" state, and the chip remove button had no accessible name.

Two people picked. "Chloe Kim" is both a chip and the input's value:

![before](https://md.netchamp.dev/gameplan-add-members-ux/before-dialog-two-selected.png)

## What it is now

![after](https://md.netchamp.dev/gameplan-add-members-ux/after-dialog-empty.png)

`AddCommunityMembersDialog.vue`, extracted out of `CommunityMembersList.vue`:

- Fixed height, `min(560px, calc(100dvh - 8rem))`. The body never resizes — on filter, on selection, or between the loading and loaded states. Measured at 560px across nine states.
- Search over name and email, undebounced: it is an array pass with no request behind it.
- A virtualized list of everyone addable, with avatar, name and email. `ListRows virtual` over the same `activeUsers` array `MembersSettings.vue` already virtualizes, so 700 people mount ~13 rows.
- Select all is the bulk control. With an empty search it covers everyone, so adding 700 people is one click. It adds to the selection rather than replacing it, matching frappe-ui's own `List.toggleSelectAll`, and the label states which set it covers: `Select all 19 people` vs `Select 4 matching`.
- The count appears twice — beside the control and on the button — because that count is the only confirmation before a bulk permission grant.
- People the search filters out stay selected and stay counted.
- Empty states for "no matches" and for a community everyone already belongs to. Loading renders skeleton rows at the same height, so nothing moves when the data lands.
- A failed submit keeps the dialog open with the selection intact and puts the error in a footer slot with a reserved height, so the footer does not resize.

Search narrows the list and the select-all label follows it:

![search](https://md.netchamp.dev/gameplan-add-members-ux/after-search-filtered.png)

Select all:

![select all](https://md.netchamp.dev/gameplan-add-members-ux/after-select-all.png)

Mobile, 375px — full-width button, error slot still reserved:

<img src="https://md.netchamp.dev/gameplan-add-members-ux/after-mobile.png" width="375">

## Backend

Unchanged. `GP Team.add_members(users)` already takes a list and is gated by `require_can_manage_community`. One POST carries every id: `GPTeam` has no `validate`, `on_update` or `before_save`, so the whole add is a single child-table write, and 700 ids is a ~20KB body. Chunking would buy nothing and would invent a partial-success state.

## Tests

New `frontend/cypress/e2e/communities/add-members.cy.ts`: the picker excludes existing members, search filters, select-all counts on the button, and one submit adds everyone and leaves the picker empty.

```
npx cypress run --spec cypress/e2e/communities/add-members.cy.ts
  ✔  add-members.cy.ts    00:14    4    4    -    -    -
```

Also verified by hand against a real site: virtual scroll reaches the last row with no drift (`scrollHeight 1004 = 19x52 + 16`, rows exactly 52px apart), select-across-searches accumulates, and the keyboard path is search → select all → Clear → rows, one tab stop per row.

## Not in this PR

- `SpaceAccessDialog.vue` still adds users to a private space one at a time. The same picker would fit, but it has a different permission gate, so it is its own change.
- Two frappe-ui gaps found on the way, both worth an upstream PR, neither blocking: `List` ships no selected-row surface for a `selectable` list (worked around here through the `data-state` hook), and `ListRow`'s checkbox has `role="checkbox"` with no accessible name and no way to pass one in.
- The community list is fetched with every member row at app boot, so a 700-member community makes that payload bigger for everyone. Pre-existing and unrelated to who does the adding, but this change makes it easier to reach.
