### PR TITLE
Fix editor scroll affordances

### DIFF
--- a/frontend/cypress/e2e/comments/comment-actions.cy.ts
+++ b/frontend/cypress/e2e/comments/comment-actions.cy.ts
@@ -28,6 +28,14 @@ describe('Comment actions', () => {
       times: 1,
     }).as('comment')
     cy.button('Add a comment').click()
+    cy.get('.comments-timeline').invoke('css', 'min-height', '1200px')
+    cy.get('[data-slot="desktop-shell-content"] > * > [data-reka-scroll-area-viewport]')
+      .scrollTo('bottom')
+      .should(($viewport) => {
+        expect($viewport[0].scrollTop).to.be.greaterThan(200)
+      })
+    cy.get('button[aria-label="Scroll to top"]').should('be.visible')
+    cy.get('.comments-timeline').invoke('css', 'min-height', '')
     cy.iconButton('Minimize comment box').should('be.visible').click()
     cy.get('button[aria-label="Scroll to top"]').should('not.exist')
     cy.iconButton('Expand comment box').should('be.visible').click()

--- a/frontend/cypress/e2e/comments/comment-actions.cy.ts
+++ b/frontend/cypress/e2e/comments/comment-actions.cy.ts
@@ -17,6 +17,7 @@ describe('Comment actions', () => {
   })
 
   it('posts a comment, reacts to it, edits it with a mention, and deletes it', () => {
+    cy.viewport(1000, 660)
     cy.intercept('GET', `/api/v2/document/GP%20Discussion/${discussion}`).as('getDiscussion')
     cy.visit(`/g/community/${community}/space/${space}/discussion/${discussion}`)
     cy.wait('@getDiscussion')
@@ -28,6 +29,7 @@ describe('Comment actions', () => {
     }).as('comment')
     cy.button('Add a comment').click()
     cy.iconButton('Minimize comment box').should('be.visible').click()
+    cy.get('button[aria-label="Scroll to top"]').should('not.exist')
     cy.iconButton('Expand comment box').should('be.visible').click()
     // Click the editor to settle focus before typing — relying on the auto-focus
     // via cy.focused() races the just-mounted ProseMirror view and drops the

--- a/frontend/cypress/e2e/discussions/discussion-actions.cy.ts
+++ b/frontend/cypress/e2e/discussions/discussion-actions.cy.ts
@@ -42,7 +42,7 @@ describe('Discussion actions', () => {
       const composer = topmostElement($composers)
       expect(composer, 'topmost comment composer').to.exist
 
-      cy.get('button[aria-label="Scroll to top"]').then(($buttons) => {
+      cy.get('button[aria-label="Scroll to top"]').should(($buttons) => {
         const button = topmostElement($buttons)
         expect(button, 'topmost scroll control').to.exist
         expect(button!.getBoundingClientRect().bottom, label).to.be.at.most(

--- a/frontend/cypress/e2e/discussions/discussion-actions.cy.ts
+++ b/frontend/cypress/e2e/discussions/discussion-actions.cy.ts
@@ -107,7 +107,7 @@ describe('Discussion actions', () => {
   })
 
   it('raises the icon-only scroll control only when it overlaps the comment composer', () => {
-    cy.viewport(900, 600)
+    cy.viewport(1000, 660)
     visitSeededDiscussion()
 
     cy.button('Add a comment').click()

--- a/frontend/cypress/e2e/discussions/discussion-actions.cy.ts
+++ b/frontend/cypress/e2e/discussions/discussion-actions.cy.ts
@@ -45,9 +45,11 @@ describe('Discussion actions', () => {
       cy.get('button[aria-label="Scroll to top"]').should(($buttons) => {
         const button = topmostElement($buttons)
         expect(button, 'topmost scroll control').to.exist
-        expect(button!.getBoundingClientRect().bottom, label).to.be.at.most(
-          composer!.getBoundingClientRect().top,
-        )
+        const container = button!.closest('.fixed')
+        expect(container, 'scroll control container').to.exist
+        const gap =
+          composer!.getBoundingClientRect().top - container!.getBoundingClientRect().bottom
+        expect(gap, label).to.be.closeTo(4, 1)
       })
     })
   }

--- a/frontend/cypress/e2e/discussions/discussion-actions.cy.ts
+++ b/frontend/cypress/e2e/discussions/discussion-actions.cy.ts
@@ -114,13 +114,9 @@ describe('Discussion actions', () => {
 
     cy.button('Add a comment').click()
     cy.get('[aria-label="Resize comment box"]').should('be.visible')
-    cy.get('[data-slot="desktop-shell"] [data-slot="scroll-area-viewport"]').then(($viewports) => {
-      const shell = $viewports
-        .toArray()
-        .sort((a, b) => b.scrollHeight - b.clientHeight - (a.scrollHeight - a.clientHeight))[0]
-      expect(shell.scrollHeight - shell.clientHeight, 'scrollable shell range').to.be.greaterThan(0)
-      cy.wrap(shell).scrollTo('bottom')
-    })
+    cy.get('[data-slot="desktop-shell-content"] > * > [data-reka-scroll-area-viewport]').scrollTo(
+      'bottom',
+    )
 
     cy.get('button[aria-label="Scroll to top"]')
       .should('be.visible')

--- a/frontend/cypress/e2e/discussions/discussion-actions.cy.ts
+++ b/frontend/cypress/e2e/discussions/discussion-actions.cy.ts
@@ -112,6 +112,7 @@ describe('Discussion actions', () => {
 
     cy.button('Add a comment').click()
     cy.get('[aria-label="Resize comment box"]').should('be.visible')
+    cy.get('.comments-timeline').invoke('css', 'min-height', '1200px')
     cy.get('[data-slot="desktop-shell-content"] > * > [data-reka-scroll-area-viewport]').scrollTo(
       'bottom',
     )

--- a/frontend/cypress/e2e/discussions/discussion-actions.cy.ts
+++ b/frontend/cypress/e2e/discussions/discussion-actions.cy.ts
@@ -37,21 +37,19 @@ describe('Discussion actions', () => {
     })
   }
 
-  function assertScrollControlAbove(composerControl: string, label: string) {
-    cy.get(composerControl)
-      .parents('.fixed')
-      .then(($composers) => {
-        const composer = topmostElement($composers)
-        expect(composer, 'topmost comment composer').to.exist
+  function assertScrollControlAbove(label: string) {
+    cy.get('[data-comment-composer-surface]').then(($composers) => {
+      const composer = topmostElement($composers)
+      expect(composer, 'topmost comment composer').to.exist
 
-        cy.get('button[aria-label="Scroll to top"]').then(($buttons) => {
-          const button = topmostElement($buttons)
-          expect(button, 'topmost scroll control').to.exist
-          expect(button!.getBoundingClientRect().bottom, label).to.be.at.most(
-            composer!.getBoundingClientRect().top,
-          )
-        })
+      cy.get('button[aria-label="Scroll to top"]').then(($buttons) => {
+        const button = topmostElement($buttons)
+        expect(button, 'topmost scroll control').to.exist
+        expect(button!.getBoundingClientRect().bottom, label).to.be.at.most(
+          composer!.getBoundingClientRect().top,
+        )
       })
+    })
   }
 
   it('publishes a new discussion into a space', () => {
@@ -108,7 +106,7 @@ describe('Discussion actions', () => {
       })
   })
 
-  it('keeps the icon-only scroll control above the comment composer', () => {
+  it('raises the icon-only scroll control only when it overlaps the comment composer', () => {
     cy.viewport(900, 600)
     visitSeededDiscussion()
 
@@ -126,7 +124,7 @@ describe('Discussion actions', () => {
         })
       })
 
-    assertScrollControlAbove('[aria-label="Resize comment box"]', 'scroll control bottom')
+    assertScrollControlAbove('scroll control bottom')
 
     // Editable, internally scrolling editors should not cover the content with
     // top/bottom fade overlays while the user is writing.
@@ -140,10 +138,24 @@ describe('Discussion actions', () => {
       expect(button, 'topmost minimize button').to.exist
       cy.wrap(button).click()
     })
-    assertScrollControlAbove(
-      'button[aria-label="Expand comment box"]',
-      'scroll control bottom after minimizing',
-    )
+    assertScrollControlAbove('scroll control bottom after minimizing')
+
+    cy.viewport(1440, 600)
+    cy.get('[data-comment-composer-surface]').then(($composers) => {
+      const composer = topmostElement($composers)
+      expect(composer, 'topmost comment composer at wide viewport').to.exist
+
+      cy.get('button[aria-label="Scroll to top"]').should(($buttons) => {
+        const button = topmostElement($buttons)
+        expect(button, 'topmost scroll control at wide viewport').to.exist
+        expect(button!.getBoundingClientRect().left, 'wide control left edge').to.be.at.least(
+          composer!.getBoundingClientRect().right,
+        )
+        const container = button!.closest('.fixed')
+        expect(container, 'scroll control container').to.exist
+        expect(getComputedStyle(container!).bottom, 'wide control bottom offset').to.equal('12px')
+      })
+    })
   })
 
   it('renames a discussion and records the rename in the activity feed', () => {

--- a/frontend/cypress/e2e/discussions/discussion-actions.cy.ts
+++ b/frontend/cypress/e2e/discussions/discussion-actions.cy.ts
@@ -26,6 +26,34 @@ describe('Discussion actions', () => {
     cy.visit(`/g/community/${community}/space/${space}/discussion/${discussion}/${discussionSlug}`)
   }
 
+  function topmostElement(elements: JQuery<HTMLElement>) {
+    return elements.toArray().find((element) => {
+      const rect = element.getBoundingClientRect()
+      const topmost = element.ownerDocument.elementFromPoint(
+        rect.left + rect.width / 2,
+        rect.top + rect.height / 2,
+      )
+      return topmost === element || element.contains(topmost)
+    })
+  }
+
+  function assertScrollControlAbove(composerControl: string, label: string) {
+    cy.get(composerControl)
+      .parents('.fixed')
+      .then(($composers) => {
+        const composer = topmostElement($composers)
+        expect(composer, 'topmost comment composer').to.exist
+
+        cy.get('button[aria-label="Scroll to top"]').then(($buttons) => {
+          const button = topmostElement($buttons)
+          expect(button, 'topmost scroll control').to.exist
+          expect(button!.getBoundingClientRect().bottom, label).to.be.at.most(
+            composer!.getBoundingClientRect().top,
+          )
+        })
+      })
+  }
+
   it('publishes a new discussion into a space', () => {
     // Publishing flushes the draft and calls the whitelisted `publish_draft` method,
     // which returns the new discussion name as the response `message`.
@@ -78,6 +106,48 @@ describe('Discussion actions', () => {
       .then((comment: { name: string }) => {
         cy.get(`div[data-id="${comment.name}"]`).should('exist')
       })
+  })
+
+  it('keeps the icon-only scroll control above the comment composer', () => {
+    cy.viewport(900, 600)
+    visitSeededDiscussion()
+
+    cy.button('Add a comment').click()
+    cy.get('[aria-label="Resize comment box"]').should('be.visible')
+    cy.get('[data-slot="desktop-shell"] [data-slot="scroll-area-viewport"]').then(($viewports) => {
+      const shell = $viewports
+        .toArray()
+        .sort((a, b) => b.scrollHeight - b.clientHeight - (a.scrollHeight - a.clientHeight))[0]
+      expect(shell.scrollHeight - shell.clientHeight, 'scrollable shell range').to.be.greaterThan(0)
+      cy.wrap(shell).scrollTo('bottom')
+    })
+
+    cy.get('button[aria-label="Scroll to top"]')
+      .should('be.visible')
+      .and(($button) => {
+        $button.each((_, element) => {
+          expect(element.textContent?.trim(), 'icon-only button text').to.equal('')
+        })
+      })
+
+    assertScrollControlAbove('[aria-label="Resize comment box"]', 'scroll control bottom')
+
+    // Editable, internally scrolling editors should not cover the content with
+    // top/bottom fade overlays while the user is writing.
+    cy.get('[aria-label="Resize comment box"]')
+      .parents('.fixed')
+      .find('[class*="before:bg-gradient-to-b"], [class*="after:bg-gradient-to-t"]')
+      .should('not.exist')
+
+    cy.get('button[aria-label="Minimize comment box"]').then(($buttons) => {
+      const button = topmostElement($buttons)
+      expect(button, 'topmost minimize button').to.exist
+      cy.wrap(button).click()
+    })
+    assertScrollControlAbove(
+      'button[aria-label="Expand comment box"]',
+      'scroll control bottom after minimizing',
+    )
   })
 
   it('renames a discussion and records the rename in the activity feed', () => {

--- a/frontend/cypress/e2e/discussions/new-discussion.cy.ts
+++ b/frontend/cypress/e2e/discussions/new-discussion.cy.ts
@@ -185,4 +185,30 @@ describe('New discussion drafts', () => {
     cy.contains('New Discussion').should('exist')
     cy.button('Publish').should('be.visible')
   })
+
+  it('keeps breathing room below the caret while typing a long discussion', () => {
+    cy.viewport(1000, 600)
+    cy.visit(`/g/community/${community}/new-discussion`)
+
+    const paragraphs = Array.from({ length: 40 }, (_, index) => `Line ${index + 1}{enter}`).join('')
+    cy.get('[aria-label="Discussion content"]')
+      .should('have.attr', 'contenteditable', 'true')
+      .click()
+      .type(`${paragraphs}Last line`)
+
+    cy.get('[data-slot="desktop-shell"] [data-slot="scroll-area-viewport"]').then(($viewports) => {
+      const shell = $viewports
+        .toArray()
+        .sort((a, b) => b.scrollHeight - b.clientHeight - (a.scrollHeight - a.clientHeight))[0]
+      cy.get('[aria-label="Discussion content"] p')
+        .last()
+        .then(($lastLine) => {
+          const clearance =
+            shell.getBoundingClientRect().bottom - $lastLine[0].getBoundingClientRect().bottom
+
+          expect(shell.scrollTop, 'shell scrolled while typing').to.be.greaterThan(0)
+          expect(clearance, 'space below caret').to.be.at.least(140)
+        })
+    })
+  })
 })

--- a/frontend/cypress/e2e/discussions/new-discussion.cy.ts
+++ b/frontend/cypress/e2e/discussions/new-discussion.cy.ts
@@ -196,19 +196,19 @@ describe('New discussion drafts', () => {
       .click()
       .type(`${paragraphs}Last line`)
 
-    cy.get('[data-slot="desktop-shell"] [data-slot="scroll-area-viewport"]').then(($viewports) => {
-      const shell = $viewports
-        .toArray()
-        .sort((a, b) => b.scrollHeight - b.clientHeight - (a.scrollHeight - a.clientHeight))[0]
-      cy.get('[aria-label="Discussion content"] p')
-        .last()
-        .then(($lastLine) => {
-          const clearance =
-            shell.getBoundingClientRect().bottom - $lastLine[0].getBoundingClientRect().bottom
+    cy.get('[data-slot="desktop-shell-content"] > * > [data-reka-scroll-area-viewport]').then(
+      ($shell) => {
+        const shell = $shell[0]
+        cy.get('[aria-label="Discussion content"] p')
+          .last()
+          .then(($lastLine) => {
+            const clearance =
+              shell.getBoundingClientRect().bottom - $lastLine[0].getBoundingClientRect().bottom
 
-          expect(shell.scrollTop, 'shell scrolled while typing').to.be.greaterThan(0)
-          expect(clearance, 'space below caret').to.be.at.least(140)
-        })
-    })
+            expect(shell.scrollTop, 'shell scrolled while typing').to.be.greaterThan(0)
+            expect(clearance, 'space below caret').to.be.at.least(140)
+          })
+      },
+    )
   })
 })

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,7 @@
     "@tiptap/vue-3": "^3.26.0",
     "@vueuse/core": "^10.1.2",
     "feather-icons": "^4.28.0",
-    "frappe-ui": "1.0.0-beta.63",
+    "frappe-ui": "1.0.0-beta.64",
     "fuzzysort": "^2.0.4",
     "gemoji": "^7.1.0",
     "htmldiff-js": "^1.0.5",

--- a/frontend/src/components/CommentsArea.vue
+++ b/frontend/src/components/CommentsArea.vue
@@ -568,6 +568,9 @@ const activeComposerEditorMinHeightStyle = computed(() =>
 
 defineExpose({
   editorObject,
+  get composerHeight() {
+    return addCommentHeight.value
+  },
   openCommentBox,
   scrollToCommentById,
   getCommentContentElement,
@@ -889,7 +892,6 @@ onMounted(() => {
       activities.reload()
     }
   })
-  setupComposerMeasurement()
 })
 
 onUnmounted(() => {
@@ -903,10 +905,23 @@ onUnmounted(() => {
   isNewCommentOpen.value = false
 })
 
-function setupComposerMeasurement() {
-  const $el = addComment.value
-  if (!$el) return
+watch(
+  addComment,
+  ($el) => {
+    mutationObserver?.disconnect()
+    resizeObserver?.disconnect()
 
+    if (!$el) {
+      addCommentHeight.value = 0
+      return
+    }
+
+    setupComposerMeasurement($el)
+  },
+  { immediate: true, flush: 'post' },
+)
+
+function setupComposerMeasurement($el: HTMLElement) {
   updateComposerHeight()
 
   mutationObserver = new MutationObserver(updateComposerHeight)

--- a/frontend/src/components/CommentsArea.vue
+++ b/frontend/src/components/CommentsArea.vue
@@ -94,6 +94,8 @@
     >
       <div class="pointer-events-auto" :class="{ 'h-full': isComposerFullscreen }">
         <div
+          ref="composerSurface"
+          data-comment-composer-surface
           class="discussion-container bg-surface-base sm:bg-transparent"
           :class="isComposerFullscreen ? 'h-full py-0' : 'py-3'"
         >
@@ -346,6 +348,10 @@ const props = withDefaults(defineProps<Props>(), {
   hideNewComment: false,
 })
 
+const emit = defineEmits<{
+  'composer-resize': []
+}>()
+
 const router = useRouter()
 const route = useRoute()
 const socket = useSocket()
@@ -389,6 +395,7 @@ const highlightedItem = ref<{ doctype: string; name: string } | null>(null)
 const addCommentHeight = ref(0)
 const newCommentEditor = useTemplateRef('newCommentEditor')
 const addComment = useTemplateRef('addComment')
+const composerSurface = useTemplateRef('composerSurface')
 let mutationObserver: MutationObserver | undefined
 let resizeObserver: ResizeObserver | undefined
 const commentEditorKey = ref(0)
@@ -570,6 +577,9 @@ defineExpose({
   editorObject,
   get composerHeight() {
     return addCommentHeight.value
+  },
+  get composerElement() {
+    return composerSurface.value
   },
   openCommentBox,
   scrollToCommentById,
@@ -913,6 +923,7 @@ watch(
 
     if (!$el) {
       addCommentHeight.value = 0
+      emit('composer-resize')
       return
     }
 
@@ -933,6 +944,7 @@ function setupComposerMeasurement($el: HTMLElement) {
 
 function updateComposerHeight() {
   addCommentHeight.value = addComment.value?.clientHeight ?? 0
+  emit('composer-resize')
 }
 
 function updateGlobalCommentState() {

--- a/frontend/src/components/DiscussionView.vue
+++ b/frontend/src/components/DiscussionView.vue
@@ -192,6 +192,7 @@
           :hide-new-comment="editingPost"
           :activity-version="discussion.doc.modified"
           ref="commentsArea"
+          @composer-resize="scheduleScrollToTopPlacement"
         />
         <QuoteBacklinksPopover :store="richQuotes" @select="scrollToQuotingComment" />
         <Dialog
@@ -304,6 +305,7 @@
     </div>
     <div
       v-if="!isMobileViewport && !editingPost"
+      ref="scrollToTopControl"
       class="fixed right-3 z-[2] grid h-9 place-content-center print:hidden"
       :style="{ bottom: `${scrollToTopBottomOffset}px` }"
     >
@@ -346,7 +348,7 @@ import {
   Switch,
   dialog,
 } from 'frappe-ui'
-import { until } from '@vueuse/core'
+import { until, useEventListener } from '@vueuse/core'
 import type { Editor } from '@tiptap/vue-3'
 import Reactions from './Reactions.vue'
 import UserAvatarWithHover from './UserAvatarWithHover.vue'
@@ -387,13 +389,45 @@ const route = useRoute()
 const runWhenOwned = useOwnedRouteWrites(() => route.name === 'Discussion')
 const isMobileViewport = useIsMobile()
 const commentsArea = useTemplateRef('commentsArea')
+const scrollToTopControl = useTemplateRef<HTMLElement>('scrollToTopControl')
 const postEditor = useTemplateRef<{ editor: Editor | null }>('postEditor')
 const mainPostContentEl = ref<HTMLElement | null>(null)
 const postTitleEl = useTemplateRef<HTMLElement>('postTitleEl')
 
 const isScrolled = useShellScrolled()
 const scrollContainerEl = shellScrollContainer
-const scrollToTopBottomOffset = computed(() => (commentsArea.value?.composerHeight ?? 0) + 12)
+const scrollToTopOverlapsComposer = ref(false)
+const scrollToTopBottomOffset = computed(() =>
+  scrollToTopOverlapsComposer.value ? (commentsArea.value?.composerHeight ?? 0) + 12 : 12,
+)
+
+function scheduleScrollToTopPlacement() {
+  nextTick(updateScrollToTopPlacement)
+}
+
+function updateScrollToTopPlacement() {
+  const control = scrollToTopControl.value
+  const composer = commentsArea.value?.composerElement
+  if (!control || !composer || !isScrolled.value) {
+    scrollToTopOverlapsComposer.value = false
+    return
+  }
+
+  const controlRect = control.getBoundingClientRect()
+  const composerRect = composer.getBoundingClientRect()
+  // Test the control where it would sit without the composer. Measuring the
+  // already-raised rect would make the result oscillate between the two positions.
+  const restingBottom = window.innerHeight - 12
+  const restingTop = restingBottom - controlRect.height
+  const overlapsHorizontally =
+    controlRect.left < composerRect.right && controlRect.right > composerRect.left
+  const overlapsVertically = restingTop < composerRect.bottom && restingBottom > composerRect.top
+  scrollToTopOverlapsComposer.value = overlapsHorizontally && overlapsVertically
+}
+
+watch(isScrolled, scheduleScrollToTopPlacement)
+useEventListener(window, 'resize', scheduleScrollToTopPlacement)
+
 function scrollToTop() {
   shellScrollContainer.value?.scrollTo({ top: 0, behavior: 'smooth' })
 }

--- a/frontend/src/components/DiscussionView.vue
+++ b/frontend/src/components/DiscussionView.vue
@@ -395,10 +395,12 @@ const mainPostContentEl = ref<HTMLElement | null>(null)
 const postTitleEl = useTemplateRef<HTMLElement>('postTitleEl')
 
 const scrollToTopThreshold = 200
+const scrollToTopRestingOffset = 12
+const scrollToTopComposerGap = 4
 const isScrolled = useShellScrolled({ threshold: scrollToTopThreshold })
 const scrollContainerEl = shellScrollContainer
 const showScrollToTop = ref(false)
-const scrollToTopBottomOffset = ref(12)
+const scrollToTopBottomOffset = ref(scrollToTopRestingOffset)
 let scrollToTopPlacementFrame = 0
 
 function scheduleScrollToTopPlacement() {
@@ -418,7 +420,7 @@ function updateScrollToTopPlacement() {
   const control = scrollToTopControl.value
   const composer = commentsArea.value?.composerElement
   if (!control || !composer || !showScrollToTop.value) {
-    scrollToTopBottomOffset.value = 12
+    scrollToTopBottomOffset.value = scrollToTopRestingOffset
     return
   }
 
@@ -426,13 +428,15 @@ function updateScrollToTopPlacement() {
   const composerRect = composer.getBoundingClientRect()
   // Test the control where it would sit without the composer. Measuring the
   // already-raised rect would make the result oscillate between the two positions.
-  const restingBottom = window.innerHeight - 12
+  const restingBottom = window.innerHeight - scrollToTopRestingOffset
   const restingTop = restingBottom - controlRect.height
   const overlapsHorizontally =
     controlRect.left < composerRect.right && controlRect.right > composerRect.left
   const overlapsVertically = restingTop < composerRect.bottom && restingBottom > composerRect.top
   scrollToTopBottomOffset.value =
-    overlapsHorizontally && overlapsVertically ? window.innerHeight - composerRect.top + 12 : 12
+    overlapsHorizontally && overlapsVertically
+      ? window.innerHeight - composerRect.top + scrollToTopComposerGap
+      : scrollToTopRestingOffset
 }
 
 watch(isScrolled, scheduleScrollToTopPlacement)

--- a/frontend/src/components/DiscussionView.vue
+++ b/frontend/src/components/DiscussionView.vue
@@ -310,7 +310,7 @@
       :style="{ bottom: `${scrollToTopBottomOffset}px` }"
     >
       <Button
-        v-show="isScrolled"
+        v-if="showScrollToTop"
         variant="ghost"
         icon="lucide-arrow-up"
         label="Scroll to top"
@@ -394,22 +394,30 @@ const postEditor = useTemplateRef<{ editor: Editor | null }>('postEditor')
 const mainPostContentEl = ref<HTMLElement | null>(null)
 const postTitleEl = useTemplateRef<HTMLElement>('postTitleEl')
 
-const isScrolled = useShellScrolled()
+const scrollToTopThreshold = 200
+const isScrolled = useShellScrolled({ threshold: scrollToTopThreshold })
 const scrollContainerEl = shellScrollContainer
-const scrollToTopOverlapsComposer = ref(false)
-const scrollToTopBottomOffset = computed(() =>
-  scrollToTopOverlapsComposer.value ? (commentsArea.value?.composerHeight ?? 0) + 12 : 12,
-)
+const showScrollToTop = ref(false)
+const scrollToTopBottomOffset = ref(12)
+let scrollToTopPlacementFrame = 0
 
 function scheduleScrollToTopPlacement() {
-  nextTick(updateScrollToTopPlacement)
+  cancelAnimationFrame(scrollToTopPlacementFrame)
+  scrollToTopPlacementFrame = requestAnimationFrame(() => {
+    scrollToTopPlacementFrame = requestAnimationFrame(() => {
+      // Composer layout can clamp scrollTop without dispatching a scroll event.
+      // Read it after the layout has painted, then let the control mount before measuring.
+      showScrollToTop.value = (scrollContainerEl.value?.scrollTop ?? 0) > scrollToTopThreshold
+      nextTick(updateScrollToTopPlacement)
+    })
+  })
 }
 
 function updateScrollToTopPlacement() {
   const control = scrollToTopControl.value
   const composer = commentsArea.value?.composerElement
-  if (!control || !composer || !isScrolled.value) {
-    scrollToTopOverlapsComposer.value = false
+  if (!control || !composer || !showScrollToTop.value) {
+    scrollToTopBottomOffset.value = 12
     return
   }
 
@@ -422,7 +430,8 @@ function updateScrollToTopPlacement() {
   const overlapsHorizontally =
     controlRect.left < composerRect.right && controlRect.right > composerRect.left
   const overlapsVertically = restingTop < composerRect.bottom && restingBottom > composerRect.top
-  scrollToTopOverlapsComposer.value = overlapsHorizontally && overlapsVertically
+  scrollToTopBottomOffset.value =
+    overlapsHorizontally && overlapsVertically ? window.innerHeight - composerRect.top + 12 : 12
 }
 
 watch(isScrolled, scheduleScrollToTopPlacement)
@@ -533,6 +542,7 @@ onMounted(() => {
 })
 
 onBeforeUnmount(() => {
+  cancelAnimationFrame(scrollToTopPlacementFrame)
   scrollContainerEl.value?.removeEventListener('scroll', updateMobileHeaderTitle)
 })
 

--- a/frontend/src/components/DiscussionView.vue
+++ b/frontend/src/components/DiscussionView.vue
@@ -402,9 +402,10 @@ const scrollToTopBottomOffset = ref(12)
 let scrollToTopPlacementFrame = 0
 
 function scheduleScrollToTopPlacement() {
-  cancelAnimationFrame(scrollToTopPlacementFrame)
+  if (scrollToTopPlacementFrame) return
   scrollToTopPlacementFrame = requestAnimationFrame(() => {
     scrollToTopPlacementFrame = requestAnimationFrame(() => {
+      scrollToTopPlacementFrame = 0
       // Composer layout can clamp scrollTop without dispatching a scroll event.
       // Read it after the layout has painted, then let the control mount before measuring.
       showScrollToTop.value = (scrollContainerEl.value?.scrollTop ?? 0) > scrollToTopThreshold

--- a/frontend/src/components/DiscussionView.vue
+++ b/frontend/src/components/DiscussionView.vue
@@ -304,14 +304,17 @@
     </div>
     <div
       v-if="!isMobileViewport && !editingPost"
-      class="fixed bottom-3 h-9 grid place-content-center right-3 z-[2] print:hidden"
+      class="fixed right-3 z-[2] grid h-9 place-content-center print:hidden"
+      :style="{ bottom: `${scrollToTopBottomOffset}px` }"
     >
-      <Button variant="ghost" v-show="isScrolled" @click="scrollToTop">
-        <template #prefix>
-          <span class="lucide-arrow-up h-5 w-5 text-ink-gray-6" />
-        </template>
-        Scroll to top
-      </Button>
+      <Button
+        v-show="isScrolled"
+        variant="ghost"
+        icon="lucide-arrow-up"
+        label="Scroll to top"
+        tooltip="Scroll to top"
+        @click="scrollToTop"
+      />
     </div>
   </div>
 </template>
@@ -390,6 +393,7 @@ const postTitleEl = useTemplateRef<HTMLElement>('postTitleEl')
 
 const isScrolled = useShellScrolled()
 const scrollContainerEl = shellScrollContainer
+const scrollToTopBottomOffset = computed(() => (commentsArea.value?.composerHeight ?? 0) + 12)
 function scrollToTop() {
   shellScrollContainer.value?.scrollTo({ top: 0, behavior: 'smooth' })
 }

--- a/frontend/src/components/editor/GPEditor.vue
+++ b/frontend/src/components/editor/GPEditor.vue
@@ -55,6 +55,7 @@ const editor = computed(() => ft.value?.editor ?? null)
 const hasScrollOverflow = ref(false)
 const canScrollUp = ref(false)
 const canScrollDown = ref(false)
+const showScrollFades = computed(() => Boolean(props.maxHeight && !props.editable))
 
 const scrollStyle = computed<CSSProperties>(() => ({
   maxHeight: props.maxHeight,
@@ -63,7 +64,7 @@ const scrollStyle = computed<CSSProperties>(() => ({
 }))
 
 watch(
-  () => [props.content, props.maxHeight, props.minHeight],
+  () => [props.content, props.editable, props.maxHeight, props.minHeight],
   () => nextTick(updateScrollFades),
   { immediate: true },
 )
@@ -112,9 +113,9 @@ function updateScrollFades() {
           class="relative"
           :class="{
             'before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:z-10 before:h-8 before:bg-gradient-to-b before:from-surface-base before:to-transparent before:opacity-0 before:transition-opacity before:duration-150':
-              maxHeight,
+              showScrollFades,
             'after:pointer-events-none after:absolute after:inset-x-0 after:bottom-0 after:z-10 after:h-8 after:bg-gradient-to-t after:from-surface-base after:to-transparent after:opacity-0 after:transition-opacity after:duration-150':
-              maxHeight,
+              showScrollFades,
             'before:opacity-100': canScrollUp,
             'after:opacity-100': canScrollDown,
           }"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2476,10 +2476,10 @@ framer-motion@^12.25.0:
     motion-utils "^12.39.0"
     tslib "^2.4.0"
 
-frappe-ui@1.0.0-beta.63:
-  version "1.0.0-beta.63"
-  resolved "https://registry.yarnpkg.com/frappe-ui/-/frappe-ui-1.0.0-beta.63.tgz#4538261c9fd8bad4802d55b9b46c3f42548cb1bd"
-  integrity sha512-wUVIAFwpBGQTnmItSfWaDVu1/OxT885ENWMH7FUVb9j9NGDnSwcQDwaPAJyRUjGp+91jL4Be2xS0cBCzhXcpvA==
+frappe-ui@1.0.0-beta.64:
+  version "1.0.0-beta.64"
+  resolved "https://registry.yarnpkg.com/frappe-ui/-/frappe-ui-1.0.0-beta.64.tgz#ce6f44de79db212ada5e750a66fb9051a0b8ac25"
+  integrity sha512-Q+WoGvweUKfuEF6EOulaR1TtOxQb3NCj32UD+QznC7JePAYteY1EGLQA13NUWXrEoHhakuP2tfWdEGHUrp01og==
   dependencies:
     "@codemirror/lang-css" "^6.3.0"
     "@codemirror/lang-html" "^6.4.9"


### PR DESCRIPTION
## Summary

- render the desktop scroll-to-top control as an accessible icon button and lift it by the live measured comment-composer height
- keep composer measurement attached across open, minimized, hidden, and remounted states
- remove scroll-fade overlays from editable editor surfaces while retaining them for read-only internal scrollers
- add browser regressions for composer overlap, icon-only rendering, fade removal, and long-form caret clearance

The existing `typewriterScroll` extension on `develop` already sets the bottom `scrollMargin` to the requested 160px value. This PR keeps that behavior intact and adds explicit browser coverage for it.

## Verification

- `yarn build`
- `pre-commit run --files frontend/cypress/e2e/discussions/discussion-actions.cy.ts frontend/cypress/e2e/discussions/new-discussion.cy.ts frontend/src/components/CommentsArea.vue frontend/src/components/DiscussionView.vue frontend/src/components/editor/GPEditor.vue`
- non-destructive Cypress/Electron browser check against existing data: 1000x600 long-form typing auto-scrolled and kept >=140px below the last caret line; 900x600 visual check confirmed the icon control above the open composer and no editable fade overlays

The committed seeded Cypress cases were not run locally because `resetData` wipes the entire site and this bench has no disposable-data confirmation.