### PR TITLE
Fix search focus

### DIFF
--- a/frontend/cypress/e2e/search/search-page.cy.ts
+++ b/frontend/cypress/e2e/search/search-page.cy.ts
@@ -16,7 +16,7 @@ describe('Search page', () => {
     cy.visit('/g/search')
     cy.wait('@filterOptions').its('response.statusCode').should('eq', 200)
 
-    cy.get('input[placeholder="Search or press / to focus"]').type('roadmap{enter}')
+    cy.get('input[aria-label="Search"]').type('roadmap{enter}')
     cy.wait('@search').its('response.statusCode').should('eq', 200)
     cy.contains('6 matches').should('be.visible')
 

--- a/frontend/src/pages/Search.vue
+++ b/frontend/src/pages/Search.vue
@@ -13,7 +13,8 @@
             <TextInput
               ref="searchInput"
               class="flex-1"
-              placeholder="Search or press / to focus"
+              placeholder="Search"
+              aria-label="Search"
               v-focus
               :model-value="query"
               @update:model-value="updateQuery"
@@ -542,7 +543,7 @@ function handleKeyPress(event: KeyboardEvent) {
 }
 
 function focusSearchInput() {
-  searchInput.value?.el?.focus()
+  searchInput.value?.focus()
 }
 
 function isSearchCharacter(event: KeyboardEvent) {


### PR DESCRIPTION
https://github.com/user-attachments/assets/d770e3fd-1510-4050-8e0a-1f3f7f11bd3c

### Problem

When typing on the Search page without the input focused, characters appeared in the search field, but **Enter and Backspace did not work**. The input had to be clicked manually to recover.

### Cause

The global `keydown` handler calls `focusSearchInput()` after receiving a character. This function accessed `searchInput.value.el`, but `frappe-ui`'s `TextInput` does not expose `el`. It exposes a `focus()` method instead.

Because of optional chaining, the incorrect access failed silently, so focus never moved to the input. As a result, **Enter and Backspace continued to be handled by the global handler**, which only processes single-character keys.

### Fix

Changed `focusSearchInput()` to use the exposed `focus()` method. The input now receives focus after the first keystroke and handles **Enter** and **Backspace** normally.

This also fixes the `/` shortcut, which uses the same function.


