### PR TITLE
fix(polls): restore the mobile gap above a poll in the timeline

### DIFF
--- a/frontend/src/components/CommentsArea.vue
+++ b/frontend/src/components/CommentsArea.vue
@@ -61,6 +61,11 @@
         />
         <Poll
           v-else-if="item.doctype == 'GP Poll'"
+          :class="{
+            'pt-14 sm:pt-0': needsMobileCommentGap(timelineItems, i, {
+              includeFirstComment: true,
+            }),
+          }"
           :ref="($poll) => setItemRef($poll, item)"
           :highlight="
             highlightedItem?.doctype == item.doctype && highlightedItem?.name == item.name

--- a/frontend/src/utils/commentTimeline.ts
+++ b/frontend/src/utils/commentTimeline.ts
@@ -2,16 +2,20 @@ interface TimelineItemWithDoctype {
   doctype?: string
 }
 
+// Comments and polls are both posts: on mobile they carry their own gap here,
+// because their sticky headers only pad themselves out from `sm` up.
+const POST_DOCTYPES = ['GP Comment', 'GP Poll']
+
 export function needsMobileCommentGap(
   timelineItems: TimelineItemWithDoctype[],
   index: number,
   options: { includeFirstComment?: boolean } = {},
 ) {
   const item = timelineItems[index]
-  if (item?.doctype !== 'GP Comment') return false
+  if (!POST_DOCTYPES.includes(item?.doctype ?? '')) return false
 
   return Boolean(
     (options.includeFirstComment && index === 0) ||
-    timelineItems[index - 1]?.doctype === 'GP Comment',
+    POST_DOCTYPES.includes(timelineItems[index - 1]?.doctype ?? ''),
   )
 }


### PR DESCRIPTION
On a phone, a poll in a discussion timeline sat flush against the post body above it, or against the poll before it. Desktop was never affected.

### Cause

`b0668865` changed the poll header padding from `pt-14` to `sm:pt-14`, the same move `a7627e6b` made for `Comment.vue`. `Comment` got its mobile gap back through a wrapper class (`pt-14 sm:pt-0`, driven by `needsMobileCommentGap`). `Poll` got nothing.

### Fix

- `needsMobileCommentGap` treats `GP Poll` as a post, like `GP Comment`.
- `CommentsArea.vue` applies the same `pt-14 sm:pt-0` wrapper to `Poll`.

### Before / after

Mobile, 390x844, a discussion with two consecutive polls.

| Before | After |
| --- | --- |
| <img src="https://md.netchamp.dev/gameplan-poll-mobile-gap/before.png" width="320"> | <img src="https://md.netchamp.dev/gameplan-poll-mobile-gap/after.png" width="320"> |

Desktop at 1280 is unchanged.

### Not included

No unit test. `needsMobileCommentGap` has none today and there is no test file for `frontend/src/utils/`. `CommentsList.vue` is untouched; it does not render polls.
