### PR TITLE
fix(polls): vote in a single-answer poll with radios

### DIFF
--- a/frontend/cypress/e2e/polls/poll-lifecycle.cy.ts
+++ b/frontend/cypress/e2e/polls/poll-lifecycle.cy.ts
@@ -212,7 +212,7 @@ describe('Poll lifecycle', () => {
     cy.visit(`/g/community/${community}/space/${space}/discussion/${discussion}`)
     cy.contains('Archived poll').should('be.visible')
     cy.contains('button', 'Stop Poll').should('not.exist')
-    pollAnswer('Yes').should('be.disabled')
+    pollChoice('Yes').should('be.disabled')
 
     cy.iconButton('Poll Options').click()
     cy.get('[role="menuitem"]:visible').contains('Show results').should('be.visible')
@@ -240,8 +240,14 @@ function labelledCheckbox(label: string) {
     .then(($label) => cy.get(`input[type="checkbox"][id="${$label.attr('for')}"]`))
 }
 
+/** An answer on a multiple-answer poll, where each option is an independent checkbox. */
 function pollAnswer(label: string) {
   return cy.get(`input[type="checkbox"][aria-label="${label}"]`)
+}
+
+/** An answer on a single-answer poll, where the options are one radiogroup. */
+function pollChoice(label: string) {
+  return cy.get(`[role="radio"][aria-label="${label}"]`)
 }
 
 /** The option's whole row: the checkbox, its share of the vote, and the bar behind them. */

--- a/frontend/cypress/e2e/polls/poll-lifecycle.cy.ts
+++ b/frontend/cypress/e2e/polls/poll-lifecycle.cy.ts
@@ -116,6 +116,54 @@ describe('Poll lifecycle', () => {
     pollAnswer('Yes').should('be.disabled')
   })
 
+  // One answer per voter is a radiogroup, not a row of ticks. The bug this pins was a
+  // checkbox on a poll that only ever accepts one answer: it offered a clear box next to
+  // an empty one, a state the vote cannot hold, and it read as "pick as many as you
+  // like" when a second pick in fact replaces the first.
+  it('votes in a single-answer poll through radios, where a second pick replaces the first', () => {
+    cy.request({
+      method: 'POST',
+      url: '/api/v2/document/GP%20Poll',
+      body: {
+        title: 'Ship on Friday?',
+        discussion,
+        options: [{ title: 'Yes' }, { title: 'No' }],
+      },
+    })
+
+    cy.intercept('POST', '/api/v2/document/GP%20Poll/*/method/submit_vote').as('submitVote')
+    cy.intercept('POST', '/api/v2/document/GP%20Poll/*/method/retract_vote').as('retractVote')
+    cy.visit(`/g/community/${community}/space/${space}/discussion/${discussion}`)
+    cy.contains('Ship on Friday?').should('be.visible')
+
+    // The options are one group, and not one of them is a checkbox.
+    cy.get('[role="radiogroup"]').should('have.length', 1)
+    cy.get('[data-poll-option] input[type="checkbox"]').should('not.exist')
+
+    pollChoice('Yes').click()
+    cy.wait('@submitVote').its('request.body.option').should('equal', 'Yes')
+    pollChoice('Yes').should('have.attr', 'aria-checked', 'true')
+    cy.contains('1 vote').should('exist')
+    assertShare('Yes', '100%')
+
+    // Picking the other option replaces the answer, so the poll still holds one vote and
+    // nothing was retracted to get there.
+    pollChoice('No').click()
+    cy.wait('@submitVote').its('request.body.option').should('equal', 'No')
+    cy.contains('1 vote').should('exist')
+    pollChoice('Yes').should('have.attr', 'aria-checked', 'false')
+    pollChoice('No').should('have.attr', 'aria-checked', 'true')
+    assertShare('Yes', '0%')
+    assertShare('No', '100%')
+
+    // A radio cannot clear itself, so leaving the poll unanswered goes through the menu.
+    cy.selectDropdownOption('Poll Options', 'Retract vote')
+    cy.dialog('button:contains("Retract vote")').click()
+    cy.wait('@retractVote')
+    pollChoice('No').should('have.attr', 'aria-checked', 'false')
+    cy.contains('0 votes').should('exist')
+  })
+
   // A poll is a post like any other, so it carries reactions too. Reacting to it used
   // to blow up: GP Poll rendered the Reactions widget without mixing in HasReactions,
   // so the `react` doc-method the widget posts to did not exist.

--- a/frontend/src/components/Poll.vue
+++ b/frontend/src/components/Poll.vue
@@ -61,7 +61,15 @@
     <!-- Twitter-style: once results are visible the row itself becomes the bar, with the
          share filled in behind the label. Capped to a readable measure — a bar spanning
          the full thread width reads as a progress indicator, not a share of the vote. -->
-    <div class="my-4 max-w-sm space-y-1.5">
+    <!-- A single-answer poll is a radiogroup, so the group owns the row spacing; a
+         multiple-answer poll is a plain list of independent checkboxes and spaces
+         itself. -->
+    <component
+      :is="isSingleChoice ? RadioGroup : 'div'"
+      v-bind="optionGroupProps"
+      class="my-4 max-w-sm"
+      :class="{ 'space-y-1.5': !isSingleChoice }"
+    >
       <div
         v-for="option in _poll.options"
         :key="option.idx"
@@ -76,10 +84,34 @@
           aria-hidden="true"
         />
         <div class="relative flex h-7 items-center justify-between gap-3 px-2">
+          <!-- One answer per voter is a radio, not a tick: picking an option replaces
+               the previous answer and there is nothing to clear, which is exactly what
+               a radio offers and a checkbox does not. Clearing a single answer is the
+               "Retract vote" item in the poll menu.
+
+               Radio sizes the circle and the label as flex items that grow to their
+               content, so a long option would run past the row instead of truncating in
+               it: the classes unlock the shrink chain down to the label, then give the
+               label the width its own truncation measures against. -->
+          <Radio
+            v-if="isSingleChoice"
+            :id="optionId(option)"
+            :value="option.title"
+            class="min-w-0 [&>span:last-child]:min-w-0 [&_[data-slot=label]]:w-full"
+          >
+            <template #label>
+              <span
+                class="block truncate text-ink-gray-8"
+                :class="{ 'font-medium': isVotedByUser(option.title) }"
+              >
+                {{ option.title }}
+              </span>
+            </template>
+          </Radio>
           <!-- Checkbox's own label is top-aligned to the first line of a wrapping label,
                which leaves the box high against a single-line one. Pair it with our own
                <label for> instead so the row can centre them. -->
-          <div class="flex min-w-0 items-center gap-2">
+          <div v-else class="flex min-w-0 items-center gap-2">
             <Checkbox
               size="md"
               :id="optionId(option)"
@@ -104,7 +136,7 @@
           </span>
         </div>
       </div>
-    </div>
+    </component>
     <!-- The tick moves optimistically, so a rejected vote has to say why it snapped back. -->
     <ErrorMessage class="-mt-2 mb-3" :message="voteError" />
     <div class="mt-3">
@@ -150,11 +182,14 @@ import {
   Dropdown,
   Dialog,
   ErrorMessage,
+  Radio,
+  RadioGroup,
   Tooltip,
   dayjsLocal,
   dialog,
   useDoc,
 } from 'frappe-ui'
+import type { RadioValue } from 'frappe-ui'
 import UserAvatar from './UserAvatar.vue'
 import UserAvatarWithHover from './UserAvatarWithHover.vue'
 import UserProfileLink from './UserProfileLink.vue'
@@ -226,6 +261,22 @@ const showResults = computed(() => participated.value || isStopped.value)
 // so greying every option for the round trip just makes a click flicker. Overlapping
 // clicks are handled by queueing them instead (see queueVote).
 const isOptionDisabled = computed(() => isStopped.value || props.readOnlyMode || voteIsFinal.value)
+const isSingleChoice = computed(() => !_poll.value.multiple_answers)
+// The radiogroup reads the same map the checkboxes do, so an optimistic pick and the
+// snap-back after a rejected vote behave identically for both controls.
+const selectedOption = computed(() =>
+  Object.keys(selectedAnswers).find((title) => selectedAnswers[title]),
+)
+const optionGroupProps = computed(() =>
+  isSingleChoice.value
+    ? {
+        size: 'md',
+        modelValue: selectedOption.value,
+        disabled: isOptionDisabled.value,
+        'onUpdate:modelValue': (value: RadioValue) => selectOption(String(value)),
+      }
+    : {},
+)
 const canDeletePoll = computed(() => canDeleteContent(_poll.value, props.space, sessionUser))
 const isStopped = computed(
   () => Boolean(_poll.value.stopped_at) && dayjsLocal().isAfter(_poll.value.stopped_at),
@@ -332,11 +383,18 @@ async function handlePollUpdate(data: { doctype?: string; name?: string | number
   }
 }
 
+/** Picking a radio always casts a vote: a radiogroup cannot clear itself, so the only
+ *  way out of an answer is the "Retract vote" menu item. */
+function selectOption(title: string) {
+  const option = _poll.value.options.find((o) => o.title === title)
+  if (option) toggleOption(option, true)
+}
+
 /**
- * Every poll type votes through the same checkbox. What differs is what a tick means:
- * on a multiple-answer poll each option stands alone, on a single-answer poll ticking a
- * new option replaces the previous answer, and an anonymous vote is confirmed once and
- * never changed.
+ * Both controls vote through here. What differs is what a pick means: on a
+ * multiple-answer poll each option stands alone and can be cleared, on a single-answer
+ * poll picking a new option replaces the previous answer, and an anonymous vote is
+ * confirmed once and never changed.
  */
 async function toggleOption(option: GPPollOption, checked: boolean) {
   // Drive the tick from our own state rather than the checkbox's: a cancelled dialog or a
@@ -446,8 +504,9 @@ function formatPercentage(percentage?: number) {
   return Math.round(percentage || 0)
 }
 
-/** Ties each option's <label for> to its checkbox. Both parts are numeric, so it is a
- *  valid id even though option titles are free text. */
+/** Identifies one option's control: the target of the checkbox's <label for>, and a
+ *  stable id for the radio. Both parts are numeric, so it is a valid id even though
+ *  option titles are free text. */
 function optionId(option: GPPollOption) {
   return `poll-${props.poll.name}-option-${option.idx}`
 }


### PR DESCRIPTION
Reported in the Raven `Raven-gameplan` channel: a poll that takes one answer showed a checkbox per option.

## What was broken

Every poll drew the same control. On a single-answer poll that control was wrong in three ways:

- It read as "pick as many as you like", when a second pick replaces the first.
- It offered a state the vote does not have: a cleared box with nothing else picked.
- Unticking sent a retract, which is a menu action for this kind of poll.

## Screenshots

A poll with one answer per voter, before and after:

| Before | After |
| --- | --- |
| <img src="https://md.netchamp.dev/gameplan-poll-radios/before-single.png" width="440"> | <img src="https://md.netchamp.dev/gameplan-poll-radios/after-single.png" width="440"> |

A multiple-answer poll keeps its checkboxes:

<img src="https://md.netchamp.dev/gameplan-poll-radios/after-multiple.png" width="440">

## Root cause

`frontend/src/components/Poll.vue` rendered one `Checkbox` per option for every poll. `multiple_answers` only changed what a tick meant in the handler, never the control. The backend was already correct: `submit_vote` replaces the voter's previous answer when the poll is single-answer.

## What changed

- Single-answer polls render one frappe-ui `RadioGroup`, one `Radio` per option. Multiple-answer polls keep their independent checkboxes.
- Both controls vote through the same handler and the same optimistic state, so a cancelled anonymous confirm and a rejected vote snap back as before.
- Clearing a single answer stays the "Retract vote" menu item, which a radiogroup cannot do on its own.
- The row keeps its result bar, its share, its bold label for your own answer, and its truncation for long options.

## How it was verified

Cypress `polls/poll-lifecycle.cy.ts` against a local dev server, with a new spec that pins the fix:

```
  Poll lifecycle
    ✓ creates a multiple-answer poll, toggles answers, receives a live tally, and stops it
    ✓ votes in a single-answer poll through radios, where a second pick replaces the first
    ✓ reacts to a poll, and the reaction survives a reload
    ✓ keeps a poll readable but inert after its space is archived

  4 passing
```

Also checked in a browser on the dev site, desktop and mobile: vote, change the answer, retract from the menu, arrow-key selection, a stopped poll, an anonymous poll (confirm, cancel, and the disabled group after voting), and a long option truncating in the row.

Not run: the Python suite. No backend file changed.

