### PR TITLE
fix(discussions): keep a selected image ring under the pinned author row

### DIFF
--- a/frontend/cypress/e2e/discussions/new-discussion.cy.ts
+++ b/frontend/cypress/e2e/discussions/new-discussion.cy.ts
@@ -142,7 +142,10 @@ describe('New discussion drafts', () => {
     // Hold every draft save open long enough to type into the composer while the publish
     // is waiting on one. A save only covers the snapshot it was built from, so the draft
     // is dirty again the moment it returns — with nothing actually failing.
-    cy.intercept('POST', '**/api/method/frappe.client.set_value', (req) => {
+    // Autosave pushes through the GP Draft doctype, so the delay has to sit on
+    // PUT /api/v2/document/GP Draft/<name>. Matched by regex: the doctype segment is
+    // percent-encoded ("GP%20Draft"), which a minimatch glob can't target cleanly.
+    cy.intercept({ method: 'PUT', url: /\/api\/v2\/document\/GP%20Draft/ }, (req) => {
       req.continue((res) => res.setDelay(1500))
     }).as('draftSave')
 

--- a/frontend/cypress/e2e/discussions/pinned-author-row.cy.ts
+++ b/frontend/cypress/e2e/discussions/pinned-author-row.cy.ts
@@ -1,0 +1,66 @@
+// The pinned author row masks the content scrolling under it. A selected image draws
+// its ring 4px outside its own box (`ring-2 ring-offset-2` in frappe-ui's media node
+// view), and that box is already the full width of the content column. A row that
+// stops at the column edge leaves the ring's two vertical edges visible above it,
+// running up to the page header.
+import { resetData } from '../../support/seed'
+
+// ring-2 (2px) + ring-offset-2 (2px)
+const RING_PX = 4
+
+// Any asset the site already serves does: the node view lays the image out from the
+// width/height attributes, so this fills the column like a real screenshot would. A
+// `data:` src would be simpler but frappe's HTML sanitizer strips it on save.
+const WIDE_IMAGE = '<img src="/assets/frappe/images/frappe-favicon.svg" width="1600" height="900">'
+
+describe('Pinned author row', () => {
+  let community: string
+  let space: string
+  let discussion: string
+
+  beforeEach(() => {
+    resetData('space_with_discussion').then((ids) => {
+      community = ids.community as string
+      space = ids.space as string
+      discussion = ids.discussion as string
+    })
+    cy.loginAs('member')
+  })
+
+  function assertRowOverhangs(dropdownLabel: string, scope: string) {
+    cy.get(scope)
+      .find(`button[aria-haspopup=menu][aria-label="${dropdownLabel}"]`)
+      .parents('.sticky')
+      .first()
+      .then(($row) => {
+        cy.get(scope)
+          .find('img[src*="frappe-favicon"]')
+          .then(($image) => {
+            const row = $row[0].getBoundingClientRect()
+            const image = $image[0].getBoundingClientRect()
+            expect(row.left, 'row covers the ring on the left').to.be.at.most(image.left - RING_PX)
+            expect(row.right, 'row covers the ring on the right').to.be.at.least(
+              image.right + RING_PX,
+            )
+          })
+      })
+  }
+
+  it('is wider than the content column, in the post and in a comment', () => {
+    cy.request('PUT', `/api/v2/document/GP%20Discussion/${discussion}`, {
+      content: `<p>Post content</p>${WIDE_IMAGE}`,
+    })
+    cy.request('POST', '/api/v2/document/GP%20Comment', {
+      reference_doctype: 'GP Discussion',
+      reference_name: discussion,
+      content: `<p>Comment content</p>${WIDE_IMAGE}`,
+    }).then(({ body }) => {
+      const comment = `div[data-id="${body.data.name}"]`
+      cy.visit(`/g/community/${community}/space/${space}/discussion/${discussion}`)
+
+      cy.get(comment).should('exist')
+      assertRowOverhangs('Discussion Options', '.discussion-container')
+      assertRowOverhangs('Comment Options', comment)
+    })
+  })
+})

--- a/frontend/src/components/Comment.vue
+++ b/frontend/src/components/Comment.vue
@@ -10,10 +10,17 @@
       fine when reading, but it buries the line you are typing while editing
       (worst on a phone, where it eats ~56px of a keyboard-shrunk viewport).
       Same treatment the post editor already gets in DiscussionView.
+
+      The negative margins widen the opaque row out to the container's padding
+      edge. A selected image paints a ring 4px outside its own box, and that box
+      is already the full column width, so a row that stopped at the column edge
+      let the ring show above it. Same fix as DiscussionView.
     -->
     <div
       class="flex items-center bg-surface-base pb-2 pt-2 text-md text-ink-gray-8 sm:pt-14 sm:text-base"
-      :class="{ 'sticky -top-px z-[1] sm:top-0': !isEditing }"
+      :class="{
+        'sticky -top-px z-[1] -mx-3 px-3 sm:-mx-5 sm:px-5 sm:top-0': !isEditing,
+      }"
     >
       <UserProfileLink class="mr-3" :user="author.name">
         <UserAvatarWithHover class="sm:hidden" size="xl" :user="author.name" />

--- a/frontend/src/components/DiscussionView.vue
+++ b/frontend/src/components/DiscussionView.vue
@@ -52,9 +52,22 @@
           @keydown.meta.enter.capture.stop="updatePost"
           @keydown.esc="cancelEdit"
         >
+          <!--
+            While pinned, this row masks the content scrolling under it, so it has to
+            be at least as wide as anything that content can paint. A selected image
+            draws a ring 4px outside its own box, and that box is already the full
+            width of the column. A row that stopped at the column edge left the ring's
+            two vertical edges visible above it, running up to the page header. The
+            negative margins bleed the row out to the container's padding edge, and the
+            padding puts its contents back where they were.
+          -->
           <div
-            class="flex w-full items-center bg-surface-base pb-2 pt-2"
-            :class="editingPost ? 'sm:pt-0' : 'sticky -top-px z-[1] sm:top-0 sm:pt-14'"
+            class="flex items-center bg-surface-base pb-2 pt-2"
+            :class="
+              editingPost
+                ? 'w-full sm:pt-0'
+                : 'sticky -top-px z-[1] -mx-3 px-3 sm:-mx-5 sm:px-5 sm:top-0 sm:pt-14'
+            "
           >
             <UserProfileLink class="mr-3" :user="discussion.doc.owner">
               <UserAvatarWithHover class="sm:hidden" size="xl" :user="discussion.doc.owner" />


### PR DESCRIPTION
From a bug report in the Raven `Raven-gameplan` channel: a border was showing through at the top of a discussion, right under the page header.

## What was broken

Click a full-width image in a discussion or a comment, then scroll it up behind the pinned author row. The image's selection ring stayed visible: two vertical lines, plus a rounded top corner, running from the row up to the page header.

## Root cause

The pinned author row is opaque and is the only thing masking the content that scrolls under it, but it was exactly as wide as the content column. A selected image draws its ring 4px outside its own box (`ring-2 ring-offset-2` on frappe-ui's media node view), and that box is already the full column width. The 4px on each side fell outside the row and stayed on screen.

## What changed

- `DiscussionView.vue` and `Comment.vue`: the pinned author row now bleeds out to the container's padding edge (`-mx-3 px-3 sm:-mx-5 sm:px-5`) and pads its contents back, so it covers everything the column can paint. Poll.vue already did this with `-mx-2 px-2`.
- New spec `cypress/e2e/discussions/pinned-author-row.cy.ts`: puts a full-width image in a post and in a comment and asserts both rows overhang the image by at least 4px on each side.

## Screenshots

A full-width image is selected, then scrolled up behind the pinned author row. Left: the app at 1280px. Right: a 3x detail of the column's left edge.

Post author row:

![post author row, before and after](https://md.netchamp.dev/gameplan-pinned-author-row/post-row.png)

Comment author row:

![comment author row, before and after](https://md.netchamp.dev/gameplan-pinned-author-row/comment-row.png)

Mobile (390px), after the fix:

![mobile, after](https://md.netchamp.dev/gameplan-pinned-author-row/mobile.png)

## Verification

Browser, dev server on the demo site, image selected and scrolled behind the row. Before: the ring's edges run up to the header. After: nothing above the row. Checked at 1280px and at 390px, plus a pixel diff of the unselected read view and of the post-edit state at three scroll positions, all identical before and after.

The new spec fails on the code before the fix and passes after:

```
# before
AssertionError: row covers the ring on the left: expected 295 to be at most 291

# after
  Spec                                              Tests  Passing  Failing
  ✔  discussions/pinned-author-row.cy.ts      00:07        1        1        -
  ✔  discussions/discussion-actions.cy.ts     00:35        7        7        -
  ✔  comments/comment-actions.cy.ts           00:19        2        2        -
```

Reverting only `Comment.vue` also reddens the spec, so the comment row is covered too.

`comments/comment-drafts.cy.ts` and `polls/poll-lifecycle.cy.ts` each fail one test on this bench. Both fail identically with the change reverted, so they are unrelated to this branch.
