### PR TITLE
chore(frontend): bump frappe-ui to 1.0.0-beta.61 for mention prefixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ still carries the old names. Do not rename the doctypes.
 ## Traps
 
 - **The vendored `./frappe-ui/` is not the version that runs.** The submodule is on
-  beta.28; `frontend/package.json` pins beta.51. `yarn dev:frappe-ui` symlinks the
+  beta.28; `frontend/package.json` pins beta.61. `yarn dev:frappe-ui` symlinks the
   stale checkout. Read `frontend/node_modules/frappe-ui/` for current library
   source; use `./frappe-ui/` only when doing library work.
 - **Cypress wipes the entire site**, not the records a spec created — `resetData`

--- a/frontend/cypress/e2e/comments/mention-prefixes.cy.ts
+++ b/frontend/cypress/e2e/comments/mention-prefixes.cy.ts
@@ -1,0 +1,48 @@
+import { resetData } from '../../support/seed'
+
+// TipTap's default allowedPrefixes is only a space. frappe-ui 1.0.0-beta.61
+// (frappe/frappe-ui#1129) also treats `( [ { <` and quotes as mention prefixes.
+describe('Mention prefixes', () => {
+  let community: string
+  let space: string
+  let discussion: string
+
+  beforeEach(() => {
+    resetData('space_with_discussion').then((ids) => {
+      community = String(ids.community)
+      space = String(ids.space)
+      discussion = String(ids.discussion)
+    })
+    cy.loginAs('member')
+  })
+
+  function visitDiscussion() {
+    cy.intercept('GET', `/api/v2/document/GP%20Discussion/${discussion}`).as('getDiscussion')
+    cy.visit(`/g/community/${community}/space/${space}/discussion/${discussion}`)
+    cy.wait('@getDiscussion')
+    cy.button('Add a comment').click()
+    cy.get('[contenteditable=true]').should('be.visible').click()
+  }
+
+  it('opens the mention list after an opening parenthesis', () => {
+    visitDiscussion()
+    cy.get('[contenteditable=true]').type('(@')
+    cy.get('[aria-label="Suggestions"]').should('be.visible')
+    cy.get('[aria-label="Suggestions"]').contains('Everyone').should('be.visible')
+  })
+
+  it('does not open the mention list inside an email address', () => {
+    visitDiscussion()
+    cy.get('[contenteditable=true]').type('test@example.com')
+    cy.get('[aria-label="Suggestions"]').should('not.exist')
+  })
+
+  it('inserts @ after ( from the toolbar without a padding space', () => {
+    visitDiscussion()
+    cy.get('[contenteditable=true]').type('(')
+    cy.iconButton('Mention').click()
+    cy.get('[contenteditable=true]').should('contain.text', '(@')
+    cy.get('[contenteditable=true]').should('not.contain.text', '( @')
+    cy.get('[aria-label="Suggestions"]').should('be.visible')
+  })
+})

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,7 @@
     "@tiptap/vue-3": "^3.26.0",
     "@vueuse/core": "^10.1.2",
     "feather-icons": "^4.28.0",
-    "frappe-ui": "1.0.0-beta.51",
+    "frappe-ui": "1.0.0-beta.61",
     "fuzzysort": "^2.0.4",
     "gemoji": "^7.1.0",
     "htmldiff-js": "^1.0.5",

--- a/frontend/src/components/Settings/SettingsDialog.vue
+++ b/frontend/src/components/Settings/SettingsDialog.vue
@@ -1,6 +1,6 @@
 <template>
   <SettingsDialog
-    v-model="show"
+    v-model:open="show"
     v-model:tab="activeTabValue"
     size="5xl"
     :shortcut="false"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1417,7 +1417,7 @@
   resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.5.35.tgz#192eb3d720c40715db79313454c4937432a4e86d"
   integrity sha512-zSbjL7gRXwks2ZQLRGCajBtBXEOXW9Ddhn/HvSdrGkE2dqGnumzW8XtusRrxrE9LvqtiqDXQ+A60Hp6mvdYxfA==
 
-"@vueuse/core@^10.1.2", "@vueuse/core@^10.4.1":
+"@vueuse/core@^10.1.2":
   version "10.11.1"
   resolved "https://registry.yarnpkg.com/@vueuse/core/-/core-10.11.1.tgz#15d2c0b6448d2212235b23a7ba29c27173e0c2c6"
   integrity sha512-guoy26JQktXPcz+0n3GukWIy/JDNKti9v6VEMu6kV2sYBsWuGiTU8OWdg+ADfUbHg3/3DlqySDe7JmdHrktiww==
@@ -2476,10 +2476,10 @@ framer-motion@^12.25.0:
     motion-utils "^12.39.0"
     tslib "^2.4.0"
 
-frappe-ui@1.0.0-beta.51:
-  version "1.0.0-beta.51"
-  resolved "https://registry.yarnpkg.com/frappe-ui/-/frappe-ui-1.0.0-beta.51.tgz#27a101e64b833f8483f5cfe37ac4399f422417a2"
-  integrity sha512-DH0/ft6pNiJsGWSZLnfJ/Of14ZxMmqeERKHJywh/BDTZLg2W6JrRp6Q4Ru+N3z/98b5VpJoLjnPBqv+07Inleg==
+frappe-ui@1.0.0-beta.61:
+  version "1.0.0-beta.61"
+  resolved "https://registry.yarnpkg.com/frappe-ui/-/frappe-ui-1.0.0-beta.61.tgz#36199c5afa46dc6a176bac5e76c4aa60e5e1fd0a"
+  integrity sha512-Fb43V5x8uVBMaNcqLXgG4teAJuKm2dWloZx1xzLsH8+WE4ZhrS/VrDUvhQ8Wa1H2iUonvYPZCSES+7QMiQeFRw==
   dependencies:
     "@codemirror/lang-css" "^6.3.0"
     "@codemirror/lang-html" "^6.4.9"
@@ -2492,7 +2492,6 @@ frappe-ui@1.0.0-beta.51:
     "@codemirror/lang-xml" "^6.1.0"
     "@codemirror/lang-yaml" "^6.1.3"
     "@floating-ui/dom" "^1.7.4"
-    "@headlessui/vue" "^1.7.14"
     "@tailwindcss/forms" "^0.5.3"
     "@tailwindcss/line-clamp" "^0.4.4"
     "@tailwindcss/typography" "^0.5.16"
@@ -2532,7 +2531,7 @@ frappe-ui@1.0.0-beta.51:
     "@tiptap/starter-kit" "^3.26.0"
     "@tiptap/suggestion" "^3.26.0"
     "@tiptap/vue-3" "^3.26.0"
-    "@vueuse/core" "^10.4.1"
+    "@vueuse/core" "^14.1.0"
     codemirror "^6.0.1"
     dayjs "^1.11.13"
     dompurify "^3.4.0"
@@ -2542,7 +2541,7 @@ frappe-ui@1.0.0-beta.51:
     highlight.js "^11.11.1"
     idb-keyval "^6.2.0"
     lowlight "^3.3.0"
-    lucide-static "^1.16.0"
+    lucide-static "^1.31.0"
     magic-string "^0.30.21"
     marked "^15.0.12"
     ora "5.4.1"
@@ -3259,10 +3258,10 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
-lucide-static@^1.16.0:
-  version "1.17.0"
-  resolved "https://registry.yarnpkg.com/lucide-static/-/lucide-static-1.17.0.tgz#2b2367d2ab5ba3e70edb48627efa8e7f586330cd"
-  integrity sha512-VORJmPqi4DZ5lf4/n2qqcIz1nTKGFReS83DJINcK5nXY7z+4P3G6CW/7SXpzlGllEI0vHKFH24eSM+aMFaK5zw==
+lucide-static@^1.31.0:
+  version "1.43.0"
+  resolved "https://registry.yarnpkg.com/lucide-static/-/lucide-static-1.43.0.tgz#efc55edcd4f055121aa0a9e38b683041d66b156d"
+  integrity sha512-w7vdVFqh4vv7RxWHN4sSeylA0s3GHV5vpyGqZI0q22MINKJyhMNWSMd90RyTUYWBRNYqdZVZzrMmijVxU3Cl9A==
 
 magic-string@^0.30.17, magic-string@^0.30.21:
   version "0.30.21"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Problem

Typing `@` right after an opening bracket or quote (`(@jane`, `[@task`) did not open the mention list. TipTap’s default `allowedPrefixes` is only a space. Gameplan [#567](https://github.com/frappe/gameplan/pull/567) patched this in app code; Faris asked for the fix in frappe-ui instead.

### Fix

Bump `frappe-ui` from `1.0.0-beta.51` to **`1.0.0-beta.61`**, which includes [frappe/frappe-ui#1129](https://github.com/frappe/frappe-ui/pull/1129). Mentions now treat space, NBSP, `( [ { <`, full-width / CJK openers, guillemets, and quotes as valid prefixes. Slash, tag, and emoji suggestions stay on the space-only default.

Gameplan does not reconfigure `allowedPrefixes`; the published Mention extension carries the list. Toolbar `@` after `(` inserts `(@` without a padding space.

### Migration

`SettingsDialog` in this beta only binds visibility as `v-model:open`. Bare `v-model` is dropped silently (the overlay never opens). That broke CI settings flows (join/leave, members, profile settings, space options). Gameplan now uses `v-model:open`.

### What changed

- `frontend/package.json` / `frontend/yarn.lock`: pin `frappe-ui@1.0.0-beta.61`
- `AGENTS.md`: document the current pin
- `frontend/src/components/Settings/SettingsDialog.vue`: `v-model:open`
- `frontend/cypress/e2e/comments/mention-prefixes.cy.ts`: `(@` opens the list, emails do not, toolbar insert after `(` does not pad a space

Follow-up to #567. That local patch can close once this lands.

### Test plan

- [x] Cypress `mention-prefixes` spec (3/3 locally)
- [x] Greptile 5/5
- [ ] CI UI tests after the SettingsDialog binding fix

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c76fd3a8-27e7-4aeb-8018-b00e687c6e21?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c76fd3a8-27e7-4aeb-8018-b00e687c6e21&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

