### PR TITLE
fix(shell): restore apps submenu content

### DIFF
--- a/frontend/cypress/e2e/shell/settings-menu.cy.ts
+++ b/frontend/cypress/e2e/shell/settings-menu.cy.ts
@@ -23,4 +23,12 @@ describe('Settings entry points', () => {
     cy.location('pathname').should('equal', '/g/settings/profile')
     cy.contains('[role="dialog"]', 'User settings').should('be.visible')
   })
+
+  it('shows the installed apps in the app switcher', () => {
+    cy.document().its('documentElement').invoke('setAttribute', 'data-theme', 'dark')
+    cy.iconButton('Gameplan menu').click()
+    cy.contains('[role="menuitem"]', 'Apps').click()
+
+    cy.contains('[role="menu"] a[href="/app"]', 'Desk').should('be.visible')
+  })
 })

--- a/frontend/src/components/AppDropdown.vue
+++ b/frontend/src/components/AppDropdown.vue
@@ -19,7 +19,7 @@
 </template>
 
 <script setup lang="ts">
-import { h, markRaw, ref } from 'vue'
+import { h, ref } from 'vue'
 import { Dropdown } from 'frappe-ui'
 import { clear as clearIndexDb } from 'idb-keyval'
 import { settingsShortcutLabel, showSettingsDialog } from '@/components/Settings'
@@ -36,7 +36,9 @@ const dropdownItems = [
     label: 'Apps',
     submenu: [
       {
-        component: markRaw(AppSelector),
+        slots: {
+          item: () => h(AppSelector),
+        },
       },
     ],
   },


### PR DESCRIPTION
## Summary

- render the app switcher through frappe-ui’s supported per-item slot API
- remove the blank submenu row caused by the removed legacy component option
- cover the guaranteed Desk entry with a dark-mode browser regression test

## Root cause

The Apps submenu still passed AppSelector through a legacy component menu option. frappe-ui now treats that shape as a plain action, so it rendered an unlabeled empty row instead of mounting AppSelector.

## Verification

- CYPRESS_BASE_URL=http://gameplan-demo.test:8081 yarn cypress run --spec cypress/e2e/shell/settings-menu.cy.ts --browser electron
- yarn build
- pre-commit run --files frontend/src/components/AppDropdown.vue frontend/cypress/e2e/shell/settings-menu.cy.ts