### PR TITLE
fix(mentions): allow mentions trigger after opening brackets

### DIFF
--- a/frontend/src/components/editor/config.ts
+++ b/frontend/src/components/editor/config.ts
@@ -1,7 +1,24 @@
 import type { Component } from 'vue'
 import type { AnyExtension } from '@tiptap/core'
 import { useFileUpload } from 'frappe-ui'
-import type { MediaUploadRequestOptions, UploadedFile } from 'frappe-ui/editor'
+import { Mention, type MediaUploadRequestOptions, type UploadedFile } from 'frappe-ui/editor'
+
+export const ALLOWED_MENTION_PREFIXES = [' ', '(', '\\[', '{', '<', '（', '【', '《', '"', "'"]
+
+const origAddExtensions = Mention.config.addExtensions
+Mention.config.addExtensions = function () {
+  const extensions = origAddExtensions ? origAddExtensions.call(this) : []
+  return extensions.map((ext: any) => {
+    if (ext.name === 'mentionSuggestion') {
+      return ext.configure({
+        suggestion: {
+          allowedPrefixes: ALLOWED_MENTION_PREFIXES,
+        },
+      })
+    }
+    return ext
+  })
+}
 import RichQuoteNodeExtension from '@/components/RichQuoteExtension/rich-quote-node-extension'
 import QuoteBacklinkDecoration from '@/components/RichQuoteExtension/quote-backlink-decoration'
 import type { RichQuoteController } from '@/components/RichQuoteExtension/useRichQuotes'


### PR DESCRIPTION
### Problem
Typing `@` immediately after an opening bracket (like `(@user`) failed to trigger the mention suggestion popup unless an extra space was manually added. This happened because TipTap's default configuration only allowed spaces before the `@` symbol (`allowedPrefixes: [' ']`).

### Fix
Expanded the allowed prefixes so the mention list triggers naturally after punctuation, without needing an extra space. Standard email addresses (e.g. `test@example.com`) and mid-word characters are still properly ignored.

### What changed
* **`frontend/src/components/editor/config.ts`:** Updated `allowedPrefixes` on `mentionSuggestion` to include standard opening brackets (`(`, `[`, `{`, `<`), full-width brackets (`（`, `【`, `《`), and quotes (`"`, `'`) alongside standard whitespace.

#### Before:
<img width="406" height="154" alt="image" src="https://github.com/user-attachments/assets/92cc2b48-57ed-4839-8bf0-2b76a98e3e36" />


#### After:
<img width="529" height="184" alt="15549c95-b04e-4960-8213-d385cd82e993" src="https://github.com/user-attachments/assets/26a9f9d0-78bc-43ac-abd3-8340671ae205" />
