### PR TITLE
fix(editor): scroll table horizontally when columns exceed width

### DIFF
--- a/frontend/src/components/RevisionsDialog.vue
+++ b/frontend/src/components/RevisionsDialog.vue
@@ -273,4 +273,7 @@ del {
   all: unset;
   background-color: theme('colors.red.100');
 }
+.ProseMirror {
+  overflow-x: auto;
+}
 </style>

--- a/frontend/src/components/editor/commentExtensions.ts
+++ b/frontend/src/components/editor/commentExtensions.ts
@@ -35,7 +35,7 @@ export function commentExtensions(
   return [
     CommentKit.configure({
       heading: { levels: [...gameplanHeadingLevels] },
-      table: {},
+      table: { cellMinWidth: 25 },
       ...suggestionConfig(true),
     }),
     // TaskItem requires TaskList; Iframe ships the `openIframeDialog` command and

--- a/frontend/src/components/editor/richTextExtensions.ts
+++ b/frontend/src/components/editor/richTextExtensions.ts
@@ -15,6 +15,7 @@ export function richTextExtensions(opts: { suggestions?: boolean } = {}) {
   return [
     RichTextKit.configure({
       heading: { levels: [...gameplanHeadingLevels] },
+      table: { cellMinWidth: 25 },
       // The kit's stock slash registry is replaced by the same registry plus the
       // gameplan-only "Collapsible section" command.
       slashCommands: false,

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -146,3 +146,7 @@ body {
     text-decoration: none !important;
   }
 }
+
+.ProseMirror table col[style*="min-width"] {
+  width: 120px;
+}


### PR DESCRIPTION
### Problem
Previously, adding a new column would shrink all existing columns so the table could fit on the screen.

### Fix
I tried fixing this by hardcoding TipTap's `cellMinWidth` to `125px`, but that completely blocked users from manually resizing columns below `125px`.

Handled the initial width using CSS instead of TipTap's config. TipTap gives unresized columns an inline `min-width` and resized columns an explicit `width`. By targeting only the unresized columns with CSS, we can enforce a `120px` starting width. This naturally triggers horizontal scrolling for wide tables, while letting us drop the minimum manual drag limit down to `25px`.

### What changed
* **`commentExtensions.ts` & `richTextExtensions.ts`:** Lowered `cellMinWidth` on the Table extension from `125` to `25`.
* **`index.css`:** Added `.ProseMirror table col[style*="min-width"] { width: 120px; }` to set the default width for untouched columns.
* **`RevisionsDialog.vue`:** Added `overflow-x: auto` to `.ProseMirror` so tables scroll horizontally in the revisions diff view.