### PR TITLE
fix(composer): stop failing a publish over an edit that arrived mid-save

### DIFF
--- a/frontend/cypress/e2e/discussions/new-discussion.cy.ts
+++ b/frontend/cypress/e2e/discussions/new-discussion.cy.ts
@@ -134,6 +134,44 @@ describe('New discussion drafts', () => {
     })
   })
 
+  it('publishes an edit that lands while the last draft save is in flight', () => {
+    createStoredDraft()
+    // Hold every draft save open long enough to type into the composer while the publish
+    // is waiting on one. A save only covers the snapshot it was built from, so the draft
+    // is dirty again the moment it returns — with nothing actually failing.
+    cy.intercept('POST', '**/api/method/frappe.client.set_value', (req) => {
+      req.continue((res) => res.setDelay(1500))
+    }).as('draftSave')
+
+    cy.get('[contenteditable=true]').click().type(' First edit.')
+    cy.button('Publish').click()
+    cy.get('[contenteditable=true]').type(' Late edit.')
+
+    cy.url({ timeout: 20000 }).should(
+      'include',
+      `/community/${community}/space/${space}/discussion/`,
+    )
+    cy.contains('Late edit.').should('exist')
+  })
+
+  it('reports a failed publish to the server', () => {
+    createStoredDraft()
+    cy.intercept(
+      'POST',
+      '**/api/method/gameplan.gameplan.doctype.gp_draft.gp_draft.publish_draft',
+      { statusCode: 500, body: { exception: 'PublishError: no' } },
+    ).as('failedPublish')
+    cy.intercept('POST', '**/api/method/gameplan.api.log_client_error').as('errorReport')
+
+    cy.button('Publish').click()
+
+    cy.wait('@failedPublish')
+    cy.wait('@errorReport').its('request.body.context.action').should('eq', 'publish-discussion')
+    // Still on the composer, with the draft intact and the button clickable again.
+    cy.url().should('include', 'new-discussion')
+    cy.button('Publish').should('be.enabled')
+  })
+
   it('shows the publish button on the mobile composer', () => {
     cy.viewport('iphone-6')
     cy.visit(`/g/community/${community}/new-discussion`)

--- a/frontend/src/data/useDraftSync.ts
+++ b/frontend/src/data/useDraftSync.ts
@@ -16,6 +16,7 @@ import { ref, computed, watch, toValue, nextTick, onScopeDispose, type MaybeRefO
 import { call, debounce, toast, dayjsLocal } from 'frappe-ui'
 import { session } from './session'
 import { isEditorContentEmpty } from '@/utils'
+import { captureError } from '@/utils/errorReporting'
 import {
   getDraftRecord,
   putDraftRecord,
@@ -68,8 +69,10 @@ export function useDraftSync(options: UseDraftSyncOptions) {
   const saving = ref(false)
   const savedAt = ref<number | null>(null)
   const restored = ref(false)
-  // Tracks whether the last server push failed, so we toast once per streak (not per keystroke).
-  const pushFailed = ref(false)
+  // The error from the most recent failed push, cleared by the next success. Doubles as the
+  // "are we in a failure streak" flag (so we toast once, not per keystroke) and as the reason
+  // a caller like publish() can report when the draft is still unsynced.
+  const lastError = ref<unknown>(null)
   const serverName = ref<string | null>(toValue(options.draftName ?? null))
 
   // Last local edit vs last successful push, on THIS device. Drives reconciliation
@@ -183,18 +186,18 @@ export function useDraftSync(options: UseDraftSyncOptions) {
       syncedAt.value = Math.max(syncedAt.value ?? 0, pushedAt)
       savedAt.value = Date.now()
       await persistLocal()
-      pushFailed.value = false
+      lastError.value = null
     } catch (error) {
       // Keep the local copy; the next edit (or unmount flush) retries. Standalone
       // new-discussion drafts that never land here are adopted later by
       // recoverOrphanedDrafts(), so a missed push no longer strands a draft locally.
-      console.error('Draft sync failed', error)
+      captureError(error, { action: 'draft-push', draft: serverName.value })
       // Tell the user once per failure streak so a silently-failing save can't quietly
       // lose server-side persistence. Reset on the next success above.
-      if (!pushFailed.value) {
-        pushFailed.value = true
+      if (!lastError.value) {
         toast.error('Could not save your draft to the server — keeping a local copy and retrying.')
       }
+      lastError.value = error
     } finally {
       saving.value = false
     }
@@ -240,7 +243,8 @@ export function useDraftSync(options: UseDraftSyncOptions) {
         })
       }
     } catch (error) {
-      console.error('Draft lookup failed', error)
+      // The composer stays usable on a failed lookup, so this is invisible without a report.
+      captureError(error, { action: 'draft-load', draft: serverName.value })
     }
     return null
   }
@@ -407,6 +411,8 @@ export function useDraftSync(options: UseDraftSyncOptions) {
     savedAt,
     /** There are local edits not yet pushed to the server. */
     dirty,
+    /** Why the last push failed, or null if the last one succeeded. */
+    lastError,
     /** A pre-existing draft was found and restored on load. */
     restored,
     serverName,
@@ -563,7 +569,7 @@ async function recoverOrphanedDraft(record: DraftRecord): Promise<boolean> {
     broadcastDraftChange(newKey)
     return true
   } catch (error) {
-    console.error('Failed to recover orphaned draft', error)
+    captureError(error, { action: 'draft-recovery', draft: record.serverName })
     return false
   }
 }

--- a/frontend/src/globals.d.ts
+++ b/frontend/src/globals.d.ts
@@ -32,6 +32,8 @@ declare module 'vue' {
 declare global {
   interface Window {
     site_name: string
+    /** Set from the boot data in `gameplan/www/g.py`; absent when the site has no DSN. */
+    gameplan_frontend_sentry_dsn?: string
   }
 }
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -19,6 +19,7 @@ import { getPlatform } from './utils'
 import { useUser, users } from './data/users'
 import { isSessionUser, session } from './data/session'
 import { initSocket } from './socket'
+import { installErrorReporting } from './utils/errorReporting'
 import resetDataMixin from './utils/resetDataMixin'
 
 let globalComponents = {
@@ -32,6 +33,8 @@ let globalComponents = {
 }
 let app = createApp(App)
 app.use(router)
+// Installed before anything else runs, so an error thrown during setup is reported too.
+installErrorReporting(app, router)
 app.mixin(resetDataMixin)
 for (let key in globalComponents) {
   app.component(key, globalComponents[key])
@@ -75,21 +78,6 @@ function setupApp() {
   socket = initSocket()
   app.config.globalProperties.$socket = socket
   app.mount('#app')
-}
-
-// Sentry error logging. Loaded lazily (dynamic import) so the ~250 KB SDK stays
-// out of the entry chunk — it's the #1 resource on the initial critical path and
-// is only ever needed in production when a DSN is configured. The import fires
-// during setup so browser-tracing still attaches early enough to capture vitals.
-if (import.meta.env.PROD && window.gameplan_frontend_sentry_dsn) {
-  import('@sentry/vue').then((Sentry) => {
-    Sentry.init({
-      app,
-      dsn: window.gameplan_frontend_sentry_dsn,
-      integrations: [Sentry.browserTracingIntegration({ router })],
-      tracesSampleRate: 1.0,
-    })
-  })
 }
 
 if (import.meta.env.DEV) {

--- a/frontend/src/pages/NewDiscussion/useNewDiscussion.ts
+++ b/frontend/src/pages/NewDiscussion/useNewDiscussion.ts
@@ -8,10 +8,12 @@ import { canPostInSpace, getSpace } from '@/data/spaces'
 import { useSessionUser, useUser } from '@/data/users'
 import { tags } from '@/data/tags'
 import { extractServerMessage, isEditorContentEmpty } from '@/utils'
+import { captureError } from '@/utils/errorReporting'
 import type { GPDiscussion } from '@/types/doctypes'
 
 const PUBLISH_DRAFT = 'gameplan.gameplan.doctype.gp_draft.gp_draft.publish_draft'
 const LOADING_STATUS_DELAY_MS = 200
+const FLUSH_ATTEMPTS = 3
 
 /** Title or non-empty body — the threshold for persisting a draft at all. */
 function hasMeaningfulContent(payload: Partial<DraftPayload>): boolean {
@@ -193,6 +195,21 @@ export function useNewDiscussion() {
     immediateSave()
   }
 
+  // publish_draft builds the discussion from the SERVER row, so a draft that is still dirty
+  // after a flush would be published minus whatever failed to push — most often as an empty
+  // body. A push only covers the snapshot it was built from, so an edit that lands while it
+  // is in flight (a keystroke, an image upload finishing) leaves the draft dirty even though
+  // nothing failed: flush again for those instead of telling the author to check a
+  // connection that is fine. A push that actually threw stops us on the first attempt.
+  async function flushUntilPushed(): Promise<boolean> {
+    for (let attempt = 0; attempt < FLUSH_ATTEMPTS; attempt++) {
+      await draft.flush()
+      if (!draft.serverName.value || !draft.dirty.value) return true
+      if (draft.lastError.value) return false
+    }
+    return false
+  }
+
   // Publish: flush the latest content, then turn the draft into a discussion. The draft
   // row is deleted server-side by publish, so we only forget the local copy afterwards.
   async function publish() {
@@ -202,12 +219,11 @@ export function useNewDiscussion() {
 
     publishing.value = true
     try {
-      await draft.flush()
-
-      // publish_draft builds the discussion from the SERVER row, so a draft that is still
-      // dirty after a flush would be published minus whatever failed to push — most often
-      // as an empty body. Stop instead of shipping a post the author didn't write.
-      if (draft.serverName.value && draft.dirty.value) {
+      if (!(await flushUntilPushed())) {
+        captureError(draft.lastError.value ?? new Error('Draft still unsynced after flush'), {
+          action: 'publish-discussion-unsynced-draft',
+          draft: draft.serverName.value,
+        })
         publishError.value =
           'Could not save your draft to the server. Check your connection and try again.'
         publishing.value = false
@@ -229,18 +245,29 @@ export function useNewDiscussion() {
         discussionId = doc?.name
       }
 
+      // Nothing to navigate to. Say so and keep the draft: leaving `publishing` on would
+      // spin the button forever, and forgetting the draft would drop the only copy left.
+      if (!discussionId) {
+        captureError(new Error('Publishing returned no discussion'), {
+          action: 'publish-discussion-no-id',
+          draft: draft.serverName.value,
+        })
+        publishError.value = 'Could not publish this post.'
+        publishing.value = false
+        return
+      }
+
       await draft.forget()
 
-      if (discussionId) {
-        const spaceId = draftData.value.project
-        const targetCommunityId = communityId.value || (spaceId ? getSpace(spaceId)?.team : null)
-        await router.replace({
-          name: 'Discussion',
-          params: { communityId: targetCommunityId, spaceId, postId: discussionId },
-        })
-        tags.reload()
-      }
+      const spaceId = draftData.value.project
+      const targetCommunityId = communityId.value || (spaceId ? getSpace(spaceId)?.team : null)
+      await router.replace({
+        name: 'Discussion',
+        params: { communityId: targetCommunityId, spaceId, postId: discussionId },
+      })
+      tags.reload()
     } catch (error: any) {
+      captureError(error, { action: 'publish-discussion', draft: draft.serverName.value })
       publishError.value = extractServerMessage(error) || 'Could not publish this post.'
       publishing.value = false
     } finally {
@@ -300,7 +327,7 @@ export function useNewDiscussion() {
         try {
           await draft.flush()
         } catch (error) {
-          console.error('Failed to save draft before leaving:', error)
+          captureError(error, { action: 'draft-flush-on-leave', draft: draft.serverName.value })
         }
       }
       return true

--- a/frontend/src/utils/errorReporting.ts
+++ b/frontend/src/utils/errorReporting.ts
@@ -1,0 +1,122 @@
+/// <reference types="vite/client" />
+/**
+ * One funnel for errors, including the ones the UI swallows.
+ *
+ * Most failures here are caught and turned into a message next to a button, so nothing
+ * about them survives the tab: no exception, no trace, nothing on the server. That is
+ * why an intermittent report ("it did not post the first time") is impossible to chase.
+ * `captureError` is the reporting call for those handled paths; the global handlers
+ * installed below cover everything that reaches the browser uncaught.
+ *
+ * Every report goes to the site's Error Log through `gameplan.api.log_client_error`, and
+ * to Sentry as well when a DSN is configured. The server sink is the one that always
+ * works, since most sites run without a DSN.
+ */
+import { call } from 'frappe-ui'
+import type { App } from 'vue'
+import type { Router } from 'vue-router'
+
+const LOG_CLIENT_ERROR = 'gameplan.api.log_client_error'
+
+/** Per page load. A render loop can raise the same error thousands of times; the server
+ *  has its own hourly quota, and this keeps us from spending the request budget on it. */
+const MAX_REPORTS_PER_PAGE_LOAD = 20
+
+export interface ErrorContext {
+  /** What the user was doing, e.g. `publish-discussion`. Becomes the Error Log title. */
+  action: string
+  [key: string]: unknown
+}
+
+type SentryModule = typeof import('@sentry/vue')
+
+let sentry: SentryModule | null = null
+let reportCount = 0
+const reportedFingerprints = new Set<string>()
+
+/**
+ * Report an error the UI handled itself. Logs to the console, sends it to the server, and
+ * forwards it to Sentry when it is loaded. Never throws and never rejects: reporting a
+ * failure must not turn into a second failure.
+ */
+export function captureError(error: unknown, context: ErrorContext): void {
+  try {
+    console.error(`[${context.action}]`, error)
+    sentry?.captureException(error, { extra: { ...context } })
+    sendToServer(error, context)
+  } catch (reportingError) {
+    console.error('Error reporting failed', reportingError)
+  }
+}
+
+/**
+ * Install the global handlers and start Sentry. Called before mount, so an error thrown
+ * during setup is still reported — the Sentry SDK is a lazy import (~250 KB off the entry
+ * chunk) and only attaches once it lands.
+ */
+export function installErrorReporting(app: App, router: Router): void {
+  const previousHandler = app.config.errorHandler
+  app.config.errorHandler = (error, instance, info) => {
+    captureError(error, { action: 'vue-error-handler', info })
+    previousHandler?.(error, instance, info)
+  }
+
+  window.addEventListener('error', (event) => {
+    // A failed <img>/<script> load fires a plain Event on the same channel. It carries no
+    // error and no message, so there is nothing to report.
+    if (!(event instanceof ErrorEvent)) return
+    captureError(event.error ?? event.message, {
+      action: 'uncaught-error',
+      source: event.filename ? `${event.filename}:${event.lineno}:${event.colno}` : undefined,
+    })
+  })
+
+  window.addEventListener('unhandledrejection', (event) => {
+    captureError(event.reason, { action: 'unhandled-rejection' })
+  })
+
+  if (import.meta.env.PROD && window.gameplan_frontend_sentry_dsn) {
+    import('@sentry/vue').then((Sentry) => {
+      Sentry.init({
+        app,
+        dsn: window.gameplan_frontend_sentry_dsn,
+        integrations: [Sentry.browserTracingIntegration({ router })],
+        tracesSampleRate: 1.0,
+      })
+      sentry = Sentry
+    })
+  }
+}
+
+function sendToServer(error: unknown, context: ErrorContext): void {
+  const message = describe(error)
+  const fingerprint = `${context.action}::${message.split('\n')[0]}`
+  // One report per distinct error per page load: a retried action repeats the same
+  // failure, and twenty copies of it say nothing the first one did not.
+  if (reportedFingerprints.has(fingerprint)) return
+  if (reportCount >= MAX_REPORTS_PER_PAGE_LOAD) return
+  reportedFingerprints.add(fingerprint)
+  reportCount += 1
+
+  call(LOG_CLIENT_ERROR, {
+    message,
+    context: { ...context, url: window.location.href, user_agent: navigator.userAgent },
+  }).catch(() => {
+    // The sink is unreachable (offline, or the request that failed is failing again).
+    // Dropping the report is the only safe move: retrying it would loop.
+  })
+}
+
+/** A single string carrying the name, the message and the stack, for anything thrown. */
+function describe(error: unknown): string {
+  if (error instanceof Error) {
+    const header = `${error.name}: ${error.message}`
+    return error.stack?.includes(error.message) ? error.stack : `${header}\n${error.stack ?? ''}`
+  }
+  if (typeof error === 'string') return error
+  try {
+    return JSON.stringify(error)
+  } catch {
+    return String(error)
+  }
+}

--- a/gameplan/api.py
+++ b/gameplan/api.py
@@ -2,10 +2,12 @@
 # See license.txt
 
 
+import json
+
 import frappe
 from frappe import _
 from frappe.query_builder.functions import Count
-from frappe.utils import split_emails, validate_email_address
+from frappe.utils import cint, split_emails, validate_email_address
 
 import gameplan
 from gameplan.gameplan.doctype.gp_invitation.gp_invitation import grant_access
@@ -351,3 +353,62 @@ def can_access_gameplan():
 		return True
 
 	return False
+
+
+CLIENT_ERROR_QUOTA = 20
+CLIENT_ERROR_QUOTA_WINDOW = 60 * 60
+CLIENT_ERROR_FIELD_LIMIT = 4000
+
+
+@frappe.whitelist(methods=["POST"])
+@validate_type
+def log_client_error(message: str, context: dict = None):
+	"""Record a browser-side error in the Error Log.
+
+	The UI catches most request failures and shows a message instead of raising, so a
+	report like "it did not post the first time" leaves no trace on the server. The
+	frontend sends those caught errors here together with the stack and the action that
+	failed, which is what makes them diagnosable after the fact.
+
+	The payload is attacker-controlled: it is truncated, stored as plain text, and each
+	user gets an hourly quota so a looping client cannot fill the Error Log.
+	"""
+	if _client_error_quota_spent():
+		return
+
+	action = _error_action(context)
+	title = f"Gameplan client error: {action}" if action else "Gameplan client error"
+
+	body = [_truncate(message)]
+	if context:
+		body.append("Context:\n" + _truncate(json.dumps(context, indent=2, default=str)))
+	frappe.log_error(title=title, message="\n\n".join(body))
+
+
+def _error_action(context: dict | None) -> str:
+	"""The action label for the log title. Kept to one short line: frappe.log_error treats a
+	multi-line title as a traceback and swaps its arguments."""
+	action = context.get("action") if isinstance(context, dict) else None
+	if not isinstance(action, str):
+		return ""
+	return " ".join(action.split())[:100]
+
+
+def _client_error_quota_spent() -> bool:
+	"""Whether this user has already used up their hourly client-error budget.
+
+	Read-then-write rather than an atomic counter: two reports racing can slip one past
+	the cap, which is fine for a throttle whose only job is to bound the row count.
+	"""
+	key = f"gameplan:client-error-count:{frappe.session.user}"
+	cache = frappe.cache()
+	count = cint(cache.get_value(key))
+	if count >= CLIENT_ERROR_QUOTA:
+		return True
+	cache.set_value(key, count + 1, expires_in_sec=CLIENT_ERROR_QUOTA_WINDOW)
+	return False
+
+
+def _truncate(value: str, limit: int = CLIENT_ERROR_FIELD_LIMIT) -> str:
+	value = str(value or "")
+	return value if len(value) <= limit else value[:limit] + "… (truncated)"

--- a/gameplan/tests/platform/test_api_endpoints.py
+++ b/gameplan/tests/platform/test_api_endpoints.py
@@ -10,10 +10,13 @@ import frappe
 from frappe.utils import add_days, now
 
 from gameplan.api import (
+	CLIENT_ERROR_FIELD_LIMIT,
+	CLIENT_ERROR_QUOTA,
 	can_access_gameplan,
 	get_search_filter_options,
 	get_user_info,
 	invite_by_email,
+	log_client_error,
 	onboarding,
 	search_sqlite,
 )
@@ -399,3 +402,89 @@ class TestSearchEndpoint(IsolatedSearchIndex, APIEndpointTestCase):
 
 	def test_anonymous_caller_is_denied(self):
 		self.assert_anonymous_denied(search_sqlite)
+
+
+class TestLogClientErrorEndpoint(APIEndpointTestCase):
+	"""The sink the frontend reports caught errors to, so a swallowed failure is traceable."""
+
+	LOG_FILTER = {"method": ["like", "Gameplan client error%"]}
+
+	def setUp(self):
+		super().setUp()
+		# Error Log is a MyISAM table, so its rows ignore the transaction the rest of the
+		# suite rolls back. Track what was there before and delete only what a test wrote.
+		self.existing_logs = set(frappe.get_all("Error Log", filters=self.LOG_FILTER, pluck="name"))
+		self.addCleanup(self.delete_logged_errors)
+		self.addCleanup(self.clear_quota)
+		self.clear_quota()
+
+	def clear_quota(self):
+		for user in (self.member.name, self.second_member.name):
+			frappe.cache().delete_value(f"gameplan:client-error-count:{user}")
+
+	def delete_logged_errors(self):
+		for log in self.client_error_logs():
+			frappe.db.delete("Error Log", {"name": log.name})
+
+	def client_error_logs(self):
+		rows = frappe.get_all("Error Log", filters=self.LOG_FILTER, fields=["name", "method", "error"])
+		return [row for row in rows if row.name not in self.existing_logs]
+
+	def test_a_reported_error_lands_in_the_error_log_with_its_action_and_context(self):
+		with self.as_user(self.member):
+			log_client_error(
+				message="TypeError: cannot read name\n  at publish()",
+				context={"action": "publish-discussion", "draft": "draft-1"},
+			)
+
+		logs = self.client_error_logs()
+		self.assertEqual(len(logs), 1)
+		self.assertEqual(logs[0].method, "Gameplan client error: publish-discussion")
+		self.assertIn("cannot read name", logs[0].error)
+		self.assertIn("draft-1", logs[0].error)
+
+	def test_a_report_without_context_still_logs(self):
+		with self.as_user(self.member):
+			log_client_error(message="Boom")
+
+		logs = self.client_error_logs()
+		self.assertEqual(len(logs), 1)
+		self.assertEqual(logs[0].method, "Gameplan client error")
+
+	def test_a_multiline_action_cannot_turn_the_title_into_a_traceback(self):
+		with self.as_user(self.member):
+			log_client_error(message="Boom", context={"action": "publish\nfake traceback"})
+
+		logs = self.client_error_logs()
+		self.assertEqual(logs[0].method, "Gameplan client error: publish fake traceback")
+		self.assertIn("Boom", logs[0].error)
+
+	def test_an_oversized_message_is_truncated(self):
+		with self.as_user(self.member):
+			log_client_error(message="x" * (CLIENT_ERROR_FIELD_LIMIT * 2))
+
+		error = self.client_error_logs()[0].error
+		self.assertIn("(truncated)", error)
+		self.assertLess(len(error), CLIENT_ERROR_FIELD_LIMIT * 2)
+
+	def test_a_looping_client_cannot_fill_the_error_log(self):
+		with self.as_user(self.member):
+			for _index in range(CLIENT_ERROR_QUOTA + 5):
+				log_client_error(message="Boom")
+
+		self.assertEqual(len(self.client_error_logs()), CLIENT_ERROR_QUOTA)
+
+	def test_the_quota_is_per_user(self):
+		with self.as_user(self.member):
+			for _index in range(CLIENT_ERROR_QUOTA):
+				log_client_error(message="Boom")
+		with self.as_user(self.second_member):
+			log_client_error(message="Boom from another user")
+
+		self.assertEqual(len(self.client_error_logs()), CLIENT_ERROR_QUOTA + 1)
+
+	def test_the_endpoint_is_post_only(self):
+		self.assertEqual(declared_http_methods(log_client_error), {"POST"})
+
+	def test_anonymous_caller_is_denied(self):
+		self.assert_anonymous_denied(log_client_error)


### PR DESCRIPTION
## What was broken

A user could not publish a post on the first attempt. The second attempt worked. Their
connection was fine. Reported in the Raven `Raven-gameplan` channel.

## Root cause

The composer publishes a draft by flushing it to the server and then calling
`publish_draft`, which builds the discussion from the **server** row. Since 11c8a2c4 it
refuses to publish a row that is still dirty, so a body that never reached the server
cannot be published as an empty post.

A push only covers the snapshot it was built from. Anything that changes the draft while
that push is in flight — a keystroke, an image upload finishing — leaves the draft dirty
the moment the push returns, with nothing having failed. The composer read that as a
failed save and showed "Could not save your draft to the server. Check your connection and
try again." Publishing again worked, because by then the edit had been pushed.

Nothing about this was recorded anywhere: the failure is caught, shown as a string, and
forgotten. That is why the report could not be chased from the server side.

## What changed

**The publish path**

- Flush again when the draft is still dirty but no push failed, up to three attempts.
  Stop immediately when a push actually threw — that is the case the connection message is
  for.
- A publish that returns no discussion no longer leaves the button spinning forever with
  the draft already forgotten. It reports the error and keeps the draft.

**Error trace capture** (the ask attached to the report)

- New `gameplan.api.log_client_error`: POST-only, writes to the site's Error Log. The
  payload is truncated, its action label is collapsed to one line (`frappe.log_error`
  treats a multi-line title as a traceback and swaps its arguments), and each user has an
  hourly quota so a looping client cannot fill the table.
- New `frontend/src/utils/errorReporting.ts`: `captureError()` for handled failures, plus
  handlers for uncaught errors, unhandled rejections and Vue render errors, installed
  before mount. Duplicate reports are dropped and the count is capped per page load.
- Sentry init moves out of `main.js` into the same module, so both sinks live in one
  place. Sentry still needs a DSN; the Error Log sink works without one.
- Wired into the publish path and the draft composable's three silent `console.error`
  paths: a failed push, a failed lookup, a failed orphan recovery.

## Verification

Backend, `gameplan.tests.platform.test_api_endpoints` on a disposable site:

```
Ran 35 tests in 3.736s

OK
```

E2E, two new specs in `new-discussion.cy.ts` — the first types into the composer while the
publish is waiting on a delayed draft save, the second fails `publish_draft` and asserts
the report reaches the server:

```
  Running:  new-discussion.cy.ts

    ✓ saves a draft while composing and publishes it into the chosen space (20181ms)
    ✓ blocks editing while a saved draft is loading (8725ms)
    ✓ allows editing when a saved draft fails to load (6569ms)
    ✓ publishes an edit that lands while the last draft save is in flight (7809ms)
    ✓ reports a failed publish to the server (3816ms)
    ✓ shows the publish button on the mobile composer (2126ms)

  6 passing (50s)
```

Both new specs fail on the pre-fix code — the first times out on the composer instead of
navigating to the published post, which is the reported symptom.

Regression run (draft, composer and shell specs), all green: `discussions/composer`,
`comments/comment-drafts`, `mobile/create-discussion`, `shell/*`, `journeys/onboarding` —
23 passing.

Checked the row this produces on the site. A failed publish now logs the stack, the draft
name, the URL and the browser; the "draft fails to load" spec logs a `draft-load` row that
was previously invisible.

## Not done

- No dedicated space for these rows in the UI: they land in the standard Error Log list,
  titled `Gameplan client error: <action>`.
- Reports are dropped when the sink itself is unreachable (offline). No local buffer.
- Only the draft/publish paths call `captureError` explicitly. Other handled failures are
  covered only if they reach the global handlers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
