### PR TITLE
fix(drafts): keep the drafts list in the doctype store

### DIFF
--- a/frontend/cypress/e2e/comments/comment-drafts.cy.ts
+++ b/frontend/cypress/e2e/comments/comment-drafts.cy.ts
@@ -28,8 +28,8 @@ describe('Comment drafts', () => {
   const interceptDrafts = () => cy.intercept(/get_my_drafts/).as('getDrafts')
 
   it('shows a comment draft in the list and reopens it with the composer restored', () => {
-    // The draft is created lazily on the first push via frappe.client.insert.
-    cy.intercept('POST', '/api/method/frappe.client.insert').as('draftInsert')
+    // The draft row is created lazily on the first push, through the GP Draft list.
+    cy.intercept('POST', '/api/v2/document/GP%20Draft').as('draftInsert')
 
     cy.visit(`/g/community/${community}/space/${space}/discussion/${discussion}`)
 
@@ -54,7 +54,7 @@ describe('Comment drafts', () => {
   })
 
   it('removes the comment draft from the list once submitted', () => {
-    cy.intercept('POST', '/api/method/frappe.client.insert').as('draftInsert')
+    cy.intercept('POST', '/api/v2/document/GP%20Draft').as('draftInsert')
     cy.intercept('POST', '/api/v2/document/GP%20Comment').as('comment')
 
     cy.visit(`/g/community/${community}/space/${space}/discussion/${discussion}`)

--- a/frontend/cypress/e2e/discussions/composer.cy.ts
+++ b/frontend/cypress/e2e/discussions/composer.cy.ts
@@ -36,7 +36,10 @@ describe('Community composer and drafts', () => {
     // is created on space-select; the title/content land on a following autosave).
     const draftContent = 'Published from the scoped composer.'
     let draftContentSaved = false
-    cy.intercept('POST', '**/api/method/frappe.client.*', (req) => {
+    // Autosave writes the GP Draft row: POST to create it, PUT for every later push. Match
+    // both with one method-less regex — the doctype segment is percent-encoded ("GP%20Draft"),
+    // which a minimatch glob can't target cleanly.
+    cy.intercept(/\/api\/v2\/document\/GP%20Draft/, (req) => {
       if (JSON.stringify(req.body ?? {}).includes(draftContent)) draftContentSaved = true
     })
 

--- a/frontend/cypress/e2e/discussions/new-discussion.cy.ts
+++ b/frontend/cypress/e2e/discussions/new-discussion.cy.ts
@@ -43,7 +43,10 @@ describe('New discussion drafts', () => {
     const updatedContent = 'This is my updated draft content. Ready to publish!'
     let draftContentSaved = false
     let updatedContentSaved = false
-    cy.intercept('POST', '**/api/method/frappe.client.*', (req) => {
+    // Autosave writes the GP Draft row: POST to create it, PUT for every later push. Match
+    // both with one method-less regex — the doctype segment is percent-encoded ("GP%20Draft"),
+    // which a minimatch glob can't target cleanly.
+    cy.intercept(/\/api\/v2\/document\/GP%20Draft/, (req) => {
       const body = JSON.stringify(req.body ?? {})
       if (body.includes(draftContent)) draftContentSaved = true
       if (body.includes(updatedContent)) updatedContentSaved = true

--- a/frontend/src/data/drafts.ts
+++ b/frontend/src/data/drafts.ts
@@ -1,5 +1,5 @@
 import { computed } from 'vue'
-import { useCall } from 'frappe-ui'
+import { useList } from 'frappe-ui'
 import { session } from './session'
 
 /** A row from `get_my_drafts` — a new-discussion draft or a new-comment draft on a
@@ -23,14 +23,23 @@ export interface DraftRow {
 /**
  * One enriched, route-ready feed of the user's new drafts — discussions and comment
  * replies alike. The backend resolves comment drafts' parent discussion + space, which
- * the bare GP Draft row can't express, so the client just renders and routes.
+ * the bare GP Draft row can't express, so `url` points the list at that method instead of
+ * the plain document endpoint.
  *
- * Shared rather than page-local: the rail counts these in a tooltip, so the fetch has to
- * outlive the Drafts page.
+ * It is still a `useList` on `GP Draft`, which is what keeps it current: the list registers
+ * under its doctype, so any `useDoc`/`useDoctype` write on a GP Draft — the composer
+ * deleting a draft, a debounced content push — updates or drops the matching row here with
+ * no refetch, and `drafts.insert` adds a new one. Creating and deleting a draft happens in
+ * the composer, far from this feed; as a bare fetch it went stale until a page reload.
+ *
+ * Shared rather than page-local: the rail counts these in a tooltip, so it has to outlive
+ * the Drafts page.
  */
-export const drafts = useCall<DraftRow[]>({
+export const drafts = useList<DraftRow>({
+  doctype: 'GP Draft',
   url: '/api/v2/method/gameplan.gameplan.doctype.gp_draft.gp_draft.get_my_drafts',
-  method: 'POST',
+  // The method returns every draft the user owns, so paging is the list's own concern only.
+  limit: 999,
   // get_my_drafts is owner-scoped on the server; scope the client cache to the session user
   // too, so a same-tab account switch can't briefly show the previous user's draft rows.
   cacheKey: ['drafts', session.user],
@@ -38,3 +47,30 @@ export const drafts = useCall<DraftRow[]>({
 })
 
 export const draftCount = computed(() => drafts.data?.length ?? 0)
+
+/**
+ * Create a `GP Draft` through the list that owns it, so the new row appears here (and in the
+ * rail count) as soon as the server has it.
+ *
+ * Serialized because `drafts.insert` is a single shared request: two composers creating their
+ * first draft at the same moment would otherwise read each other's response and bind to the
+ * wrong draft name.
+ */
+let insertQueue: Promise<unknown> = Promise.resolve()
+
+export function createDraft(fields: Record<string, unknown>): Promise<DraftDoc> {
+  const next = insertQueue.then(async () => {
+    const doc = (await drafts.insert.submit(fields as Partial<DraftRow>)) as DraftDoc | null
+    // useCall resolves with null instead of rejecting; callers rely on a throw to keep their
+    // local copy and retry.
+    if (!doc?.name) throw new Error('Could not create the draft')
+    return doc
+  })
+  insertQueue = next.catch(() => {})
+  return next
+}
+
+/** The bare `GP Draft` row an insert returns — not the enriched {@link DraftRow} the list holds. */
+interface DraftDoc {
+  name: string
+}

--- a/frontend/src/data/useDraftSync.ts
+++ b/frontend/src/data/useDraftSync.ts
@@ -13,8 +13,9 @@
  *    so the local key is per-instance until the server assigns a unique name.
  */
 import { ref, computed, watch, toValue, nextTick, onScopeDispose, type MaybeRefOrGetter } from 'vue'
-import { call, debounce, toast, dayjsLocal } from 'frappe-ui'
+import { call, debounce, toast, dayjsLocal, useDoctype } from 'frappe-ui'
 import { session } from './session'
+import { createDraft, drafts } from './drafts'
 import { isEditorContentEmpty } from '@/utils'
 import {
   getDraftRecord,
@@ -61,6 +62,10 @@ let instanceCounter = 0
 
 export function useDraftSync(options: UseDraftSyncOptions) {
   const { identity, debounceMs = 500, canSave = hasContent, initialPayload, onCreate } = options
+
+  // Per instance, not module-level: these hold the in-flight request, and two composers
+  // writing different drafts at once would share one URL and one response.
+  const draftDoc = useDoctype('GP Draft')
 
   const data = ref<DraftPayload>(initialPayload ? initialPayload() : { content: '' })
   const ready = ref(false)
@@ -168,15 +173,12 @@ export function useDraftSync(options: UseDraftSyncOptions) {
     saving.value = true
     try {
       if (serverName.value) {
-        await call('frappe.client.set_value', {
-          doctype: 'GP Draft',
-          name: serverName.value,
-          fieldname: fields,
-        })
+        // setValue writes through the doctype, so the drafts list picks up the new
+        // title/content on its own — no refetch.
+        const updated = await draftDoc.setValue.submit({ name: serverName.value, ...fields })
+        if (!updated) throw new Error('Could not save the draft')
       } else {
-        const doc = await call('frappe.client.insert', {
-          doc: { doctype: 'GP Draft', ...identityFields(), ...fields },
-        })
+        const doc = await createDraft({ ...identityFields(), ...fields })
         serverName.value = doc.name
         onCreate?.(doc.name)
       }
@@ -355,7 +357,10 @@ export function useDraftSync(options: UseDraftSyncOptions) {
     await forget()
     if (name) {
       try {
-        await call('frappe.client.delete', { doctype: 'GP Draft', name })
+        // Deleting through the doctype drops the row from every GP Draft list, so the
+        // drafts page and the rail count follow without a refetch.
+        const deleted = await draftDoc.delete.submit({ name })
+        if (!deleted) throw new Error('Could not delete the draft')
       } catch (error) {
         console.error('Failed to delete draft', error)
       }
@@ -380,13 +385,17 @@ export function useDraftSync(options: UseDraftSyncOptions) {
           reference_doctype: id.referenceDoctype,
           reference_name: id.referenceName,
         })
+        // commit_draft deletes the row server-side, so drop it from the list here — the
+        // doctype APIs never saw the write.
+        drafts.removeRow(name)
       } catch (error) {
         console.error('Failed to commit draft', error)
       }
     } else if (name) {
       // No target to migrate into (shouldn't happen for singletons) — just delete.
       try {
-        await call('frappe.client.delete', { doctype: 'GP Draft', name })
+        const deleted = await draftDoc.delete.submit({ name })
+        if (!deleted) throw new Error('Could not delete the draft')
       } catch (error) {
         console.error('Failed to delete draft', error)
       }
@@ -524,9 +533,7 @@ async function recoverOrphanedDraft(record: DraftRecord): Promise<boolean> {
         fields.reference_name = id.referenceName
       }
 
-      doc = await call('frappe.client.insert', {
-        doc: { doctype: 'GP Draft', type: id.type, mode: id.mode, ...fields },
-      })
+      doc = await createDraft({ type: id.type, mode: id.mode, ...fields })
     } else {
       // A server row already exists for this singleton (created on another tab/device). Only push
       // our local orphan over it when the content differs AND our last local edit is newer than the
@@ -538,11 +545,7 @@ async function recoverOrphanedDraft(record: DraftRecord): Promise<boolean> {
       if (localContent !== serverContent) {
         const localIsNewer = record.updatedAt > dayjsLocal(doc.modified).valueOf()
         if (localIsNewer) {
-          await call('frappe.client.set_value', {
-            doctype: 'GP Draft',
-            name: doc.name,
-            fieldname: { content: localContent },
-          })
+          await useDoctype('GP Draft').setValue.submit({ name: doc.name, content: localContent })
         } else {
           payload = { ...payload, content: serverContent }
         }

--- a/frontend/src/pages/Drafts.vue
+++ b/frontend/src/pages/Drafts.vue
@@ -248,6 +248,10 @@ function deleteDrafts() {
       let deletedCount = response?.success_count || 0
       let failedCount = response?.failure_count || 0
 
+      // bulk_delete is a custom method, so the doctype APIs never saw these deletes —
+      // drop the rows the list is still holding.
+      response?.deleted.forEach((name) => drafts.removeRow(name))
+
       if (deletedCount > 0) {
         toast.success(deletedCount === 1 ? 'Draft deleted' : `${deletedCount} drafts deleted`)
       }
@@ -259,12 +263,10 @@ function deleteDrafts() {
             ? '1 draft could not be deleted'
             : `${failedCount} drafts could not be deleted`,
         )
-        drafts.reload()
         showDeleteConfirm.value = false
         return
       }
 
-      drafts.reload()
       selectedDrafts.value = []
       showDeleteConfirm.value = false
       isBulkDeleteMode.value = false
@@ -276,10 +278,10 @@ function deleteDrafts() {
 }
 
 // Drafts whose server row never got created (a push that never landed) live only in
-// IndexedDB and would otherwise never show here. Adopt them on open, then refresh.
-onMounted(async () => {
-  const recovered = await recoverOrphanedDrafts()
-  if (recovered > 0) drafts.reload()
+// IndexedDB and would otherwise never show here. Adopting one inserts it through the list,
+// which is what puts it on screen.
+onMounted(() => {
+  recoverOrphanedDrafts()
 })
 
 function contentPreview(content?: string | null) {

--- a/frontend/src/pages/NewDiscussion/useNewDiscussion.ts
+++ b/frontend/src/pages/NewDiscussion/useNewDiscussion.ts
@@ -3,6 +3,7 @@ import { useRoute, useRouter, onBeforeRouteLeave } from 'vue-router'
 import { call, useDoctype, dialog } from 'frappe-ui'
 import { useOwnedRouteWrites } from '@/composables/useOwnedRouteWrites'
 import { useDraftSync, type DraftPayload } from '@/data/useDraftSync'
+import { drafts } from '@/data/drafts'
 import { useGroupedSpaceOptions } from '@/data/groupedSpaces'
 import { canPostInSpace, getSpace } from '@/data/spaces'
 import { useSessionUser, useUser } from '@/data/users'
@@ -215,6 +216,7 @@ export function useNewDiscussion() {
       }
 
       let discussionId: string | undefined
+      const draftRowName = draft.serverName.value
       if (draft.serverName.value) {
         isPublishingSuccessfully.value = true
         discussionId = await call(PUBLISH_DRAFT, { name: draft.serverName.value })
@@ -230,6 +232,9 @@ export function useNewDiscussion() {
       }
 
       await draft.forget()
+      // publish_draft deletes the row server-side, so the doctype APIs never saw it go —
+      // drop it from the drafts list here.
+      if (draftRowName) drafts.removeRow(draftRowName)
 
       if (discussionId) {
         const spaceId = draftData.value.project

--- a/gameplan/gameplan/doctype/gp_draft/gp_draft.py
+++ b/gameplan/gameplan/doctype/gp_draft/gp_draft.py
@@ -110,7 +110,7 @@ def find_my_draft(
 	return frappe.get_doc("GP Draft", name).as_dict()
 
 
-@frappe.whitelist(methods=["POST"])
+@frappe.whitelist(methods=["GET"])
 def get_my_drafts():
 	"""Return the current user's new-content drafts, enriched for the Drafts list.
 
@@ -141,15 +141,16 @@ def get_my_drafts():
 		ignore_permissions=False,
 	).run(as_dict=True)
 
-	# A rare create race can leave multiple drafts for one reply. This endpoint is POST-only so the
-	# stale siblings are committed as deleted instead of reappearing after the newest draft is used.
+	# A rare create race can leave multiple drafts for one reply. Show only the newest (rows are
+	# ordered by modified desc); the stale siblings are deleted by find_my_draft the next time that
+	# reply composer opens. This endpoint stays a pure read so the drafts list can be a useList,
+	# which a GET rolls back anyway.
 	seen = set()
 	deduped = []
 	for r in rows:
 		if r.type == "Comment" and r.reference_name:
 			key = (r.reference_doctype, r.reference_name)
 			if key in seen:
-				frappe.delete_doc("GP Draft", r.name, ignore_permissions=False, delete_permanently=True)
 				continue
 			seen.add(key)
 		deduped.append(r)

--- a/gameplan/tests/features/test_drafts.py
+++ b/gameplan/tests/features/test_drafts.py
@@ -380,10 +380,13 @@ class TestMyDrafts(GameplanTestCase):
 		self.assertIsNone(row["community"])
 		self.assertEqual(row["is_private"], 0)
 
-	def test_collapses_duplicate_reply_drafts_and_deletes_them_permanently(self):
-		"""Same self-healing as find_my_draft, on the list path: the newest reply survives and
-		the stale sibling is destroyed outright rather than archived into Deleted Document,
-		where the abandoned text would stay readable."""
+	def test_the_list_collapses_duplicate_reply_drafts_without_deleting_them(self):
+		"""One row per reply on the list path, but the stale sibling stays on disk.
+
+		get_my_drafts is a GET so the Drafts page can be a useList, and Frappe rolls a GET
+		back — a delete here would look like cleanup and change nothing. The permanent
+		delete lives on find_my_draft, which runs when that reply composer next opens
+		(test_duplicate_singleton_drafts_self_heal_on_read)."""
 		discussion = create_discussion("Duplicate Reply Target", self.space)
 		reference = dict(
 			type="Comment",
@@ -398,7 +401,4 @@ class TestMyDrafts(GameplanTestCase):
 			drafts = get_my_drafts()
 
 		self.assertEqual([row["name"] for row in drafts], [newer.name])
-		self.assertFalse(frappe.db.exists("GP Draft", older.name))
-		self.assertFalse(
-			frappe.db.exists("Deleted Document", {"deleted_doctype": "GP Draft", "deleted_name": older.name})
-		)
+		self.assertTrue(frappe.db.exists("GP Draft", older.name))

--- a/gameplan/tests/test_get_request_transactions.py
+++ b/gameplan/tests/test_get_request_transactions.py
@@ -68,6 +68,9 @@ READ_ONLY_ENDPOINTS = frozenset(
 		"gameplan.gameplan.doctype.gp_project.gp_project.get_unread_count",
 		"gameplan.gameplan.doctype.gp_unread_record.api.get_unread_count",
 		"gameplan.gameplan.doctype.gp_unread_record.api.get_participating_unread_count",
+		# The Drafts list. Collapses duplicate reply drafts in its response but writes nothing;
+		# find_my_draft is what destroys the stale sibling, on its own POST path.
+		"gameplan.gameplan.doctype.gp_draft.gp_draft.get_my_drafts",
 		# Profile reads.
 		"gameplan.gameplan.doctype.gp_user_profile.gp_user_profile.get_last_post",
 		"gameplan.gameplan.doctype.gp_user_profile.gp_user_profile.get_my_bento_cards",
@@ -360,8 +363,12 @@ class TestGetRequestTransactions(FrappeAPITestCase):
 		)
 		self.assertTrue(frappe.db.get_value("User", email, "reset_password_key"))
 
-	def test_get_my_drafts_post_persists_duplicate_cleanup(self):
-		"""The POST returns the newest reply draft and permanently removes stale duplicates."""
+	def test_get_my_drafts_reads_without_writing(self):
+		"""The Drafts list is a plain read, so it may be a GET.
+
+		It still shows one row per reply, but it collapses duplicates in the response only and
+		leaves both rows on disk. Destroying the stale sibling is find_my_draft's job, on the
+		POST path where the delete survives the end-of-request rollback."""
 		suffix = frappe.generate_hash(length=8)
 		user = create_member(f"get_drafts_{suffix}@example.com", "GET Drafts")
 		self.users.append(user.name)
@@ -384,7 +391,7 @@ class TestGetRequestTransactions(FrappeAPITestCase):
 		frappe.db.commit()
 		self.login_as(user.name)
 
-		response = self.post(self.method("gameplan.gameplan.doctype.gp_draft.gp_draft.get_my_drafts"), {})
+		response = self.get(self.method("gameplan.gameplan.doctype.gp_draft.gp_draft.get_my_drafts"))
 
 		self.assertEqual(response.status_code, 200, response.text)
 		self.assertEqual([draft["name"] for draft in response.json["message"]], [newer.name])
@@ -392,4 +399,4 @@ class TestGetRequestTransactions(FrappeAPITestCase):
 		stored = frappe.get_all(
 			"GP Draft", filters={"owner": user.name, **fields}, order_by="modified desc", pluck="name"
 		)
-		self.assertEqual(stored, [newer.name])
+		self.assertEqual(stored, [newer.name, older.name])


### PR DESCRIPTION
## Problem

Create a draft, go back to **Drafts**, and the new draft is not there. Delete a draft and it stays in the list. Both only correct themselves on a full page reload.

The feed in `frontend/src/data/drafts.ts` was a bare `useCall` on `get_my_drafts`. That put it outside the `listStore` that keeps `useList` in sync with `useDoc`/`useDoctype` writes, so it fetched once and then held whatever the server returned at that moment. Drafts are created and deleted in the composer, far from the feed, and nothing there could reach it.

## Fix

Make the feed a `useList` on `GP Draft` and write through the doctype APIs, so the list follows on its own.

- `data/drafts.ts` — `useList<DraftRow>({ doctype: 'GP Draft', url: '…get_my_drafts' })`. The `url` keeps the enriched endpoint (a comment draft needs its parent discussion and space resolved server-side); the `doctype` is what registers it in the `listStore`.
- `useDraftSync` — `useDoctype('GP Draft').delete` drops the row, `.setValue` updates it in place, `drafts.insert` adds one. No `frappe.client.*` v1 calls left on the write path.
- `publish_draft`, `commit_draft` and `bulk_delete` delete rows behind custom methods the doctype APIs never see, so those three call `drafts.removeRow(name)`.
- `get_my_drafts` becomes a `GET`. It was POST-only so it could delete duplicate reply drafts, which a GET rolls back; it now skips them instead, and `find_my_draft` still deletes stale siblings the next time that reply composer opens.

Falling out of the same change: the row preview now tracks the draft as it is typed, because every debounced `setValue` reaches the row through `listStore.updateRow`. The rail's draft count reads the same list, so it stays right too.

## Before

Create → back to Drafts shows "No drafts". Delete → the row is still listed.

![before](https://md.netchamp.dev/gameplan-drafts-list-refresh/drafts-before.gif)

## After

Create → the draft is listed straight away, with its content preview. Delete → the list empties straight away.

![after](https://md.netchamp.dev/gameplan-drafts-list-refresh/drafts-after.gif)

## Verification

Driven with Playwright against a local dev site, same script before and after the change:

| Step | Before | After |
| --- | --- | --- |
| Drafts list on open | empty | empty |
| after CREATE, in-app nav to Drafts | **empty** | 1 row |
| after CREATE + page refresh | 1 row | 1 row |
| after DELETE, in-app nav to Drafts | **1 row** | empty |
| after DELETE + page refresh | empty | empty |

The row after create reads `Weekly release notes / General: Draft saved automatically.` — the preview text the old feed left blank.

`tsc --noEmit` reports two fewer errors than `develop` and no new ones. Prettier is clean.

Not done: no Cypress spec for this. The e2e suite needs the `gameplan-demo.test` site, which lives on a different bench here, so a new spec could not be run.
