### PR TITLE
Add Cloud Agent environment configuration for Gameplan

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -1,0 +1,66 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PYTHON_VERSION=3.14
+ENV NODE_MAJOR=24
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        git \
+        gnupg \
+        lsb-release \
+        sudo \
+        wget \
+        build-essential \
+        libcups2-dev \
+        libffi-dev \
+        libmariadb-dev \
+        libssl-dev \
+        mariadb-client \
+        mariadb-server \
+        redis-server \
+        cron \
+        software-properties-common \
+    && rm -rf /var/lib/apt/lists/*
+
+# Python 3.14 via deadsnakes
+RUN add-apt-repository -y ppa:deadsnakes/ppa \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        python3.14 \
+        python3.14-dev \
+        python3.14-venv \
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -sf /usr/bin/python3.14 /usr/local/bin/python3 \
+    && ln -sf /usr/bin/python3.14 /usr/local/bin/python
+
+# Node.js 24
+RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_MAJOR}.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/* \
+    && corepack enable \
+    && corepack prepare yarn@1.22.22 --activate
+
+# wkhtmltopdf for Frappe PDF features
+RUN wget -q https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-3/wkhtmltox_0.12.6.1-3.jammy_amd64.deb \
+    && apt-get update \
+    && apt-get install -y ./wkhtmltox_0.12.6.1-3.jammy_amd64.deb \
+    && rm -f wkhtmltox_0.12.6.1-3.jammy_amd64.deb \
+    && rm -rf /var/lib/apt/lists/*
+
+# Bench CLI
+RUN python3 -m pip install --no-cache-dir --break-system-packages frappe-bench
+
+# Default MariaDB root password for local development only
+RUN service mariadb start \
+    && mariadb -e "ALTER USER 'root'@'localhost' IDENTIFIED BY '123'; FLUSH PRIVILEGES;" \
+    && service mariadb stop
+
+# Allow passwordless sudo for service management in start.sh
+RUN echo "ubuntu ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/ubuntu \
+    && chmod 0440 /etc/sudoers.d/ubuntu
+
+USER ubuntu
+WORKDIR /home/ubuntu

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -5,8 +5,8 @@
     "dockerfile": "Dockerfile",
     "context": "."
   },
-  "install": "bash .cursor/install.sh",
-  "start": "bash .cursor/start.sh",
+  "install": "bash /agent/repos/gameplan/.cursor/install.sh",
+  "start": "bash /agent/repos/gameplan/.cursor/start.sh",
   "terminals": [
     {
       "name": "bench",

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,36 @@
+{
+  "name": "Gameplan",
+  "user": "ubuntu",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": "."
+  },
+  "install": "bash .cursor/install.sh",
+  "start": "bash .cursor/start.sh",
+  "terminals": [
+    {
+      "name": "bench",
+      "command": "cd ~/frappe-bench && bench start",
+      "description": "Frappe backend, Socket.IO, workers, and asset builder"
+    },
+    {
+      "name": "vite",
+      "command": "cd ~/frappe-bench/apps/gameplan/frontend && yarn dev",
+      "description": "Vite dev server for the Gameplan SPA at /g"
+    }
+  ],
+  "ports": [
+    {
+      "name": "Frappe Backend",
+      "port": 8000
+    },
+    {
+      "name": "Vite Dev Server",
+      "port": 8080
+    },
+    {
+      "name": "Socket.IO",
+      "port": 9000
+    }
+  ]
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GAMEPLAN_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+BENCH_DIR="${HOME}/frappe-bench"
+MARIADB_ROOT_PASSWORD="${MARIADB_ROOT_PASSWORD:-123}"
+SITE="${GAMEPLAN_SITE:-gameplan.localhost}"
+FRAPPE_BRANCH="${FRAPPE_BRANCH:-version-16}"
+
+source "${SCRIPT_DIR}/services.sh"
+ensure_services_ready
+
+echo "Gameplan root: ${GAMEPLAN_ROOT}"
+
+cd "${GAMEPLAN_ROOT}"
+git submodule update --init --recursive
+
+cd "${GAMEPLAN_ROOT}/frontend"
+yarn install --frozen-lockfile
+
+if [ -d "${BENCH_DIR}/apps/frappe" ]; then
+	echo "Bench already initialised, skipping setup."
+	exit 0
+fi
+
+echo "Initialising frappe-bench..."
+bench init --skip-redis-config-generation --frappe-branch "${FRAPPE_BRANCH}" \
+	--python "$(command -v python3.14)" \
+	"${BENCH_DIR}"
+cd "${BENCH_DIR}"
+
+bench set-mariadb-host 127.0.0.1
+bench set-redis-cache-host 127.0.0.1:6379
+bench set-redis-queue-host 127.0.0.1:6379
+bench set-redis-socketio-host 127.0.0.1:6379
+
+sed -i '/redis/d' ./Procfile
+sed -i '/watch/d' ./Procfile
+
+echo "Installing gameplan app from checkout..."
+bench get-app gameplan "${GAMEPLAN_ROOT}"
+rm -rf apps/gameplan
+ln -sfn "${GAMEPLAN_ROOT}" apps/gameplan
+./env/bin/pip install -e apps/gameplan
+
+echo "Creating development site..."
+bench new-site "${SITE}" \
+	--force \
+	--mariadb-root-password "${MARIADB_ROOT_PASSWORD}" \
+	--admin-password admin \
+	--no-mariadb-socket
+
+bench --site "${SITE}" install-app gameplan
+bench --site "${SITE}" set-config developer_mode 1
+bench --site "${SITE}" set-config mute_emails 1
+bench --site "${SITE}" set-config allow_tests 1
+bench --site "${SITE}" set-config enable_ui_tests 1
+bench --site "${SITE}" add-user alex@example.com \
+	--first-name Alex \
+	--last-name Scott \
+	--password 123 \
+	--user-type "System User" \
+	--add-role "Gameplan Admin"
+bench use "${SITE}"
+
+echo "Gameplan install complete."

--- a/.cursor/services.sh
+++ b/.cursor/services.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+export PATH="/usr/bin:${HOME}/.local/bin:${PATH}"
+
+MARIADB_ROOT_PASSWORD="${MARIADB_ROOT_PASSWORD:-123}"
+SITE="${GAMEPLAN_SITE:-gameplan.localhost}"
+
+start_mariadb() {
+	if pgrep -x mariadbd >/dev/null 2>&1 || pgrep -x mysqld >/dev/null 2>&1; then
+		return 0
+	fi
+	sudo service mariadb start
+}
+
+start_redis() {
+	if pgrep -x redis-server >/dev/null 2>&1; then
+		return 0
+	fi
+	sudo service redis-server start
+}
+
+wait_for_mariadb() {
+	local attempt=0
+	until mariadb -u root -p"${MARIADB_ROOT_PASSWORD}" -e "SELECT 1" &>/dev/null; do
+		attempt=$((attempt + 1))
+		if [ "${attempt}" -ge 60 ]; then
+			echo "MariaDB did not become ready in time." >&2
+			return 1
+		fi
+		sleep 1
+	done
+}
+
+ensure_hosts_entry() {
+	if ! grep -q "[[:space:]]${SITE}$" /etc/hosts; then
+		echo "127.0.0.1 ${SITE}" | sudo tee -a /etc/hosts >/dev/null
+	fi
+}
+
+ensure_repo_sites_link() {
+	# frontend/src imports ../../../../sites/common_site_config.json. From the
+	# repo checkout that resolves to /agent/sites, so link it to the bench sites dir.
+	if [ -d "/agent" ]; then
+		sudo ln -sfn "${HOME}/frappe-bench/sites" /agent/sites
+	fi
+}
+
+ensure_services_ready() {
+	start_mariadb
+	start_redis
+	wait_for_mariadb
+	ensure_hosts_entry
+	ensure_repo_sites_link
+}

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/services.sh"
+
+ensure_services_ready
+
+SITE="${GAMEPLAN_SITE:-gameplan.localhost}"
+if curl -sf "http://${SITE}:8000/api/method/ping" >/dev/null 2>&1; then
+	echo "Frappe backend is already responding."
+else
+	echo "Infrastructure ready. Start bench and vite from terminals."
+fi


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a repository-managed Cloud Agent environment for full-stack Gameplan development:

- **Dockerfile** — Ubuntu 24.04 with Python 3.14, Node 24, MariaDB, Redis, cron, wkhtmltopdf, and frappe-bench
- **install.sh** — Idempotent bench init, site creation (`gameplan.localhost`), frontend deps, test user
- **start.sh / services.sh** — Start MariaDB/Redis, hosts entry, `/agent/sites` symlink for Vite
- **terminals** — `bench start` (8000/9000) and `yarn dev` (8080)

## Validation

| Check | Result |
| --- | --- |
| Backend ping | `{"message":"pong"}` |
| Frontend `/g` | HTTP 200 |
| Login (`alex@example.com` / `123`) | HTTP 200, onboarding UI |
| Backend smoke tests | 19/19 passed (`test_unsplash`) |
| Install idempotence | Passed twice |
| Fresh Cloud Agent build | `bld-20260908-773ee2a6-ccb8-4a93-85fb-8705c3223466` — all checks passed |

## Dev credentials

- Site: `gameplan.localhost`
- Login: `alex@example.com` / `123`

## Notes

- Vite must run from `~/frappe-bench/apps/gameplan/frontend` so `common_site_config.json` resolves
- `/agent/sites` is symlinked to the bench sites directory on boot
- Cypress E2E wipes the entire site — use a disposable site only
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-09ea8eed-bf78-49d1-9734-2c77a4209f99?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-09ea8eed-bf78-49d1-9734-2c77a4209f99&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

