### PR TITLE
refactor: migrate to the frappe-ui v1 API (beta.63)

### DIFF
--- a/frontend/cypress/e2e/profile/profile-customize.cy.ts
+++ b/frontend/cypress/e2e/profile/profile-customize.cy.ts
@@ -758,16 +758,15 @@ function dragCardOnto(
     firePointer(win, win, 'pointermove', begin.x, begin.y)
     cy.get('[data-profile-drag-ghost="true"]').should('exist')
     cy.then(() => {
-      // Read once the card is up, not before. Picking it up takes a frame, and a
-      // rect measured on the other side of one is the only rect the drop can
-      // trust. The dragged card keeps its slot while it floats, so nothing here
-      // has moved on account of the pickup itself.
-      let target = cardIn(win, targetId).getBoundingClientRect()
+      // Read once the card is up, not before: picking it up takes a frame. The
+      // dragged card keeps its slot while it floats, so nothing here has moved
+      // on account of the pickup itself.
+      let target = declaredViewportRect(win, targetId)
       // `middle` stops just short of it, so a reading that splits the target in
       // two is decided rather than sitting on the boundary.
       let landing = {
         middle: { x: target.left + target.width / 2 - 4, y: target.top + target.height / 2 - 4 },
-        seam: { x: target.right + 6, y: target.top + target.height / 2 },
+        seam: { x: target.left + target.width + 6, y: target.top + target.height / 2 },
         'top-left': { x: target.left + target.width / 4, y: target.top + target.height / 8 },
       }[land]
       // The pointer, worked back from where the dragged card has to end up.
@@ -884,7 +883,40 @@ function declaredRect(element: HTMLElement) {
   let [left = 0, top = 0] = (element.style.transform.match(/-?[\d.]+px/g) || []).map((value) =>
     Number.parseFloat(value),
   )
-  return { left, top, width: Number.parseFloat(element.style.width) }
+  return {
+    left,
+    top,
+    width: Number.parseFloat(element.style.width),
+    height: Number.parseFloat(element.style.height),
+  }
+}
+
+/**
+ * A card's packed slot, in viewport coordinates.
+ *
+ * The grid decides a drop by counting the packer's slots, not by hit testing
+ * the DOM (`insertionIndex` in `useProfileBentoDrag.ts`). So a drop point aimed
+ * with `getBoundingClientRect` is measured in the wrong space: for the 200ms a
+ * tile spends sliding, its real rect is wherever it has got to and the packer's
+ * is where it is going. Aiming at the real one puts the pointer somewhere the
+ * grid never agreed was that card. The seam between two cards is a few pixels
+ * wide, so it misses first.
+ *
+ * The grid is the wrapper's offset parent, so its rect is what turns a slot
+ * back into viewport coordinates. That is the same sum `insertionIndex` undoes.
+ */
+function declaredViewportRect(win: Window, cardId: string) {
+  let wrapper = win.document.querySelector(
+    `[data-profile-card-wrapper="true"][data-profile-card-id="${cardId}"]`,
+  ) as HTMLElement
+  let grid = wrapper.parentElement.getBoundingClientRect()
+  let declared = declaredRect(wrapper)
+  return {
+    left: grid.left + declared.left,
+    top: grid.top + declared.top,
+    width: declared.width,
+    height: declared.height,
+  }
 }
 
 /** A pointer event built in the app's own realm, so its handlers accept it. */

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,7 @@
     "@tiptap/vue-3": "^3.26.0",
     "@vueuse/core": "^10.1.2",
     "feather-icons": "^4.28.0",
-    "frappe-ui": "1.0.0-beta.61",
+    "frappe-ui": "1.0.0-beta.63",
     "fuzzysort": "^2.0.4",
     "gemoji": "^7.1.0",
     "htmldiff-js": "^1.0.5",

--- a/frontend/src/components/AppDropdown.vue
+++ b/frontend/src/components/AppDropdown.vue
@@ -1,7 +1,7 @@
 <template>
   <!-- The logo is the app menu's trigger. It carries no tooltip and its own
        open/hover treatment (surface-base fill / opacity dim), so it stays a
-       bespoke button rather than a RailItem. -->
+       bespoke button rather than a SidebarRailItem. -->
   <Dropdown :options="dropdownItems" side="bottom" align="start">
     <template #default="{ open }">
       <button

--- a/frontend/src/components/AppRail/AppRail.vue
+++ b/frontend/src/components/AppRail/AppRail.vue
@@ -1,6 +1,6 @@
 <template>
-  <Rail :class="showBorder ? 'border-r' : ''">
-    <!-- Cancel Rail's own top padding and stand exactly one PageHeader tall (min-h-12),
+  <SidebarRail :class="showBorder ? 'border-r' : ''">
+    <!-- Cancel SidebarRail's own top padding and stand exactly one PageHeader tall (min-h-12),
          so the divider below the logo continues the header's bottom border across the
          rail instead of sitting a couple of pixels under it. -->
     <div class="-mt-2.5 flex h-12 shrink-0 items-center justify-center">
@@ -10,7 +10,7 @@
     <!-- App-wide destinations sit directly under the logo, so their position never
          shifts with how many communities you belong to. -->
     <div class="flex w-full shrink-0 flex-col items-center gap-0.5 border-t pt-3">
-      <RailItem
+      <SidebarRailItem
         v-for="item in shortcuts"
         :key="item.label"
         :label="item.label"
@@ -46,7 +46,7 @@
           class="h-full w-[50px] overflow-y-auto overflow-x-hidden pb-3 pt-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
         >
           <div class="flex w-[50px] flex-col items-center gap-3">
-            <RailItem
+            <SidebarRailItem
               v-for="community in activeCommunities"
               :key="community.name"
               :label="community.title"
@@ -56,7 +56,7 @@
               @click="goToCommunity(community)"
             >
               <CommunityImage :community="community" class="size-7 transition" />
-            </RailItem>
+            </SidebarRailItem>
           </div>
         </div>
       </div>
@@ -78,7 +78,7 @@
         </button>
       </template>
     </UserDropdown>
-  </Rail>
+  </SidebarRail>
 
   <CustomizeSidebarDialog v-model="showCustomizeSidebarDialog" />
 </template>
@@ -87,7 +87,7 @@
 import { computed, nextTick, onMounted, ref, useTemplateRef, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useEventListener, useResizeObserver } from '@vueuse/core'
-import { Rail, RailItem } from 'frappe-ui'
+import { SidebarRail, SidebarRailItem } from 'frappe-ui'
 import type { RouteLocationRaw } from 'vue-router'
 import { communityState } from '@/data/communityState'
 import { activeCommunities } from '@/data/communities'

--- a/frontend/src/components/ProfileBento/ProfileBentoEditorPanel.vue
+++ b/frontend/src/components/ProfileBento/ProfileBentoEditorPanel.vue
@@ -93,7 +93,7 @@
               />
 
               <div class="space-y-1.5">
-                <FormLabel label="Size" size="md" />
+                <FormLabel label="Size" />
                 <TabButtons
                   :options="profileCardSizeOptions"
                   :model-value="card.size"
@@ -105,7 +105,7 @@
 
               <template v-if="hasImage">
                 <div class="space-y-1.5">
-                  <FormLabel label="Rendering" size="md" />
+                  <FormLabel label="Rendering" />
                   <TabButtons
                     :options="profileImageRenderingOptions"
                     :model-value="card.imageRendering || 'Cover'"

--- a/frontend/src/components/ProfileBento/ProfileImageField.vue
+++ b/frontend/src/components/ProfileBento/ProfileImageField.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="space-y-1.5">
-    <FormLabel :label="label" size="md" />
+    <FormLabel :label="label" />
     <div class="flex flex-wrap items-center gap-2">
       <ImageUploader :kind="kind" @success="(file) => emit('upload', file.file_url)">
         <template #default="{ progress, error, uploading, openFileSelector }">

--- a/frontend/src/components/ProfileBento/boundFields/ProfileBoundRichTextField.vue
+++ b/frontend/src/components/ProfileBento/boundFields/ProfileBoundRichTextField.vue
@@ -2,7 +2,7 @@
   <!-- Rich text does not fit an aside this narrow, so the panel offers the way
        into a dialog rather than a cramped editor. -->
   <div class="space-y-1.5">
-    <FormLabel :label="spec.title" size="md" />
+    <FormLabel :label="spec.title" />
     <Button icon-left="lucide-edit-2" @click="showDialog = true">Edit {{ actionName }}</Button>
 
     <ProfileAboutDialog

--- a/frontend/src/pages/Configure/CommunitiesList.vue
+++ b/frontend/src/pages/Configure/CommunitiesList.vue
@@ -29,8 +29,11 @@
 
   <List
     v-else-if="filteredCommunities.length"
-    :columns="['minmax(12rem,6fr)', 'minmax(6rem,1.2fr)', 'minmax(6rem,1.2fr)', '5.75rem']"
-    class="list-gap-12 max-md:list-cols-[minmax(0,1fr)]"
+    :columns="{
+      base: ['minmax(0,1fr)'],
+      md: ['minmax(12rem,6fr)', 'minmax(6rem,1.2fr)', 'minmax(6rem,1.2fr)', '5.75rem'],
+    }"
+    class="list-gap-12"
   >
     <!-- Sticky at the settings scroll-viewport top — it rests exactly where it
          pins, so it never visibly moves. px-1.5 aligns the labels with the

--- a/frontend/src/pages/Configure/CommunityGuestsList.vue
+++ b/frontend/src/pages/Configure/CommunityGuestsList.vue
@@ -8,8 +8,10 @@
     </div>
 
     <List
-      :columns="['1.25rem', 'minmax(12rem,1fr)', 'minmax(12rem,1fr)', '8rem', '3rem']"
-      class="max-md:list-cols-[1.25rem_minmax(0,1fr)_2rem]"
+      :columns="{
+        base: ['1.25rem', 'minmax(0,1fr)', '2rem'],
+        md: ['1.25rem', 'minmax(12rem,1fr)', 'minmax(12rem,1fr)', '8rem', '3rem'],
+      }"
     >
       <ListHeader class="max-md:hidden">
         <ListHeaderCell class="col-span-2">Guest</ListHeaderCell>

--- a/frontend/src/pages/Configure/CommunityMembersList.vue
+++ b/frontend/src/pages/Configure/CommunityMembersList.vue
@@ -23,8 +23,10 @@
 
   <List
     v-if="filteredMembers.length"
-    :columns="['1.25rem', 'minmax(12rem,1fr)', 'minmax(12rem,1fr)', '8rem', '1.5rem']"
-    class="max-md:list-cols-[1.25rem_minmax(0,1fr)]"
+    :columns="{
+      base: ['1.25rem', 'minmax(0,1fr)'],
+      md: ['1.25rem', 'minmax(12rem,1fr)', 'minmax(12rem,1fr)', '8rem', '1.5rem'],
+    }"
   >
     <!-- Sticky at the settings scroll-viewport top — it rests exactly where it
          pins, so it never visibly moves. -->

--- a/frontend/src/pages/Configure/CommunitySpacesList.vue
+++ b/frontend/src/pages/Configure/CommunitySpacesList.vue
@@ -8,12 +8,13 @@
 
   <List
     v-if="filteredSpaces.length"
-    :columns="
-      hasGuests
+    :columns="{
+      base: ['minmax(0,1fr)', 'auto'],
+      md: hasGuests
         ? ['minmax(8rem,1fr)', '15.25rem', '5rem', '1.5rem']
-        : ['minmax(8rem,1fr)', '15.25rem', '1.5rem']
-    "
-    class="list-gap-12 max-md:list-gap-1 max-md:list-cols-[minmax(0,1fr)_auto]"
+        : ['minmax(8rem,1fr)', '15.25rem', '1.5rem'],
+    }"
+    class="list-gap-12 max-md:list-gap-1"
   >
     <!-- Sticky at the settings scroll-viewport top — it rests exactly where it
          pins, so it never visibly moves. -->

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2476,10 +2476,10 @@ framer-motion@^12.25.0:
     motion-utils "^12.39.0"
     tslib "^2.4.0"
 
-frappe-ui@1.0.0-beta.61:
-  version "1.0.0-beta.61"
-  resolved "https://registry.yarnpkg.com/frappe-ui/-/frappe-ui-1.0.0-beta.61.tgz#36199c5afa46dc6a176bac5e76c4aa60e5e1fd0a"
-  integrity sha512-Fb43V5x8uVBMaNcqLXgG4teAJuKm2dWloZx1xzLsH8+WE4ZhrS/VrDUvhQ8Wa1H2iUonvYPZCSES+7QMiQeFRw==
+frappe-ui@1.0.0-beta.63:
+  version "1.0.0-beta.63"
+  resolved "https://registry.yarnpkg.com/frappe-ui/-/frappe-ui-1.0.0-beta.63.tgz#4538261c9fd8bad4802d55b9b46c3f42548cb1bd"
+  integrity sha512-wUVIAFwpBGQTnmItSfWaDVu1/OxT885ENWMH7FUVb9j9NGDnSwcQDwaPAJyRUjGp+91jL4Be2xS0cBCzhXcpvA==
   dependencies:
     "@codemirror/lang-css" "^6.3.0"
     "@codemirror/lang-html" "^6.4.9"


### PR DESCRIPTION
Moves gameplan onto the frappe-ui v1 API and bumps the pin to `1.0.0-beta.63`, the first release that carries it.

Three breaking changes land in that release. One stops the build; two are silent.

```text
frappe-ui 1.0.0-beta.61 → 1.0.0-beta.63
├── Rail → SidebarRail            build fails, loud
├── list-cols-[…] removed         wrong tracks at 640–767px, silent
└── FormLabel.size removed        invalid DOM attribute, silent
```

## `Rail` → `SidebarRail`

The rail joins the Sidebar family by name. Composition, props and layout are unchanged — it still sits beside `Sidebar` and still renders alone.

```diff
-import { Rail, RailItem } from 'frappe-ui'
+import { SidebarRail, SidebarRailItem } from 'frappe-ui'
```

Six sites in `AppRail.vue`, plus two comments that named the old components. The `data-slot` values changed too (`rail` → `sidebar-rail`, and so on), but a live DOM census shows the same element counts under the new names and gameplan has no CSS selecting on them, so nothing else moves.

![The rail after the rename](https://github.com/user-attachments/assets/bddab1e0-252d-49e7-b212-116863b8ac25)

## Responsive list columns

`list-cols-[…]` is gone. Column tracks are a prop now, and `List` takes a breakpoint object where each tier replaces the whole track list:

```diff
-<List
-  class="max-md:list-cols-[1.25rem_minmax(0,1fr)]"
-  :columns="['1.25rem', 'minmax(12rem,1fr)', 'minmax(12rem,1fr)', '8rem', '3rem']"
-/>
+<List
+  :columns="{
+    base: ['1.25rem', 'minmax(0,1fr)'],
+    md: ['1.25rem', 'minmax(12rem,1fr)', 'minmax(12rem,1fr)', '8rem', '3rem'],
+  }"
+/>
```

All four Configure lists used `max-md:`, so `md` is the right tier in every case. `CommunitySpacesList`'s `hasGuests` ternary moved across intact, now under `md`. `list-gap-*` is untouched — that utility survives in v1, so those stay classes.

Measured on the booted app rather than inferred. At 700px: Communities `minmax(0px, 1fr)`, Members `20px 279.219px`, Spaces `279.219px 24px`. At 1440px Members flips to the full `20px 229.609px 229.609px 128px 24px`, so the tier switches in both directions. The built CSS puts `md` at `(width >= 768px)`, matching gameplan's own `max-md:hidden`.

![Members list at 700px](https://github.com/user-attachments/assets/01c57a22-6385-4ead-99e4-a7aeeb4e52d1)

## `FormLabel.size`

Labels are a fixed 13px in `ink-gray-6` now, so the size axis had nothing left to do and was removed. Four sites, all the literal `size="md"`.

This one was worth fixing rather than leaving: with `size` no longer a declared prop it stopped being ignored and started falling through to the DOM as a real attribute — `<label size="md">` — which is invalid HTML that nothing flags. Read back off the live elements, the labels now carry `class` only.

![Bento editor panel labels](https://github.com/user-attachments/assets/9a7ad027-520f-4f68-b9d8-1bfba93f1e35)

## Verification

Built and booted against a real site, as `maya@moonhollow.studio` on the Moonhollow demo data, with a vite dev server on this branch proxying to the bench.

`yarn build` exits 0, `✓ built in 3.18s`, 2473 modules.

The settings dialog opens with all six tabs and Communities renders four real communities. That surface was dead against `beta.62` before `678e19be` landed on `develop`, so this confirms the fix holds under the rest of the v1 changes:

![Settings, Communities](https://github.com/user-attachments/assets/819ad9b5-f5a2-4eb2-b210-fd7d1236692a)

A residual sweep is clean: no `list-cols`, no `--list-columns`, no `FormLabel size`, no `Rail`/`RailItem` identifiers. The 14 remaining `size="xl"` hits are all `Avatar`, `UserAvatar` and `Dialog`, which still declare `xl` — input `xl` was the one removed, and gameplan never used it.

## Not verified

- **`CommunityGuestsList` was never rendered.** The demo site has no `GP Guest Access` rows, so the list `v-if`s away. Its template was checked by writing its exact carriers onto a live list and reading back `20px 247.219px 32px` at 700px, the intended base tracks — but the component itself did not render with data.
- **`profile-card-editing.cy.ts` was not run.** It is the right guard for the settings dialog, but its `beforeEach` calls `resetData`, which deletes every Gameplan row and every non-persona User on whichever site answers — and `baseUrl` points at the curated demo site. It needs a disposable site. Its exact assertion was checked by hand instead: `<h2>Profile</h2>` renders and is visible.
- Two backend `403`s on this session leave the **Profile** settings panel body empty (`document/User/…` and `get_my_drafts`). They look like a permission quirk of the synthesized session rather than anything from this change, but that panel's contents were not verified.
- Socket.io was not running, so nothing realtime was exercised. Dark theme only, one site, one user.
- `yarn.lock` was hand-patched with npm's own shasum and integrity for `beta.63`. `beta.61` and `beta.63` have byte-identical `dependencies`, so no transitive entries move, but `yarn install --frozen-lockfile` has not been run against it.

## Pre-existing, not from this change

In the 640–767px band the Configure rows overlap: `CommunityRow.vue` is a fixed `h-10` while the single-track layout stacks name, metadata and button into roughly 72px. The tracks are correct and identical to what `max-md:list-cols-[minmax(0,1fr)]` produced before, so this predates the migration. Worth its own issue.
